### PR TITLE
Add support for specifying the SDK path on macos

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,9 +162,9 @@ if( BLA_VENDOR MATCHES "^Intel" )
   add_definitions( -DHAVE_MKL )
 endif()
 # HDF5
-find_package( HDF5 COMPONENTS C Fortran HL REQUIRED )
+find_package( HDF5 COMPONENTS C Fortran REQUIRED )
 include_directories( ${HDF5_INCLUDE_DIRS} )
-set( OFT_HDF5_LIBS ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES} )
+set( OFT_HDF5_LIBS ${HDF5_LIBRARIES} )
 list(REVERSE OFT_HDF5_LIBS)
 list(REMOVE_DUPLICATES OFT_HDF5_LIBS) # HDF5 often provides several duplicates
 list(REVERSE OFT_HDF5_LIBS)

--- a/src/utilities/build_libs.py
+++ b/src/utilities/build_libs.py
@@ -1253,9 +1253,9 @@ class BLAS_LAPACK(package):
                 'export FCFLAGS="{0}"'.format(" ".join(fflags))
             ]
         cmake_options = [
-            "-DCMAKE_INSTALL_PREFIX:PATH={BLAS_LAPACK_ROOT}"
-            "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON"
-            "-Wno-dev"
+            "-DCMAKE_INSTALL_PREFIX:PATH={BLAS_LAPACK_ROOT}",
+            "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON",
+            "-Wno-dev",
             "-DCMAKE_BUILD_TYPE=Release"
         ]
         if 'MACOS_SDK_PATH' in self.config_dict:

--- a/src/utilities/build_libs.py
+++ b/src/utilities/build_libs.py
@@ -922,7 +922,7 @@ class HDF5(package):
                 "--enable-shared=no",
                 "--enable-static=yes",
                 "--enable-tests=no",
-                "--enable-examples=no",
+                # "--enable-examples=no",
                 "--with-pic"
             ]
         if self.parallel and ("MPI_CC" in self.config_dict):
@@ -953,7 +953,7 @@ class HDF5(package):
         if self.cmake_build:
             build_lines.append("{CMAKE} " + " ".join(cmake_options) + " ..")
         else:
-            build_lines.append("../configure " + " ".join(configure_options) + " ..")
+            build_lines.append("../configure " + " ".join(configure_options))
         build_lines += [
             "make -j{MAKE_THREADS}",
             "make install"

--- a/src/utilities/build_libs.py
+++ b/src/utilities/build_libs.py
@@ -422,6 +422,8 @@ def build_cmake_script(mydict,build_debug=False,use_openmp=False,build_python=Fa
         "-DCMAKE_CXX_COMPILER:FILEPATH={CXX}",
         "-DCMAKE_Fortran_COMPILER:FILEPATH={FC}"
     ]
+    if 'MACOS_SDK_PATH' in tmp_dict:
+        cmake_lines.append('-DCMAKE_OSX_SYSROOT={0}'.format(tmp_dict['MACOS_SDK_PATH']))
     if mydict['BASE_CFLAGS'] != '':
         cmake_lines.append('-DCMAKE_C_FLAGS:STRING="{BASE_CFLAGS}"')
     if mydict['BASE_FFLAGS'] != '':
@@ -775,12 +777,22 @@ class METIS(package):
 
     def build(self):
         build_dir = os.getcwd()
+        cmake_options = [
+            '-DCMAKE_INSTALL_PREFIX={METIS_ROOT}',
+            '-DCMAKE_C_COMPILER={CC}',
+            '-DCMAKE_CXX_COMPILER={CXX}',
+            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON',
+            '-DGKRAND:BOOL=ON',
+            '-DGKLIB_PATH=$GKLIB_PATH'
+        ]
+        if 'MACOS_SDK_PATH' in self.config_dict:
+            cmake_options.append('-DCMAKE_OSX_SYSROOT={0}'.format(self.config_dict['MACOS_SDK_PATH']))
         build_lines = [
             "GKLIB_PATH={0}".format(os.path.join(build_dir,"GKlib")),
             "rm -rf build",
             "mkdir -p build",
             "cd build",
-            "{CMAKE} -DCMAKE_INSTALL_PREFIX={METIS_ROOT} -DCMAKE_C_COMPILER={CC} -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON -DGKRAND:BOOL=ON -DGKLIB_PATH=$GKLIB_PATH .. ",
+            "{CMAKE} " + " ".join(cmake_options) + " .. ",
             "make -j{MAKE_THREADS}",
             "make install"
         ]
@@ -846,11 +858,12 @@ class MPI(package):
 
 
 class HDF5(package):
-    def __init__(self, parallel=False):
+    def __init__(self, parallel=False, legacy_build=False):
         self.name = "HDF5"
-        # self.url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.14/hdf5-1.14.2/src/hdf5-1.14.2.tar.gz"
-        self.url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.10/src/hdf5-1.10.10.tar.gz"
+        self.url = "https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.5/hdf5-1.14.5.tar.gz"
+        # self.url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.10/src/hdf5-1.10.10.tar.gz"
         self.parallel = parallel
+        self.cmake_build = (not legacy_build)
 
     def setup(self, config_dict):
         self.config_dict = config_dict.copy()
@@ -879,23 +892,28 @@ class HDF5(package):
             "mkdir build",
             "cd build"
         ]
