### PR TITLE
TokaMaker: Increase accessible size of case field in gEQDSK file I/O

### DIFF
--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -1048,7 +1048,7 @@ integer(4), intent(in) :: nr !< Number of radial points for flux/psi grid
 integer(4), intent(in) :: nz !< Number of vertical points for flux grid
 real(8), intent(in) :: rbounds(2) !< Radial extents for flux grid
 real(8), intent(in) :: zbounds(2) !< Radial extents for flux grid
-CHARACTER(LEN=36), intent(in) :: run_info !< Run information string [36]
+CHARACTER(LEN=40), intent(in) :: run_info !< Run information string [40]
 CHARACTER(LEN=OFT_PATH_SLEN), intent(in) :: limiter_file !< Path to limiter file
 REAL(8), intent(in) :: psi_pad !< Padding at LCFS in normalized units
 REAL(8), optional, intent(in) :: rcentr_in !< Padding at LCFS in normalized units
@@ -1072,7 +1072,7 @@ REAL(8), ALLOCATABLE, DIMENSION(:) :: fpol,pres,ffprim,pprime,qpsi
 REAL(8), ALLOCATABLE, DIMENSION(:,:) :: psirz
 !---
 IF(PRESENT(error_str))error_str=""
-WRITE(*,'(2A)')oft_indent,'Saving EQDSK file'
+WRITE(*,'(3A)')oft_indent,'Saving EQDSK file: ',TRIM(filename)
 CALL oft_increase_indent
 !---
 ALLOCATE(fpol(nr),pres(nr),ffprim(nr),pprime(nr),qpsi(nr))
@@ -1241,7 +1241,7 @@ END DO
 !---------------------------------------------------------------------------
 ! Create output file
 !---------------------------------------------------------------------------
-WRITE(eqdsk_case,'(A,X,A)')'TokaMaker: ',run_info
+WRITE(eqdsk_case,'(A,X,A)')'tMaker:',run_info
 rleft = rbounds(1)
 zmid = (zbounds(2)+zbounds(1))/2.d0
 IF(PRESENT(rcentr_in))THEN
@@ -1255,7 +1255,6 @@ itor = itor/mu0
 idum = 0 ! dummy variable
 xdum = 0.d0 ! dummy variable
 ! Read or set limiting contour
-WRITE(*,*)'"',TRIM(limiter_file),'"'
 IF(TRIM(limiter_file)=='none')THEN
   nlim=gseq%nlim_con+1
   ALLOCATE(rlim(nlim),zlim(nlim))
@@ -1268,6 +1267,7 @@ IF(TRIM(limiter_file)=='none')THEN
   ! rlim=[rbounds(1),rbounds(1),rbounds(2),rbounds(2),rbounds(1)]
   ! zlim=[zbounds(1),zbounds(2),zbounds(2),zbounds(1),zbounds(1)]
 ELSE
+  WRITE(*,*)'  Limiter file: "',TRIM(limiter_file),'"'
   OPEN(NEWUNIT=io_unit,FILE=TRIM(limiter_file))
   READ(io_unit,*)nlim
   ALLOCATE(rlim(nlim),zlim(nlim))

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -729,9 +729,7 @@ class TokaMaker():
     def set_targets(self,Ip=None,Ip_ratio=None,pax=None,estore=None,R0=None,V0=None,retain_previous=False):
         r'''! Set global target values
 
-        Once set, values are retained until they are explicitly set to their respective disabled
-        values (see below). By default, all targets are disabled so this function should be called
-        at least once to set "sane" values for `alam` and `pnorm`.
+        @note Values that are not specified are reset to their defaults on each call unless `retain_previous=True`.
 
         @param alam Scale factor for \f$F*F'\f$ term (disabled if `Ip` is set)
         @param pnorm Scale factor for \f$P'\f$ term (disabled if `pax`, `estore`, or `R0` are set)
@@ -765,6 +763,27 @@ class TokaMaker():
         if V0 is not None:
             self._V0_target.value=V0
         tokamaker_set_targets(self._Ip_target,self._Ip_ratio_target,self._pax_target,self._estore_target,self._R0_target,self._V0_target)
+    
+    def get_targets(self):
+        r'''! Get global target values
+
+        @result Dictionary of global target values
+        '''
+        # Get targets
+        target_dict = {}
+        if self._Ip_target.value > 0.0:
+            target_dict['Ip'] = self._Ip_target.value
+        if self._estore_target.value > 0.0:
+            target_dict['estore'] = self._estore_target.value
+        if self._pax_target.value > 0.0:
+            target_dict['pax'] = self._pax_target.value
+        if self._Ip_ratio_target.value > -1.E98:
+            target_dict['Ip_ratio'] = self._Ip_ratio_target.value
+        if self._R0_target.value > 0.0:
+            target_dict['R0'] = self._R0_target.value
+        if self._V0_target.value > -1.E98:
+            target_dict['V0'] = self._V0_target.value
+        return target_dict
 
     def get_delstar_curr(self,psi):
         r'''! Get toroidal current density from \f$ \psi \f$ through \f$ \Delta^{*} \f$ operator

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1278,13 +1278,13 @@ class TokaMaker():
         @param nz Number of vertical sampling points
         @param rbounds Extents of grid in R
         @param zbounds Extents of grid in Z
