### PR TITLE
Update coverage action workflow

### DIFF
--- a/.github/workflows/cov_build.yaml
+++ b/.github/workflows/cov_build.yaml
@@ -96,4 +96,5 @@ jobs:
         files: libs/build_release/cleaned_coverage.txt,libs/build_release/tests/coverage.xml
         token: ${{ secrets.CODECOV_TOKEN }}
         disable_search: true
+        plugin: noop
         verbose: true

--- a/.github/workflows/cov_build.yaml
+++ b/.github/workflows/cov_build.yaml
@@ -88,10 +88,12 @@ jobs:
       run: |
         lcov -c --directory . --output-file main_coverage.info --gcov-tool $GCOV
         lcov --ignore-errors unused -r main_coverage.info -o cleaned_coverage.txt '/opt/*' '/usr/*'
+        lcov -l cleaned_coverage.txt
     
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v4
       with:
         files: libs/build_release/cleaned_coverage.txt,libs/build_release/tests/coverage.xml
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
         verbose: true

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -177,7 +177,9 @@ if( HDF5_IS_PARALLEL )
   endif()
 endif()
 # PETSc
-find_package( OFT_PETSc )
+if( OFT_PETSc_ROOT ) # Only search if PETSc root is specified
+  find_package( OFT_PETSc )
+endif()
 if( NOT OFT_PETSc_FOUND )
   # METIS
   find_package( OFT_METIS REQUIRED )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,7 @@ elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
   if(OFT_COVERAGE)
     set( CMAKE_C_FLAGS_DEBUG "-Og --coverage -fprofile-update=atomic -g -Wuninitialized" ) # -fprofile-arcs -ftest-coverage
     set( CMAKE_C_FLAGS_RELEASE "-Og --coverage -fprofile-update=atomic -g" ) # -fprofile-arcs -ftest-coverage
+    add_definitions( -DOFT_COVERAGE )
     set(CMAKE_C_OUTPUT_EXTENSION_REPLACE ON)
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE ON)
     set(CMAKE_Fortran_OUTPUT_EXTENSION_REPLACE ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,8 +93,8 @@ if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
   endif()
 elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
   if(OFT_COVERAGE)
-    set( CMAKE_C_FLAGS_DEBUG "-Og --coverage -fprofile-update=atomic -g -Wuninitialized" ) # -fprofile-arcs -ftest-coverage
-    set( CMAKE_C_FLAGS_RELEASE "-Og --coverage -fprofile-update=atomic -g" ) # -fprofile-arcs -ftest-coverage
+    set( CMAKE_C_FLAGS_DEBUG "-O0 --coverage -fprofile-update=atomic -g -Wuninitialized" ) # -fprofile-arcs -ftest-coverage
+    set( CMAKE_C_FLAGS_RELEASE "-O0 --coverage -fprofile-update=atomic -g" ) # -fprofile-arcs -ftest-coverage
     set(CMAKE_C_OUTPUT_EXTENSION_REPLACE ON)
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE ON)
     set(CMAKE_Fortran_OUTPUT_EXTENSION_REPLACE ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,8 +93,8 @@ if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
   endif()
 elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
   if(OFT_COVERAGE)
-    set( CMAKE_C_FLAGS_DEBUG "-O0 --coverage -fprofile-update=atomic -g -Wuninitialized" ) # -fprofile-arcs -ftest-coverage
-    set( CMAKE_C_FLAGS_RELEASE "-O0 --coverage -fprofile-update=atomic -g" ) # -fprofile-arcs -ftest-coverage
+    set( CMAKE_C_FLAGS_DEBUG "-Og --coverage -fprofile-update=atomic -g -Wuninitialized" ) # -fprofile-arcs -ftest-coverage
+    set( CMAKE_C_FLAGS_RELEASE "-Og --coverage -fprofile-update=atomic -g" ) # -fprofile-arcs -ftest-coverage
     set(CMAKE_C_OUTPUT_EXTENSION_REPLACE ON)
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE ON)
     set(CMAKE_Fortran_OUTPUT_EXTENSION_REPLACE ON)

--- a/src/base/oft_local_c.c
+++ b/src/base/oft_local_c.c
@@ -5,6 +5,17 @@
 
 void oft_stack_print();
 void oft_finalize();
+#ifdef OFT_COVERAGE
+void __gcov_dump();
+#endif
+
+// Dump coverage information (needed for library usage)
+void dump_cov()
+{
+#ifdef OFT_COVERAGE
+	__gcov_dump();
+#endif
+}
 
 // Define the function to be called when ctrl-c (SIGINT) signal is sent to process
 void oft_signal_handler(int signum)