-        # cmake_options = [
-        #     '-DCMAKE_INSTALL_PREFIX:PATH="{HDF5_ROOT}"',
-        #     '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON',
-        #     '-DHDF5_BUILD_FORTRAN:BOOL=ON',
-        #     '-DBUILD_SHARED_LIBS:BOOL=OFF',
-        #     '-DHDF5_BUILD_CPP_LIB=OFF',
-        #     '-DBUILD_TESTING=OFF',
-        #     '-DHDF5_BUILD_EXAMPLES=OFF'
-        # ]
-        options = [
-            "--prefix={HDF5_ROOT}",
-            "--enable-fortran",
-            "--enable-shared=no",
-            "--disable-tests",
-            "--disable-examples",
-            "--with-pic"
-        ]
+        if self.cmake_build:
+            cmake_options = [
+                '-DCMAKE_INSTALL_PREFIX:PATH="{HDF5_ROOT}"',
+                '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON',
+                '-DHDF5_BUILD_FORTRAN:BOOL=ON',
+                '-DBUILD_SHARED_LIBS:BOOL=ON',
+                '-DBUILD_STATIC_LIBS:BOOL=OFF',
+                '-DHDF5_BUILD_CPP_LIB=OFF',
+                '-DBUILD_TESTING=OFF',
+                '-DHDF5_BUILD_EXAMPLES=OFF'
+            ]
+        else:
+            configure_options = [
+                "--prefix={HDF5_ROOT}",
+                "--enable-fortran",
+                "--enable-hl=no",
+                "--enable-shared=no",
+                "--enable-static=yes",
+                "--enable-tests=no",
+                "--enable-examples=no",
+                "--with-pic"
+            ]
         if "MPI_CC" in self.config_dict:
             build_lines += [
                 "export CC={MPI_CC}",
@@ -907,8 +925,10 @@ class HDF5(package):
                 "export FC={FC}"
             ]
         if self.parallel:
-            # cmake_options += ["-DHDF5_ENABLE_PARALLEL:BOOL=ON"]
-            options += ["--enable-parallel"]
+            if self.cmake_build:
+                cmake_options.append("-DHDF5_ENABLE_PARALLEL:BOOL=ON")
+            else:
+                configure_options.append("--enable-parallel")
             if "MPI_LIBS" in self.config_dict:
                 build_lines += [
                     'export CPPFLAGS="-I{MPI_INCLUDE}"',
@@ -916,10 +936,14 @@ class HDF5(package):
                     'export LDFLAGS="-L{MPI_LIB}"',
                     'export LIBS="{MPI_LIBS}"'
                 ]
+        if 'MACOS_SDK_PATH' in self.config_dict:
+            cmake_options.append('-DCMAKE_OSX_SYSROOT={0}'.format(self.config_dict['MACOS_SDK_PATH']))
         #
+        if self.cmake_build:
+            build_lines.append("{CMAKE} " + " ".join(cmake_options) + " ..")
+        else:
+            build_lines.append("../configure " + " ".join(configure_options) + " ..")
         build_lines += [
-            # "cmake " + " ".join(cmake_options) + " ..",
-            "../configure " + " ".join(options),
             "make -j{MAKE_THREADS}",
             "make install"
         ]
@@ -1228,8 +1252,16 @@ class BLAS_LAPACK(package):
                 'export FFLAGS="{0}"'.format(" ".join(fflags)),
                 'export FCFLAGS="{0}"'.format(" ".join(fflags))
             ]
