### PR TITLE
TokaMaker: Fix behavior of limiters with multiply connected plasma domains

### DIFF
--- a/src/base/oft_base.F90
+++ b/src/base/oft_base.F90
@@ -375,10 +375,17 @@ OPEN(outunit,FILE='abort_'//proc//'.err')
 #endif
 !---Print error information
 100 FORMAT (A,I5,2A)
+101 FORMAT (2A)
 WRITE(outunit,'(A)')'#----------------------------------------------'
-WRITE(outunit,100)  '[',oft_env%rank,'] ERROR: ',TRIM(error_str)
-WRITE(outunit,100)  '[',oft_env%rank,'] SUBROUTINE: ',TRIM(sname)
-WRITE(outunit,100)  '[',oft_env%rank,'] FILE: ',TRIM(fname)
+IF(oft_env%nprocs>1)THEN
+  WRITE(outunit,100)  '[',oft_env%rank,'] ERROR: ',TRIM(error_str)
+  WRITE(outunit,100)  '[',oft_env%rank,'] SUBROUTINE: ',TRIM(sname)
+  WRITE(outunit,100)  '[',oft_env%rank,'] FILE: ',TRIM(fname)
+ELSE
+  WRITE(outunit,101)  'ERROR: ',TRIM(error_str)
+  WRITE(outunit,101)  'SUBROUTINE: ',TRIM(sname)
+  WRITE(outunit,101)  'FILE: ',TRIM(fname)
+END IF
 #ifdef OFT_ABORT_FILES
 CLOSE(outunit)
 #endif
@@ -399,7 +406,12 @@ SUBROUTINE oft_warn(error_str)
 CHARACTER(LEN=*) :: error_str
 !---Print warning information
 100 FORMAT (A,I5,2A)
-WRITE(error_unit,100)'[',oft_env%rank,'] WARNING: ',TRIM(error_str)
+101 FORMAT (2A)
+IF(oft_env%nprocs>1)THEN
+  WRITE(error_unit,100)'[',oft_env%rank,'] WARNING: ',TRIM(error_str)
+ELSE
+  WRITE(error_unit,101)'WARNING: ',TRIM(error_str)
+END IF
 END SUBROUTINE oft_warn
 !---------------------------------------------------------------------------
 !> Output control for performance messages
@@ -1051,8 +1063,13 @@ WRITE(outunit,'(A)')  ''
 WRITE(outunit,'(A)')  'Stacktrace'
 WRITE(outunit,'(A)')  '#----------------------------------------------'
 100 FORMAT (A,I5,A,2X,I2,2X,A60)
+101 FORMAT (2X,I2,2X,A60)
 DO i=nstack,1,-1
-  WRITE(outunit,100)  '[',oft_env%rank,']',i,ADJUSTR(TRIM(stack_mods(stack(1,i)))//"::"//TRIM(stack_funs(stack(2,i))))
+  IF(oft_env%nprocs>0)THEN
+    WRITE(outunit,100)  '[',oft_env%rank,']',i,ADJUSTR(TRIM(stack_mods(stack(1,i)))//"::"//TRIM(stack_funs(stack(2,i))))
+  ELSE
+    WRITE(outunit,101)  i,ADJUSTR(TRIM(stack_mods(stack(1,i)))//"::"//TRIM(stack_funs(stack(2,i))))
+  END IF
 END DO
 WRITE(outunit,'(A)')  ''
 #ifdef OFT_ABORT_FILES

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1100,7 +1100,8 @@ class TokaMaker():
             ax.tricontourf(self.r[:,0], self.r[:,1], self.lc[mask_tmp,:], mask_vals, colors=cond_color, alpha=1)
         # Show limiter
         if limiter_color and (self.lim_contour is not None):
-            ax.plot(self.lim_contour[:,0],self.lim_contour[:,1],color=limiter_color)
+            for lim_contour in self.lim_contours:
+                ax.plot(lim_contour[:,0],lim_contour[:,1],color=limiter_color)
         # Make 1:1 aspect ratio
         ax.set_aspect('equal','box')
         return colorbar

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -356,8 +356,19 @@ class TokaMaker():
         # Get limiter contour
         npts = c_int()
         r_loc = c_double_ptr()
-        tokamaker_get_limiter(ctypes.byref(npts),ctypes.byref(r_loc))
-        self.lim_contour = numpy.ctypeslib.as_array(r_loc,shape=(npts.value, 2))
+        nloops = c_int()
+        loop_ptr = c_int_ptr()
+        tokamaker_get_limiter(ctypes.byref(npts),ctypes.byref(r_loc),ctypes.byref(nloops),ctypes.byref(loop_ptr))
+        loop_ptr = numpy.ctypeslib.as_array(loop_ptr,shape=(nloops.value+1,))
+        self.lim_pts = numpy.ctypeslib.as_array(r_loc,shape=(npts.value, 2))
+        self.lim_contours = []
+        for i in range(nloops.value):
+            lim_contour = numpy.vstack((self.lim_pts[loop_ptr[i]-1:loop_ptr[i+1]-1,:],self.lim_pts[loop_ptr[i]-1,:]))
+            self.lim_contours.append(lim_contour)
+        self.lim_contour = numpy.zeros((0,2))
+        for lim_countour in self.lim_contours:
+            if lim_countour.shape[0] > self.lim_contour.shape[0]:
+                self.lim_contour = lim_countour
         # Get plotting mesh
         np_loc = c_int()
         nc_loc = c_int()

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -196,7 +196,7 @@ tokamaker_get_vfixed = ctypes_subroutine(oftpy_lib.tokamaker_get_vfixed, #(npts,
     [c_int_ptr, c_double_ptr_ptr, c_double_ptr_ptr])
 
 tokamaker_get_limiter = ctypes_subroutine(oftpy_lib.tokamaker_get_limiter, #(np,r_loc)
-    [c_int_ptr,c_double_ptr_ptr])
+    [c_int_ptr,c_double_ptr_ptr,c_int_ptr,c_int_ptr_ptr])
 
 tokamaker_save_eqdsk = ctypes_subroutine(oftpy_lib.tokamaker_save_eqdsk, #(filename,nr,nz,rbounds,zbounds,run_info,psi_pad,rcentr,error_str)
     [c_char_p, c_int, c_int, ctypes_numpy_array(numpy.float64,1), ctypes_numpy_array(numpy.float64,1), c_char_p, c_double, c_double, c_char_p])

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -433,18 +433,21 @@ END SUBROUTINE tokamaker_get_mesh
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-SUBROUTINE tokamaker_get_limiter(np,r_loc) BIND(C,NAME="tokamaker_get_limiter")
+SUBROUTINE tokamaker_get_limiter(np,r_loc,nloops,loop_ptr) BIND(C,NAME="tokamaker_get_limiter")
 TYPE(c_ptr), INTENT(out) :: r_loc !< Needs docs
+TYPE(c_ptr), INTENT(out) :: loop_ptr !< Needs docs
 INTEGER(c_int), INTENT(out) :: np !< Needs docs
+INTEGER(c_int), INTENT(out) :: nloops !< Needs docs
 INTEGER(4) :: i
 REAL(8), POINTER, DIMENSION(:,:) :: r_tmp
-np=gs_global%nlim_con+1
-ALLOCATE(r_tmp(2,gs_global%nlim_con+1))
+np=gs_global%nlim_con
+ALLOCATE(r_tmp(2,gs_global%nlim_con))
 r_loc=C_LOC(r_tmp)
 DO i=1,gs_global%nlim_con
   r_tmp(:,i)=smesh%r(1:2,gs_global%lim_con(i))
 END DO
-r_tmp(:,gs_global%nlim_con+1)=smesh%r(1:2,gs_global%lim_con(1))
+nloops=gs_global%lim_nloops
+loop_ptr=C_LOC(gs_global%lim_ptr)
 END SUBROUTINE tokamaker_get_limiter
 !------------------------------------------------------------------------------
 !> Needs docs


### PR DESCRIPTION
This pull request fixes the behavior of limiters with multiply connected plasma domains by locating all boundary loops of the plasma domain and tracking them (fixes #91).

**Note:** Only a single loop is supported in gEQDSK output so the longest loop with be used when calling `read_eqdsk()` and a warning will be printed.

Additionally, the following changes to core code were made:
 - Remove processor ID number for debug/error information in single processor runs

This pull request **does not** modify any APIs or input files.