--- a/src/bin/thincurr_eig.F90
+++ b/src/bin/thincurr_eig.F90
@@ -146,8 +146,11 @@ ELSE
   CALL tw_hodlr%setup(.FALSE.)
   IF(tw_hodlr%L_svd_tol>0.d0)THEN
     IF(direct)CALL oft_abort('HODLR compression does not support "direct=T"','thincurr_eig',__FILE__)
-    IF(save_L)CALL oft_abort('HODLR compression does not support "save_L=T"','thincurr_eig',__FILE__)
-    CALL tw_hodlr%compute_L()
+    IF(save_L)THEN
+      CALL tw_hodlr%compute_L(save_file='Lmat.save')
+    ELSE
+      CALL tw_hodlr%compute_L()
+    END IF
   ELSE
     IF(save_L)THEN
       CALL tw_compute_LmatDirect(tw_sim,tw_sim%Lmat,save_file='Lmat.save')

--- a/src/bin/thincurr_fr.F90
+++ b/src/bin/thincurr_fr.F90
@@ -173,8 +173,11 @@ IF(fr_limit/=2)THEN
   CALL tw_hodlr%setup(.FALSE.)
   IF(tw_hodlr%L_svd_tol>0.d0)THEN
     IF(direct)CALL oft_abort('HODLR compression does not support "direct=T"','thincurr_fr',__FILE__)
-    IF(save_L)CALL oft_abort('HODLR compression does not support "save_L=T"','thincurr_fr',__FILE__)
-    CALL tw_hodlr%compute_L()
+    IF(save_L)THEN
+      CALL tw_hodlr%compute_L(save_file='Lmat.save')
+    ELSE
+      CALL tw_hodlr%compute_L()
+    END IF
   ELSE
     IF(save_L)THEN
       CALL tw_compute_LmatDirect(tw_sim,tw_sim%Lmat,save_file='Lmat.save')

--- a/src/bin/thincurr_td.F90
+++ b/src/bin/thincurr_td.F90
@@ -158,8 +158,11 @@ CALL tw_hodlr%setup(.FALSE.)
 IF(.NOT.plot_run)THEN
   IF(tw_hodlr%L_svd_tol>0.d0)THEN
     IF(direct)CALL oft_abort('HODLR compression does not support "direct=T"','thincurr_td',__FILE__)
-    IF(save_L)CALL oft_abort('HODLR compression does not support "save_L=T"','thincurr_td',__FILE__)
-    CALL tw_hodlr%compute_L()
+    IF(save_L)THEN
+      CALL tw_hodlr%compute_L(save_file='Lmat.save')
+    ELSE
+      CALL tw_hodlr%compute_L()
+    END IF
   ELSE
     IF(save_L)THEN
       CALL tw_compute_LmatDirect(tw_sim,tw_sim%Lmat,save_file='Lmat.save')

--- a/src/cmake/FindOFT_UMFPACK.cmake
+++ b/src/cmake/FindOFT_UMFPACK.cmake
@@ -1,7 +1,7 @@
 # FindOFT_UMFPACK.cmake
 #
-# Finds the SuperLU library for use with the Open FUSION Toolkit
-# as installed by version "4.3+" of SuperLU.
+# Finds the UMFPACK library for use with the Open FUSION Toolkit
+# as installed by version "7.0+" of SuiteSparse.
 #
 # This will define the following variables
 #