+        cmake_options = [
+            "-DCMAKE_INSTALL_PREFIX:PATH={BLAS_LAPACK_ROOT}"
+            "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON"
+            "-Wno-dev"
+            "-DCMAKE_BUILD_TYPE=Release"
+        ]
+        if 'MACOS_SDK_PATH' in self.config_dict:
+            cmake_options.append('-DCMAKE_OSX_SYSROOT={0}'.format(self.config_dict['MACOS_SDK_PATH']))
         build_lines += [    
-            "{CMAKE} -DCMAKE_INSTALL_PREFIX:PATH={BLAS_LAPACK_ROOT} -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON -Wno-dev -DCMAKE_BUILD_TYPE=Release ..",
+            "{CMAKE} " + " ".join(cmake_options) + " .. ",
             "make -j{MAKE_THREADS}",
             "make install"
         ]
@@ -1262,7 +1294,7 @@ class ARPACK(package):
 
     def build(self):
         tmp_dict = self.config_dict.copy()
-        options = [
+        cmake_options = [
             "-DCMAKE_INSTALL_PREFIX:PATH={ARPACK_ROOT}",
             "-DCMAKE_INSTALL_LIBDIR=lib",
             "-DEXAMPLES=OFF",
@@ -1270,7 +1302,7 @@ class ARPACK(package):
             "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
         ]
         if "BLAS_LIB_PATH" in self.config_dict:
-            options += [
+            cmake_options += [
                 '-DBLAS_LIBRARIES:PATH={BLAS_LIB_PATH}',
                 '-DLAPACK_LIBRARIES:PATH={LAPACK_LIB_PATH}'
             ]
@@ -1285,7 +1317,7 @@ class ARPACK(package):
         if self.link_omp:
             fflags.append("{0}".format(tmp_dict['OMP_FLAGS']))
         if self.parallel:
-            options.append("-DMPI=ON")
+            cmake_options.append("-DMPI=ON")
             if "MPI_CC" in tmp_dict:
                 build_lines += [
                     "export CC={MPI_CC}",
@@ -1303,16 +1335,18 @@ class ARPACK(package):
                     'export CPPFLAGS="-I{MPI_INCLUDE}"'
                 ]
         else:
-            options.append("-DMPI=OFF")
+            cmake_options.append("-DMPI=OFF")
             build_lines += [
                 "export CC={CC}",
                 "export F77={FC}",
                 "export FC={FC}"
             ]
+        if 'MACOS_SDK_PATH' in tmp_dict:
+            cmake_options.append('-DCMAKE_OSX_SYSROOT={0}'.format(tmp_dict['MACOS_SDK_PATH']))
         #
         build_lines += [
             'export FFLAGS="{0}"'.format(" ".join(fflags)),
-            "{CMAKE} " + " ".join(options) + " ..",
+            "{CMAKE} " + " ".join(cmake_options) + " ..",
             "make -j{MAKE_THREADS}",
             "make install"
         ]
@@ -1350,6 +1384,14 @@ class SUPERLU(package):
         return self.config_dict
 
     def build(self):
+        cmake_options = [
+            "-DCMAKE_INSTALL_PREFIX:PATH={SUPERLU_ROOT}",
+            "-DTPL_BLAS_LIBRARIES:PATH={BLAS_LIB_PATH}",
+            "-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE",
+            "-Denable_blaslib:BOOL=TRUE",
+        ]
+        if 'MACOS_SDK_PATH' in self.config_dict:
+            cmake_options.append('-DCMAKE_OSX_SYSROOT={0}'.format(self.config_dict['MACOS_SDK_PATH']))
         build_lines = [
             "rm -rf build",
             "mkdir build",
@@ -1357,10 +1399,7 @@ class SUPERLU(package):
             "export CC={CC}",
             "export CXX={CXX}",
             "export FC={FC}",
-            "{CMAKE} -DCMAKE_INSTALL_PREFIX:PATH={SUPERLU_ROOT} \\",
-            "  -DTPL_BLAS_LIBRARIES:PATH={BLAS_LIB_PATH} \\",
-            "  -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \\",
-            "  -Denable_blaslib:BOOL=TRUE ..",
+            "{CMAKE} " + " ".join(cmake_options) + " ..",
             "make -j{MAKE_THREADS}",
             "make install"
         ]
@@ -1399,10 +1438,24 @@ SUPERLU_DIST_LIB = -L{SUPERLU_DIST_LIB} {SUPERLU_DIST_LIBS}
     def build(self):
         #
         tmp_dict = self.config_dict.copy()
+        cmake_options = [
+            "-DTPL_ENABLE_PARMETISLIB:BOOL=FALSE",
+            "-DCMAKE_INSTALL_PREFIX:PATH={SUPERLU_DIST_ROOT}",
+            "-DTPL_BLAS_LIBRARIES:PATH={BLAS_LIB_PATH}",
+            "-DTPL_LAPACK_LIBRARIES:PATH={LAPACK_LIB_PATH}",
+            "-Denable_tests=OFF -Denable_examples=OFF",
+            "-DBUILD_SHARED_LIBS:BOOL=FALSE",
+            "-DMPI_Fortran_COMPILER={MPI_FC}",
+            "-DMPI_C_COMPILER={MPI_CC}",
+            "-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE",
+            "-DCMAKE_INSTALL_LIBDIR=lib",
+        ]
         if self.build_openmp:
-            tmp_dict["SUPERLU_DIST_OMP_FLAG"] = "TRUE"
+            cmake_options.append("-Denable_openmp:BOOL=TRUE")
         else:
-            tmp_dict["SUPERLU_DIST_OMP_FLAG"] = "FALSE"
+            cmake_options.append("-Denable_openmp:BOOL=FALSE")
+        if 'MACOS_SDK_PATH' in self.config_dict:
+            cmake_options.append('-DCMAKE_OSX_SYSROOT={0}'.format(self.config_dict['MACOS_SDK_PATH']))
         build_lines = [
             "rm -rf build_dir",
             "mkdir build_dir",
@@ -1410,17 +1463,7 @@ SUPERLU_DIST_LIB = -L{SUPERLU_DIST_LIB} {SUPERLU_DIST_LIBS}
             "export CC={CC}",
             "export CXX={CXX}",
             "export FC={FC}",
-            "{CMAKE} -DTPL_ENABLE_PARMETISLIB:BOOL=FALSE \\",
-            "  -DCMAKE_INSTALL_PREFIX:PATH={SUPERLU_DIST_ROOT} \\",
-            "  -DTPL_BLAS_LIBRARIES:PATH={BLAS_LIB_PATH} \\",
-            "  -DTPL_LAPACK_LIBRARIES:PATH={LAPACK_LIB_PATH} \\",
-            "  -Denable_openmp:BOOL={SUPERLU_DIST_OMP_FLAG} \\",
-            "  -Denable_tests=OFF -Denable_examples=OFF \\",
-            "  -DBUILD_SHARED_LIBS:BOOL=FALSE \\",
-            "  -DMPI_Fortran_COMPILER={MPI_FC} \\",
-            "  -DMPI_C_COMPILER={MPI_CC} \\",
-            "  -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \\",
-            "  -DCMAKE_INSTALL_LIBDIR=lib ..",
+            "{CMAKE} " + " ".join(cmake_options) + " ..",
             "make -j{MAKE_THREADS}",
             "make install"
         ]
@@ -1467,6 +1510,8 @@ UMFPACK_LIB = -L{UMFPACK_LIB} {UMFPACK_LIBS}
         ]
         if self.config_dict.get('OpenBLAS_THREADS',False):
             AMD_CMAKE_options.append("-DCMAKE_EXE_LINKER_FLAGS={0}".format(self.config_dict['OMP_FLAGS']))
+        if 'MACOS_SDK_PATH' in self.config_dict:
+            AMD_CMAKE_options.append('-DCMAKE_OSX_SYSROOT={0}'.format(self.config_dict['MACOS_SDK_PATH']))
         config_CMAKE_options = AMD_CMAKE_options.copy() + [
             "-DBLAS_ROOT:PATH={BLAS_ROOT}",
             "-DBLA_VENDOR:STRING={BLAS_VENDOR}"
@@ -1751,23 +1796,24 @@ parser.add_argument("--setup_only", action="store_true", default=False, help="Do
 parser.add_argument("--nthread", default=1, type=int, help="Number of threads to use for make (default=1)")
 parser.add_argument("--opt_flags", default=None, type=str, help="Compiler optimization flags")
 parser.add_argument("--ld_flags", default=None, type=str, help="Linker flags")
+parser.add_argument("--macos_sdk_path", default=None, type=str, help="Path to macos SDK to use for building")
 parser.add_argument("--cross_compile_host", default=None, type=str, help="Host type for cross-compilation")
 parser.add_argument("--no_dl_progress", action="store_false", default=True, help="Do not report progress during file download")
 #
 group = parser.add_argument_group("CMAKE", "CMAKE configure options for the Open FUSION Toolkit")
-group.add_argument("--build_cmake", default=0, type=int, choices=(0,1), help="Build CMAKE instead of using system version?")
-group.add_argument("--oft_build_debug", default=0, type=int, choices=(0,1), help="Build debug version of OFT?")
+group.add_argument("--build_cmake", default=0, type=int, choices=(0,1), help="Build CMAKE instead of using system version? (default: 0)")
+group.add_argument("--oft_build_debug", default=0, type=int, choices=(0,1), help="Build debug version of OFT? (default: 0)")
 group.add_argument("--oft_build_python", default=1, type=int, choices=(0,1), help="Build OFT Python libraries? (default: 1)")
-group.add_argument("--oft_use_openmp", default=1, type=int, choices=(0,1), help="Build OFT with OpenMP support? (default)")
-group.add_argument("--oft_build_tests", default=0, type=int, choices=(0,1), help="Build OFT tests?")
-group.add_argument("--oft_build_examples", default=0, type=int, choices=(0,1), help="Build OFT examples?")
-group.add_argument("--oft_build_docs", default=0, type=int, choices=(0,1), help="Build OFT documentation? (requires doxygen)")
+group.add_argument("--oft_use_openmp", default=1, type=int, choices=(0,1), help="Build OFT with OpenMP support? (default: 1)")
+group.add_argument("--oft_build_tests", default=0, type=int, choices=(0,1), help="Build OFT tests? (default: 0)")
+group.add_argument("--oft_build_examples", default=0, type=int, choices=(0,1), help="Build OFT examples? (default: 0)")
+group.add_argument("--oft_build_docs", default=0, type=int, choices=(0,1), help="Build OFT documentation (requires doxygen)? (default: 0)")
 group.add_argument("--oft_package", action="store_true", default=False, help="Perform a packaging build of OFT?")
 group.add_argument("--oft_package_release", action="store_true", default=False, help="Perform a release package of OFT?")
 group.add_argument("--oft_build_coverage", action="store_true", default=False, help="Build OFT with code coverage flags?")
 #
 group = parser.add_argument_group("MPI", "MPI package options")
-group.add_argument("--build_mpi", default=0, type=int, choices=(0,1), help="Build MPI libraries?")
+group.add_argument("--build_mpi", default=0, type=int, choices=(0,1), help="Build MPI libraries? (default: 0)")
 group.add_argument("--mpi_cc", default=None, type=str, help="MPI C compiler wrapper")
 group.add_argument("--mpi_fc", default=None, type=str, help="MPI FORTRAN compiler wrapper")
 group.add_argument("--mpi_lib_dir", default=None, type=str, help="MPI library directory")
@@ -1778,6 +1824,7 @@ group = parser.add_argument_group("HDF5", "HDF5 package options")
 group.add_argument("--hdf5_cc", default=None, type=str, help="HDF5 C compiler wrapper")
 group.add_argument("--hdf5_fc", default=None, type=str, help="HDF5 FORTRAN compiler wrapper")
 group.add_argument("--hdf5_parallel", action="store_true", default=False, help="Use parallel HDF5 interface?")
+group.add_argument("--hdf5_legacy_build", action="store_true", default=False, help="Use legacy build instead of CMake?")
 #
 group = parser.add_argument_group("BLAS/LAPACK", "BLAS/LAPACK package options")
 group.add_argument("--oblas_threads", action="store_true", default=False, help="Build OpenBLAS with thread support (OpenMP)")
@@ -1794,39 +1841,39 @@ group = parser.add_argument_group("METIS", "METIS package options")
 group.add_argument("--metis_wrapper", action="store_true", default=False, help="METIS included in compilers")
 #
 group = parser.add_argument_group("FoX XML", "FoX XML package options")
-group.add_argument("--build_fox", default=1, type=int, choices=(0,1), help="Build Fox XML library? (default)")
+group.add_argument("--build_fox", default=1, type=int, choices=(0,1), help="Build Fox XML library? (default: 1)")
 #
 group = parser.add_argument_group("OpenNURBS", "OpenNURBS package options")
-group.add_argument("--build_onurbs", default=0, type=int, choices=(0,1), help="Build OpenNURBS library?")
+group.add_argument("--build_onurbs", default=0, type=int, choices=(0,1), help="Build OpenNURBS library? (default: 0)")
 #
 group = parser.add_argument_group("NETCDF", "NETCDF package options")
-group.add_argument("--build_netcdf", default=0, type=int, choices=(0,1), help="Build NETCDF library?")
+group.add_argument("--build_netcdf", default=0, type=int, choices=(0,1), help="Build NETCDF library? (default: 0)")
 group.add_argument("--netcdf_wrapper", action="store_true", default=False, help="NETCDF included in compilers")
 #
 group = parser.add_argument_group("ARPACK", "ARPACK package options")
-group.add_argument("--build_arpack", default=0, type=int, choices=(0,1), help="Build ARPACK library?")
+group.add_argument("--build_arpack", default=0, type=int, choices=(0,1), help="Build ARPACK library? (default: 0)")
 #
 group = parser.add_argument_group("SuperLU", "SuperLU package options")
-group.add_argument("--build_superlu", default=0, type=int, choices=(0,1), help="Build SuperLU library?")
+group.add_argument("--build_superlu", default=0, type=int, choices=(0,1), help="Build SuperLU library? (default: 0)")
 group.add_argument("--superlu_wrapper", action="store_true", default=False, help="SuperLU included in compilers")
 #
 group = parser.add_argument_group("SuperLU-DIST", "SuperLU-DIST package options")
-group.add_argument("--build_superlu_dist", default=0, type=int, choices=(0,1), help="Build SuperLU-DIST library?")
+group.add_argument("--build_superlu_dist", default=0, type=int, choices=(0,1), help="Build SuperLU-DIST library? (default: 0)")
 group.add_argument("--superlu_dist_threads", action="store_true", default=False, help="Build SuperLU-DIST with thread support (OpenMP)")
 group.add_argument("--superlu_dist_wrapper", action="store_true", default=False, help="SuperLU-DIST included in compilers")
 #
 group = parser.add_argument_group("UMFPACK", "UMFPACK package options")
-group.add_argument("--build_umfpack", default=0, type=int, choices=(0,1), help="Build UMFPACK library?")
+group.add_argument("--build_umfpack", default=0, type=int, choices=(0,1), help="Build UMFPACK library? (default: 0)")
 group.add_argument("--umfpack_wrapper", action="store_true", default=False, help="UMFPACK included in compilers")
 #
 group = parser.add_argument_group("PETSc", "PETSc package options")
-group.add_argument("--build_petsc", default=0, type=int, choices=(0,1), help="Build PETSc library?")
-group.add_argument("--petsc_debug", default=1, type=int, choices=(0,1), help="Build PETSc with debugging information (default)")
-group.add_argument("--petsc_superlu", default=1, type=int, choices=(0,1), help="Build PETSc with SuperLU (default)")
-group.add_argument("--petsc_mumps", default=1, type=int, choices=(0,1), help="Build PETSc with MUMPS (default)")
-group.add_argument("--petsc_umfpack", default=0, type=int, choices=(0,1), help="Build PETSc with UMFPACK")
+group.add_argument("--build_petsc", default=0, type=int, choices=(0,1), help="Build PETSc library? (default: 0)")
+group.add_argument("--petsc_debug", default=1, type=int, choices=(0,1), help="Build PETSc with debugging information (default: 1)")
+group.add_argument("--petsc_superlu", default=1, type=int, choices=(0,1), help="Build PETSc with SuperLU (default: 1)")
+group.add_argument("--petsc_mumps", default=1, type=int, choices=(0,1), help="Build PETSc with MUMPS (default: 1)")
+group.add_argument("--petsc_umfpack", default=0, type=int, choices=(0,1), help="Build PETSc with UMFPACK (default: 0)")
 group.add_argument("--petsc_version", default="3.8", type=str,
-    help="Use different version of PETSc [3.6,3.7,3.8,3.9,3.10] (default is 3.8)")
+    help="Use different version of PETSc [3.6,3.7,3.8,3.9,3.10] (default: 3.8)")
 group.add_argument("--petsc_wrapper", action="store_true", default=False, help="PETSc included in compilers")
 #
 options = parser.parse_args()
@@ -1845,6 +1892,12 @@ if options.ld_flags is not None:
     config_dict['LD_FLAGS'] = options.ld_flags
 if options.cross_compile_host is not None:
     config_dict['CROSS_COMPILE_HOST'] = options.cross_compile_host
+if options.macos_sdk_path is not None:
+    if options.hdf5_legacy_build:
+        parser.exit(-1, 'Use of "--macos_sdk_path" requires CMake build for HDF5\n')
+    if not os.path.isdir(options.macos_sdk_path):
+        parser.exit(-1, 'Specified "--macos_sdk_path={0}" directory does not exist\n'.format(options.macos_sdk_path))
+    config_dict['MACOS_SDK_PATH'] = options.macos_sdk_path
 # Building with MPI?
 use_mpi = False
 if (options.mpi_cc is not None) and (options.mpi_fc is not None):
@@ -1858,11 +1911,11 @@ else:
         if options.mpi_libs is not None:
             config_dict['MPI_LIBS'] = options.mpi_libs
         else:
-            parser.exit(-1, '"MPI_LIBS" required when "MPI_LIB" is specified')
+            parser.exit(-1, '"MPI_LIBS" required when "MPI_LIB" is specified\n')
         if options.mpi_include_dir is not None:
             config_dict['MPI_INCLUDE'] = options.mpi_include_dir
         else:
-            parser.exit(-1, '"MPI_INCLUDE" required when "MPI_LIB" is specified')
+            parser.exit(-1, '"MPI_INCLUDE" required when "MPI_LIB" is specified\n')
     elif options.build_mpi:
         use_mpi = True
 # Setup library builds (in order of dependency)
@@ -1876,7 +1929,7 @@ if options.use_mkl:
 else:
     if (options.blas_lib_path is not None) or (options.lapack_lib_path is not None):
         if (options.blas_lib_path is None) or (options.lapack_lib_path is None):
-            parser.exit(-1, 'Both "blas_lib_path" and "lapack_lib_path" must be specified to use pre-built BLAS/LAPACK')
+            parser.exit(-1, 'Both "blas_lib_path" and "lapack_lib_path" must be specified to use pre-built BLAS/LAPACK\n')
         packages.append(BLAS_LAPACK(blas_lib_path=options.blas_lib_path, lapack_lib_path=options.lapack_lib_path))
     else:
         if options.ref_blas or options.blas_lapack_wrapper:
@@ -1890,14 +1943,14 @@ else:
     if options.hdf5_parallel:
         print('Warning: Reverting to serial HDF5 library without MPI')
     if (options.build_petsc == 1) or options.petsc_wrapper:
-        parser.exit(-1, 'PETSc requires MPI')
+        parser.exit(-1, 'PETSc requires MPI\n')
 # HDF5
 if (options.hdf5_cc is not None) and (options.hdf5_fc is not None):
     config_dict['HDF5_CC'] = options.hdf5_cc
     config_dict['HDF5_FC'] = options.hdf5_fc
-    packages.append(HDF5(parallel=(options.hdf5_parallel and use_mpi)))
+    packages.append(HDF5(parallel=(options.hdf5_parallel and use_mpi),legacy_build=options.hdf5_legacy_build))
 else:
-    packages.append(HDF5(parallel=(options.hdf5_parallel and use_mpi)))
+    packages.append(HDF5(parallel=(options.hdf5_parallel and use_mpi),legacy_build=options.hdf5_legacy_build))
 # Are we building OpenNURBS?
 if options.build_onurbs == 1:
     packages.append(ONURBS())
@@ -1921,7 +1974,7 @@ else:
         packages.append(SUPERLU(options.superlu_wrapper))
     if (options.build_superlu_dist == 1) or options.superlu_dist_wrapper:
         if not use_mpi:
-            parser.exit(-1, 'SuperLU-DIST requires MPI')
+            parser.exit(-1, 'SuperLU-DIST requires MPI\n')
         packages.append(SUPERLU_DIST(options.superlu_dist_threads, options.superlu_dist_wrapper))
     if (options.build_umfpack == 1) or options.umfpack_wrapper:
         packages.append(UMFPACK(options.umfpack_wrapper))


### PR DESCRIPTION
This pull request updates the `build_libs.py` to support explicit specification of the SDK path on macos, including:
 - Support CMake based build of HDF5 in `build_libs.py`
 - Update HDF5 version in `build_libs.py` to 1.14.2 and do not build high-level interface
 - Cleanup and standardize CMake builds in `build_libs.py`

This pull request **does not** modify any APIs or input files. This pull request **does** add new `--macos_sdk_path`, `--hdf5_cmake_build` options to `build_libs.py`.