-        @param run_info Run information for gEQDSK file (maximum of 36 characters)
+        @param run_info Run information for gEQDSK file (maximum of 40 characters)
         @param lcfs_pad Padding in normalized flux at LCFS
-        @param rcentr `RCENTR` value for gEQDSK file (if `None`, magnetic axis is used)
+        @param rcentr `RCENTR` value for gEQDSK file (if `None`, geometric axis is used)
         '''
         cfilename = c_char_p(filename.encode())
-        if len(run_info) > 36:
-            raise ValueError('"run_info" cannot be longer than 36 characters')
+        if len(run_info) > 40:
+            raise ValueError('"run_info" cannot be longer than 40 characters')
         crun_info = c_char_p(run_info.encode())
         if rbounds is None:
             rbounds = numpy.r_[self.lim_contour[:,0].min(), self.lim_contour[:,0].max()]

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -922,7 +922,7 @@ END SUBROUTINE tokamaker_set_coil_vsc
 !------------------------------------------------------------------------------
 SUBROUTINE tokamaker_save_eqdsk(filename,nr,nz,rbounds,zbounds,run_info,psi_pad,rcentr,error_str) BIND(C,NAME="tokamaker_save_eqdsk")
 CHARACTER(KIND=c_char), INTENT(in) :: filename(80) !< Needs docs
-CHARACTER(KIND=c_char), INTENT(in) :: run_info(36) !< Needs docs
+CHARACTER(KIND=c_char), INTENT(in) :: run_info(40) !< Needs docs
 INTEGER(c_int), VALUE, INTENT(in) :: nr !< Needs docs
 INTEGER(c_int), VALUE, INTENT(in) :: nz !< Needs docs
 REAL(c_double), INTENT(in) :: rbounds(2) !< Needs docs

--- a/src/utilities/build_libs.py
+++ b/src/utilities/build_libs.py
@@ -1536,7 +1536,9 @@ UMFPACK_LIB = -L{UMFPACK_LIB} {UMFPACK_LIBS}
             "-DBLAS_ROOT:PATH={BLAS_ROOT}",
             "-DBLA_VENDOR:STRING={BLAS_VENDOR}"
         ]
-        UMFPACK_CMAKE_options = config_CMAKE_options.copy()
+        UMFPACK_CMAKE_options = config_CMAKE_options.copy() + [
+            "-DNCHOLMOD=TRUE"
+        ]
         if (config_dict['CC_VENDOR'] == 'gnu') and (self.config_dict['OS_TYPE'] == 'Darwin'):
             UMFPACK_CMAKE_options.append("-DCMAKE_SHARED_LINKER_FLAGS:STRING=-lgfortran")
         #
@@ -1548,11 +1550,9 @@ UMFPACK_LIB = -L{UMFPACK_LIB} {UMFPACK_LIBS}
         if 'CMAKE_BIN' in self.config_dict:
             build_lines += ["export PATH={0}:$PATH".format(self.config_dict['CMAKE_BIN'])]
         build_lines += [
-            "export FFLAGS=-fPIC",
             "export JOBS={MAKE_THREADS}",
             "export OPTIMIZATION=-O2",
             "export AUTOCC=no",
-            "export UMFPACK_CONFIG=-DNCHOLMOD",
             "make distclean",
             "cd SuiteSparse_config",
             'make library CMAKE_OPTIONS="{0}"'.format(' '.join(config_CMAKE_options)),


### PR DESCRIPTION
This pull request increases the accessible size of case field (`run_info` argument to `TokaMaker.save_eqdsk()`).

This pull request **does not** modify any existing APIs or input files.