@@ -18,6 +18,10 @@ find_library(UMFPACK_BASE_LIBRARY
 find_library(UMFPACK_AMD_LIBRARY
   NAMES amd
 )
+
+# find_library(UMFPACK_CHOLMOD_LIBRARY
+#   NAMES cholmod
+# )
 
 find_library(UMFPACK_SSC_LIBRARY
   NAMES suitesparseconfig

--- a/src/python/OpenFUSIONToolkit/util.py
+++ b/src/python/OpenFUSIONToolkit/util.py
@@ -87,6 +87,9 @@ oft_setup_smesh = ctypes_subroutine(oftpy_lib.oft_setup_smesh,
 # Set mesh in memory: (ndim,np,r_loc,npc,nc,lc_loc,reg_loc)
 oft_setup_vmesh = ctypes_subroutine(oftpy_lib.oft_setup_vmesh,
     [c_int,c_int, ctypes_numpy_array(float64,2) ,c_int, c_int, ctypes_numpy_array(int32,2), ctypes_numpy_array(int32,1), c_int_ptr])
+
+# Dump coverage information if needed
+oftpy_dump_cov = ctypes_subroutine(oftpy_lib.dump_cov)
 ## @endcond
 
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -61,6 +61,6 @@ add_custom_command(
 add_custom_target(test_cov)
 add_custom_command(
     TARGET  test_cov
-    COMMAND PATH=${OFT_TEST_PATH} OFT_HAVE_MPI=${OFT_MPI_TEST} OFT_DEBUG_TEST=${OFT_DEBUG_TEST} ${OFT_PYTEST_EXE} --cov=OpenFUSIONToolkit --cov-report=xml -m \"coverage\" grid lin_alg fem physics
+    COMMAND PATH=${OFT_TEST_PATH} OFT_HAVE_MPI=${OFT_MPI_TEST} OFT_DEBUG_TEST=1 ${OFT_PYTEST_EXE} --cov=OpenFUSIONToolkit --cov-report=xml -m \"coverage\" grid lin_alg fem physics
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests
 )

--- a/src/tests/physics/test_ThinCurr.py
+++ b/src/tests/physics/test_ThinCurr.py
@@ -10,6 +10,7 @@ sys.path.append(os.path.abspath(os.path.join(test_dir, '..')))
 sys.path.append(os.path.abspath(os.path.join(test_dir, '..','..','python')))
 from oft_testing import run_OFT
 from OpenFUSIONToolkit.io import histfile
+from OpenFUSIONToolkit.util import oftpy_dump_cov
 
 mu0 = np.pi*4.E-7
 
@@ -128,10 +129,12 @@ def run_td(meshfile,direct_flag,use_aca,floops,curr_waveform,volt_waveform,lin_t
         tw_model.compute_Lmat(use_hodlr=use_aca,cache_file='Lmat.save')
         tw_model.compute_Rmat()
         tw_model.run_td(2.E-5,200,direct=(direct_flag == 'T'),lin_tol=lin_tol,coil_currs=curr_waveform,coil_volts=volt_waveform,sensor_obj=sensor_obj)
-        mp_q.put(True)
+        result = True
     except BaseException as e:
         print(e)
-        mp_q.put(False)
+        result = False
+    oftpy_dump_cov()
+    mp_q.put(result)
 
 
 def run_eig(meshfile,direct_flag,use_aca,mp_q):
@@ -147,10 +150,12 @@ def run_eig(meshfile,direct_flag,use_aca,mp_q):
         eig_file = '\n'.join(['{0} 0.0'.format(eig_val) for eig_val in eig_vals])
         with open('thincurr_eigs.dat','w+') as fid:
             fid.write(eig_file)
-        mp_q.put(True)
+        result = True
     except BaseException as e:
         print(e)
-        mp_q.put(False)
+        result = False
+    oftpy_dump_cov()
+    mp_q.put(result)
 
 
 def run_fr(meshfile,direct_flag,use_aca,freq,fr_limit,floops,mp_q):
@@ -177,10 +182,12 @@ def run_fr(meshfile,direct_flag,use_aca,freq,fr_limit,floops,mp_q):
         fr_file = '\n'.join(['{0} {1}'.format(*probe_signals[:,i]) for i in range(probe_signals.shape[1])])
         with open('thincurr_fr.dat','w+') as fid:
             fid.write(fr_file)
-        mp_q.put(True)
+        result = True
     except BaseException as e:
         print(e)
-        mp_q.put(False)
+        result = False
+    oftpy_dump_cov()
+    mp_q.put(result)
     
 
 def ThinCurr_setup(meshfile,run_type,direct_flag,freq=0.0,fr_limit=0,eta=10.0,use_aca=False,

--- a/src/tests/physics/test_ThinCurr.py
+++ b/src/tests/physics/test_ThinCurr.py
@@ -42,7 +42,7 @@ oft_in_template = """
  nplot=10
  direct={1}
  cg_tol={10}
- save_L=F
+ save_L=T
  save_Mcoil=F
  plot_run=F
 /
@@ -80,6 +80,8 @@ oft_in_xml_template_template = """
 
 
 def mp_run(target,args,timeout=180):
+    if os.environ.get('OFT_DEBUG_TEST', 0):
+        timeout *= 4
     os.chdir(test_dir)
     mp_q = multiprocessing.Queue()
     p = multiprocessing.Process(target=target, args=args + (mp_q,))
@@ -123,7 +125,7 @@ def run_td(meshfile,direct_flag,use_aca,floops,curr_waveform,volt_waveform,lin_t
         if volt_waveform is not None:
             volt_waveform = np.array(volt_waveform)
         tw_model.compute_Mcoil()
-        tw_model.compute_Lmat(use_hodlr=use_aca)
+        tw_model.compute_Lmat(use_hodlr=use_aca,cache_file='Lmat.save')
         tw_model.compute_Rmat()
         tw_model.run_td(2.E-5,200,direct=(direct_flag == 'T'),lin_tol=lin_tol,coil_currs=curr_waveform,coil_volts=volt_waveform,sensor_obj=sensor_obj)
         mp_q.put(True)
@@ -139,7 +141,7 @@ def run_eig(meshfile,direct_flag,use_aca,mp_q):
         tw_model.setup_model(mesh_file=meshfile,xml_filename='oft_in.xml')
         tw_model.setup_io()
         tw_model.compute_Mcoil()
-        tw_model.compute_Lmat(use_hodlr=use_aca)
+        tw_model.compute_Lmat(use_hodlr=use_aca,cache_file='Lmat.save')
         tw_model.compute_Rmat()
         eig_vals, _ = tw_model.get_eigs(4,direct=(direct_flag == 'T'))
         eig_file = '\n'.join(['{0} 0.0'.format(eig_val) for eig_val in eig_vals])
@@ -165,7 +167,7 @@ def run_fr(meshfile,direct_flag,use_aca,freq,fr_limit,floops,mp_q):
             save_sensors(sensors)
             Msensor, Msc, _ = tw_model.compute_Msensor('floops.loc')
         Mcoil = tw_model.compute_Mcoil()
-        tw_model.compute_Lmat(use_hodlr=use_aca)
+        tw_model.compute_Lmat(use_hodlr=use_aca,cache_file='Lmat.save')
         tw_model.compute_Rmat()
         driver = np.zeros((2,tw_model.nelems))
         driver[0,:] = Mcoil[0,:]
@@ -294,8 +296,8 @@ def validate_eigs(eigs, tols=(1.E-5, 1.E-9)):
             vals = line.split()
             eigs_run_real.append(float(vals[0]))
             eigs_run_imag.append(float(vals[1]))
-    if not len(eigs_run_real) == len(eigs):
-        print("FAILED: Number of eigenvalues does not match")
+    if len(eigs_run_real) < len(eigs):
+        print("FAILED: Number of eigenvalues is not correct")
         return False
     retval = True
     for (i, val) in enumerate(eigs):
@@ -395,7 +397,16 @@ def validate_model_red(eigs, tols=(1.E-5, 1.E-9)):
     return retval
 
 #============================================================================
-# Test runners for time-dependent cases
+# Test runners for plate
+@pytest.mark.parametrize("direct_flag", ('F', 'T'))
+@pytest.mark.parametrize("python", (False, True))
+def test_eig_plate(direct_flag,python):
+    eigs = (9.735667E-3, 6.532314E-3, 6.532201E-3, 5.251598E-3)
+    assert ThinCurr_setup("tw_test-plate.h5",2 if python else 4,direct_flag,python=python)
+    assert validate_eigs(eigs)
+    if not python:
+        assert validate_model_red(eigs)
+
 @pytest.mark.parametrize("direct_flag", ('F', 'T'))
 @pytest.mark.parametrize("python", (False, True))
 def test_td_plate(direct_flag,python):
@@ -409,6 +420,17 @@ def test_td_plate(direct_flag,python):
 
 @pytest.mark.parametrize("direct_flag", ('F', 'T'))
 @pytest.mark.parametrize("python", (False, True))
+def test_fr_plate(direct_flag,python):
+    fr_real = (6.807649E-2, 7.207748E-2)
+    fr_imag = (-3.011666E-3, -2.177010E-3)
+    assert ThinCurr_setup("tw_test-plate.h5",3,direct_flag,freq=5.E3,fr_limit=0,
+                           icoils=((0.5, 0.1),),
+                           floops=((0.5, -0.05), (0.5, -0.1)),
+                           python=python)
+    assert validate_fr(fr_real, fr_imag, python=python)
+
+@pytest.mark.parametrize("direct_flag", ('F', 'T'))
+@pytest.mark.parametrize("python", (False, True))
 def test_td_plate_volt(direct_flag,python):
     sigs_final = (4.E-3, 4.580643E-4, 3.854292E-4)
     assert ThinCurr_setup("tw_test-plate.h5",1,direct_flag,
@@ -417,6 +439,17 @@ def test_td_plate_volt(direct_flag,python):
                            volt_waveform=((0.0, 1.0), (1.0, 1.0)),
                            python=python)
     assert validate_td(sigs_final)
+
+#============================================================================
+# Test runners for cylinder
+@pytest.mark.parametrize("direct_flag", ('F', 'T'))
+@pytest.mark.parametrize("python", (False, True))
+def test_eig_cyl(direct_flag,python):
+    eigs = (2.657195E-2, 1.248071E-2, 1.247103E-2, 1.200566E-2)
+    assert ThinCurr_setup("tw_test-cyl.h5",2 if python else 4,direct_flag,python=python)
+    assert validate_eigs(eigs)
+    if not python:
+        assert validate_model_red(eigs)
 
 @pytest.mark.parametrize("direct_flag", ('F', 'T'))
 @pytest.mark.parametrize("python", (False, True))
@@ -431,6 +464,17 @@ def test_td_cyl(direct_flag,python):
 
 @pytest.mark.parametrize("direct_flag", ('F', 'T'))
 @pytest.mark.parametrize("python", (False, True))
+def test_fr_cyl(direct_flag,python):
+    fr_real = (6.118337E-2, 4.356188E-3)
+    fr_imag = (-1.911861E-3, -2.283493E-3)
+    assert ThinCurr_setup("tw_test-cyl.h5",3,direct_flag,freq=5.E3,fr_limit=0,
+                           icoils=((1.1, 0.25), (1.1, -0.25)),
+                           floops=((0.9, 0.5), (0.9, 0.0)),
+                           python=python)
+    assert validate_fr(fr_real, fr_imag, python=python)
+
+@pytest.mark.parametrize("direct_flag", ('F', 'T'))
+@pytest.mark.parametrize("python", (False, True))
 def test_td_cyl_volt(direct_flag,python):
     sigs_final = (4.E-3, 1.504279E-4, 1.276624E-4)
     assert ThinCurr_setup("tw_test-cyl.h5",1,direct_flag,
@@ -439,6 +483,18 @@ def test_td_cyl_volt(direct_flag,python):
                            volt_waveform=((0.0, 1.0, 1.0), (1.0, 1.0, 1.0)),
                            python=python)
     assert validate_td(sigs_final)
+
+#============================================================================
+# Test runners for torus
+@pytest.mark.coverage
+@pytest.mark.parametrize("direct_flag", ('F', 'T'))
+@pytest.mark.parametrize("python", (False, True))
+def test_eig_torus(direct_flag,python):
+    eigs = (4.751344E-2, 2.564491E-2, 2.555695E-2, 2.285850E-2)
+    assert ThinCurr_setup("tw_test-torus.h5",2 if python else 4,direct_flag,python=python)
+    assert validate_eigs(eigs)
+    if not python:
+        assert validate_model_red(eigs)
 
 @pytest.mark.coverage
 @pytest.mark.parametrize("direct_flag", ('F', 'T'))
@@ -456,6 +512,18 @@ def test_td_torus(direct_flag,python):
 @pytest.mark.coverage
 @pytest.mark.parametrize("direct_flag", ('F', 'T'))
 @pytest.mark.parametrize("python", (False, True))
+def test_fr_torus(direct_flag,python):
+    fr_real = (-2.807955E-3, -1.196091E-4)
+    fr_imag = (-1.869732E-3, -1.248642E-4)
+    assert ThinCurr_setup("tw_test-torus.h5",3,direct_flag,freq=5.E3,fr_limit=0,
+                           icoils=((1.5, 0.5), (1.5, -0.5)),
+                           floops=((1.4, 0.0), (0.6, 0.0)),
+                           python=python)
+    assert validate_fr(fr_real, fr_imag, python=python)
+
+@pytest.mark.coverage
+@pytest.mark.parametrize("direct_flag", ('F', 'T'))
+@pytest.mark.parametrize("python", (False, True))
 def test_td_torus_volt(direct_flag,python):
     sigs_final = (4.E-3, 5.653338E-5, 4.035387E-6)
     assert ThinCurr_setup("tw_test-torus.h5",1,direct_flag,
@@ -465,6 +533,20 @@ def test_td_torus_volt(direct_flag,python):
                            lin_tol=1.E-11,
                            python=python)
     assert validate_td(sigs_final)
+
+#============================================================================
+# Test runners for filament model
+@pytest.mark.coverage
+@pytest.mark.parametrize("direct_flag", ('F', 'T'))
+@pytest.mark.parametrize("python", (False, True))
+def test_eig_passive(direct_flag,python):
+    eigs = (1.504155E-1, 6.423383E-2, 3.190175E-2, 2.942398E-2)
+    assert ThinCurr_setup("tw_test-passive.h5",2 if python else 4,direct_flag,eta=1.E4,
+                           vcoils=((0.5, 0.1), (0.5, 0.05),
+                                   (0.5, -0.05), (0.5, -0.1)),python=python)
+    assert validate_eigs(eigs)
+    if not python:
+        assert validate_model_red(eigs)
 
 @pytest.mark.coverage
 @pytest.mark.parametrize("direct_flag", ('F', 'T'))
@@ -482,118 +564,6 @@ def test_td_passive(direct_flag,python):
 @pytest.mark.coverage
 @pytest.mark.parametrize("direct_flag", ('F', 'T'))
 @pytest.mark.parametrize("python", (False, True))
-def test_td_passive_volt(direct_flag,python):
-   sigs_final = (4.E-3, 4.379235E-4, 4.389248E-4)
-   assert ThinCurr_setup("tw_test-passive.h5",1,direct_flag,eta=1.E4,
-                          vcoils=((0.5, 0.0), (0.5, 0.1)),
-                          floops=((0.5, -0.05), (0.5, -0.1)),
-                          volt_waveform=((0.0, 0.0, 1.0), (1.0, 0.0, 1.0)),
-                          python=python)
-   assert validate_td(sigs_final)
-
-#============================================================================
-# Test runners for eigenvalue cases
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-@pytest.mark.parametrize("python", (False, True))
-def test_eig_plate(direct_flag,python):
-    eigs = (9.735667E-3, 6.532314E-3, 6.532201E-3, 5.251598E-3)
-    assert ThinCurr_setup("tw_test-plate.h5",2,direct_flag,python=python)
-    assert validate_eigs(eigs)
-    
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-@pytest.mark.parametrize("python", (False, True))
-def test_eig_cyl(direct_flag,python):
-    eigs = (2.657195E-2, 1.248071E-2, 1.247103E-2, 1.200566E-2)
-    assert ThinCurr_setup("tw_test-cyl.h5",2,direct_flag,python=python)
-    assert validate_eigs(eigs)
-
-@pytest.mark.coverage
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-@pytest.mark.parametrize("python", (False, True))
-def test_eig_torus(direct_flag,python):
-    eigs = (4.751344E-2, 2.564491E-2, 2.555695E-2, 2.285850E-2)
-    assert ThinCurr_setup("tw_test-torus.h5",2,direct_flag,python=python)
-    assert validate_eigs(eigs)
-
-@pytest.mark.coverage
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-@pytest.mark.parametrize("python", (False, True))
-def test_eig_passive(direct_flag,python):
-    eigs = (1.504155E-1, 6.423383E-2, 3.190175E-2, 2.942398E-2)
-    assert ThinCurr_setup("tw_test-passive.h5",2,direct_flag,eta=1.E4,
-                           vcoils=((0.5, 0.1), (0.5, 0.05),
-                                   (0.5, -0.05), (0.5, -0.1)),python=python)
-    assert validate_eigs(eigs)
-
-#============================================================================
-# Test runners for eigenvalue-based model reduction
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-def test_mred_plate(direct_flag):
-    eigs = (9.735667E-3, 6.532314E-3, 6.532201E-3, 5.251598E-3)
-    assert ThinCurr_setup("tw_test-plate.h5",4,direct_flag)
-    assert validate_model_red(eigs)
-
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-def test_mred_cyl(direct_flag):
-    eigs = (2.657195E-2, 1.248071E-2, 1.247103E-2, 1.200566E-2)
-    assert ThinCurr_setup("tw_test-cyl.h5",4,direct_flag)
-    assert validate_model_red(eigs)
-
-@pytest.mark.coverage
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-def test_mred_torus(direct_flag):
-    eigs = (4.751344E-2, 2.564491E-2, 2.555695E-2, 2.285850E-2)
-    assert ThinCurr_setup("tw_test-torus.h5",4,direct_flag)
-    assert validate_model_red(eigs)
-
-@pytest.mark.coverage
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-def test_mred_passive(direct_flag):
-    eigs = (1.504155E-1, 6.423383E-2, 3.190175E-2, 2.942398E-2)
-    assert ThinCurr_setup("tw_test-passive.h5",4,direct_flag,eta=1.E4,
-                           vcoils=((0.5, 0.1), (0.5, 0.05),
-                                   (0.5, -0.05), (0.5, -0.1)))
-    assert validate_model_red(eigs)
-
-#============================================================================
-# Test runners for frequency-response cases
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-@pytest.mark.parametrize("python", (False, True))
-def test_fr_plate(direct_flag,python):
-    fr_real = (6.807649E-2, 7.207748E-2)
-    fr_imag = (-3.011666E-3, -2.177010E-3)
-    assert ThinCurr_setup("tw_test-plate.h5",3,direct_flag,freq=5.E3,fr_limit=0,
-                           icoils=((0.5, 0.1),),
-                           floops=((0.5, -0.05), (0.5, -0.1)),
-                           python=python)
-    assert validate_fr(fr_real, fr_imag, python=python)
-
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-@pytest.mark.parametrize("python", (False, True))
-def test_fr_cyl(direct_flag,python):
-    fr_real = (6.118337E-2, 4.356188E-3)
-    fr_imag = (-1.911861E-3, -2.283493E-3)
-    assert ThinCurr_setup("tw_test-cyl.h5",3,direct_flag,freq=5.E3,fr_limit=0,
-                           icoils=((1.1, 0.25), (1.1, -0.25)),
-                           floops=((0.9, 0.5), (0.9, 0.0)),
-                           python=python)
-    assert validate_fr(fr_real, fr_imag, python=python)
-
-@pytest.mark.coverage
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-@pytest.mark.parametrize("python", (False, True))
-def test_fr_torus(direct_flag,python):
-    fr_real = (-2.807955E-3, -1.196091E-4)
-    fr_imag = (-1.869732E-3, -1.248642E-4)
-    assert ThinCurr_setup("tw_test-torus.h5",3,direct_flag,freq=5.E3,fr_limit=0,
-                           icoils=((1.5, 0.5), (1.5, -0.5)),
-                           floops=((1.4, 0.0), (0.6, 0.0)),
-                           python=python)
-    assert validate_fr(fr_real, fr_imag, python=python)
-
-@pytest.mark.coverage
-@pytest.mark.parametrize("direct_flag", ('F', 'T'))
-@pytest.mark.parametrize("python", (False, True))
 def test_fr_passive(direct_flag,python):
     fr_real = (1.947713E-1, 1.990873E-1)
     fr_imag = (-2.174952E-4, -1.560016E-4)
@@ -604,20 +574,28 @@ def test_fr_passive(direct_flag,python):
                            python=python)
     assert validate_fr(fr_real, fr_imag, python=python)
 
+@pytest.mark.coverage
+@pytest.mark.parametrize("direct_flag", ('F', 'T'))
+@pytest.mark.parametrize("python", (False, True))
+def test_td_passive_volt(direct_flag,python):
+   sigs_final = (4.E-3, 4.379235E-4, 4.389248E-4)
+   assert ThinCurr_setup("tw_test-passive.h5",1,direct_flag,eta=1.E4,
+                          vcoils=((0.5, 0.0), (0.5, 0.1)),
+                          floops=((0.5, -0.05), (0.5, -0.1)),
+                          volt_waveform=((0.0, 0.0, 1.0), (1.0, 0.0, 1.0)),
+                          python=python)
+   assert validate_td(sigs_final)
+
 #============================================================================
-# Test runners for ACA
+# Test runners for large cylinder (w/ ACA+)
 @pytest.mark.coverage
 @pytest.mark.parametrize("python", (False, True))
 def test_eig_aca(python):
     eigs = (2.659575E-2, 1.254552E-2, 1.254536E-2, 1.208636E-2)
-    assert ThinCurr_setup("tw_test-cyl_hr.h5",2,'F',use_aca=True,python=python)
+    assert ThinCurr_setup("tw_test-cyl_hr.h5",2 if python else 4,'F',use_aca=True,python=python)
     assert validate_eigs(eigs)
-
-@pytest.mark.coverage
-def test_mred_aca():
-    eigs = (2.659575E-2, 1.254552E-2, 1.254536E-2, 1.208636E-2)
-    assert ThinCurr_setup("tw_test-cyl_hr.h5",4,'F',use_aca=True)
-    assert validate_model_red(eigs)
+    if not python:
+        assert validate_model_red(eigs)
 
 @pytest.mark.coverage
 @pytest.mark.parametrize("python", (False, True))
@@ -632,17 +610,6 @@ def test_td_aca(python):
 
 @pytest.mark.coverage
 @pytest.mark.parametrize("python", (False, True))
-def test_td_volt_aca(python):
-    sigs_final = (4.E-3, 1.512679E-4, 1.291681E-4)
-    assert ThinCurr_setup("tw_test-cyl_hr.h5",1,'F',use_aca=True,
-                           vcoils=((1.1, 0.25), (1.1, -0.25)),
-                           floops=((0.9, 0.5), (0.9, 0.0)),
-                           volt_waveform=((0.0, 1.0, 1.0), (1.0, 1.0, 1.0)),
-                           python=python)
-    assert validate_td(sigs_final)
-
-@pytest.mark.coverage
-@pytest.mark.parametrize("python", (False, True))
 def test_fr_aca(python):
     fr_real = (5.888736E-2, 4.881440E-3)
     fr_imag = (-2.017045E-3, -2.313881E-3)
@@ -651,3 +618,14 @@ def test_fr_aca(python):
                            floops=((0.9, 0.5), (0.9, 0.0)),
                            python=python)
     assert validate_fr(fr_real, fr_imag, tols=(1.E-3, 1.E-3))
+
+@pytest.mark.coverage
+@pytest.mark.parametrize("python", (False, True))
+def test_td_volt_aca(python):
+    sigs_final = (4.E-3, 1.512679E-4, 1.291681E-4)
+    assert ThinCurr_setup("tw_test-cyl_hr.h5",1,'F',use_aca=True,
+                           vcoils=((1.1, 0.25), (1.1, -0.25)),
+                           floops=((0.9, 0.5), (0.9, 0.0)),
+                           volt_waveform=((0.0, 1.0, 1.0), (1.0, 1.0, 1.0)),
+                           python=python)
+    assert validate_td(sigs_final)

--- a/src/tests/physics/test_TokaMaker.py
+++ b/src/tests/physics/test_TokaMaker.py
@@ -16,6 +16,8 @@ from OpenFUSIONToolkit.TokaMaker.util import create_isoflux, eval_green, create_
 
 
 def mp_run(target,args,timeout=30):
+    if os.environ.get('OFT_DEBUG_TEST', 0):
+        timeout *= 4
     os.chdir(test_dir)
     mp_q = multiprocessing.Queue()
     p = multiprocessing.Process(target=target, args=args + (mp_q,))

--- a/src/tests/physics/test_TokaMaker.py
+++ b/src/tests/physics/test_TokaMaker.py
@@ -13,6 +13,7 @@ sys.path.append(os.path.abspath(os.path.join(test_dir, '..','..','python')))
 from OpenFUSIONToolkit.TokaMaker import TokaMaker
 from OpenFUSIONToolkit.TokaMaker.meshing import gs_Domain, save_gs_mesh, load_gs_mesh
 from OpenFUSIONToolkit.TokaMaker.util import create_isoflux, eval_green, create_power_flux_fun
+from OpenFUSIONToolkit.util import oftpy_dump_cov
 
 
 def mp_run(target,args,timeout=30):
@@ -110,6 +111,7 @@ def run_solo_case(mesh_resolution,fe_order,mp_q):
             diff[1] = x_points[i,1]+rz_x[1]
         X_err += np.linalg.norm(diff)
     mp_q.put([psi_err, X_err])
+    oftpy_dump_cov()
 
 
 def validate_solo(results,psi_err_exp,X_err_exp):
@@ -200,6 +202,7 @@ def run_sph_case(mesh_resolution,fe_order,mp_q):
     # Compute error in psi
     psi_err = np.linalg.norm(psi_TM-psi_eig_TM)/np.linalg.norm(psi_eig_TM)
     mp_q.put([psi_err])
+    oftpy_dump_cov()
 
 
 def validate_sph(results,psi_err_exp):
@@ -278,6 +281,7 @@ def run_coil_case(mesh_resolution,fe_order,mp_q):
     psi_full = np.hstack((psi1[1:], psi2, psi3[1:]))
     psi_err = np.linalg.norm(green_full+psi_full)/np.linalg.norm(green_full)
     mp_q.put([psi_err])
+    oftpy_dump_cov()
 
 
 def validate_coil(results,psi_err_exp):
@@ -428,6 +432,7 @@ def run_ITER_case(mesh_resolution,fe_order,eig_test,mp_q):
     eq_info['MCS1_plasma'] = Lmat[mygs.coil_sets['CS1U']['id'],-1]
     eq_info['Lplasma'] = Lmat[-1,-1]
     mp_q.put([eq_info])
+    oftpy_dump_cov()
 
 
 # Test runners for LTX test cases
@@ -565,6 +570,7 @@ def run_LTX_case(fe_order,eig_test,mp_q):
     mygs.solve()
     #
     mp_q.put([mygs.get_stats()])
+    oftpy_dump_cov()
 
 # Test runners for LTX test cases
 @pytest.mark.coverage


### PR DESCRIPTION
This pull request updates the coverage action workflow to fix issues and add reporting, including:
 - Fix coverage detection for compiled code when using Python wrapper
 - Enable matrix caching in ThinCurr tests and restructure test order to improve speed

Also make the following changes to the core code:
 - Only search for PETSc in configure if path is given
 - Fix comments in UMFPACK CMAKE find script

This pull request **does not** modify any existing APIs or input files.