### PR TITLE
TokaMaker: Add support for general current source terms in `vac_solve` and `init_psi`

### DIFF
--- a/src/grid/mesh_type.F90
+++ b/src/grid/mesh_type.F90
@@ -672,8 +672,6 @@ LOGICAL, PARAMETER :: PLOT_R4_FLAG=.TRUE.
 #endif
 CONTAINS
 !------------------------------------------------------------------------------
-! FUNCTION: cell_is_curved
-!------------------------------------------------------------------------------
 !> Checks if a global mesh cell is curved or not
 !!
 !! @param[in] self Mesh containing cell
@@ -681,7 +679,7 @@ CONTAINS
 !! @result (T/F) cell is curved?
 !------------------------------------------------------------------------------
 function cell_is_curved(self,cell) result(curved)
-class(oft_mesh), intent(in) :: self
+class(oft_amesh), intent(in) :: self
 integer(i4), intent(in) :: cell
 integer(i4) :: k,i
 logical :: curved

--- a/src/physics/diagnostic.F90
+++ b/src/physics/diagnostic.F90
@@ -651,7 +651,7 @@ DEBUG_STACK_PUSH
 !---Setup
 CALL smesh%quad_rule(quad_order,quad)
 energy=0.d0
-!$omp parallel do default(firstprivate) shared(field,quad) reduction(+:energy)
+!$omp parallel do default(firstprivate) shared(field,quad,reg_mask) reduction(+:energy)
 do i=1,smesh%nc
   IF(PRESENT(reg_mask))THEN
     IF(smesh%reg(i)/=reg_mask)CYCLE

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -471,7 +471,7 @@ class TokaMaker():
         coil_gains = numpy.ascontiguousarray(coil_gains, dtype=numpy.float64)
         tokamaker_set_coil_vsc(coil_gains)
 
-    def init_psi(self, r0=-1.0, z0=0.0, a=0.0, kappa=0.0, delta=0.0):
+    def init_psi(self, r0=-1.0, z0=0.0, a=0.0, kappa=0.0, delta=0.0, curr_source=None):
         r'''! Initialize \f$\psi\f$ using uniform current distributions
 
         If r0>0 then a uniform current density inside a surface bounded by
@@ -483,9 +483,16 @@ class TokaMaker():
         @param a Minor radius for flux surface-based approach
         @param kappa Elongation for flux surface-based approach
         @param delta Triangularity for flux surface-based approach
+        @param curr_source Current source for arbitrary current distribution
         '''
+        curr_ptr = None
+        if curr_source is not None:
+            if curr_source.shape[0] != self.np:
+                raise IndexError('Incorrect shape of "curr_source", should be [np]')
+            curr_source = numpy.ascontiguousarray(curr_source, dtype=numpy.float64)
+            curr_ptr = curr_source.ctypes.data_as(c_double_ptr)
         error_flag = c_int()
-        tokamaker_init_psi(c_double(r0),c_double(z0),c_double(a),c_double(kappa),c_double(delta),ctypes.byref(error_flag))
+        tokamaker_init_psi(c_double(r0),c_double(z0),c_double(a),c_double(kappa),c_double(delta),curr_ptr,ctypes.byref(error_flag))
         return error_flag.value
 
     def load_profiles(self, f_file='f_prof.in', foffset=None, p_file='p_prof.in', eta_file='eta_prof.in', f_NI_file='f_NI_prof.in'):
@@ -554,10 +561,12 @@ class TokaMaker():
         tokamaker_solve(ctypes.byref(error_flag))
         return error_flag.value
     
-    def vac_solve(self,psi=None):
+    def vac_solve(self,psi=None,rhs_source=None):
         '''! Solve for vacuum solution (no plasma), with present coil currents
+        and optional other currents
         
         @param psi Boundary values for vacuum solve
+        @param rhs_source Current source (optional)
         '''
         if psi is None:
             psi = numpy.zeros((self.np,),dtype=numpy.float64)
@@ -565,8 +574,14 @@ class TokaMaker():
             if psi.shape[0] != self.np:
                 raise IndexError('Incorrect shape of "psi", should be [np]')
             psi = numpy.ascontiguousarray(psi, dtype=numpy.float64)
+        rhs_ptr = None
+        if rhs_source is not None:
+            if rhs_source.shape[0] != self.np:
+                raise IndexError('Incorrect shape of "rhs_source", should be [np]')
+            rhs_source = numpy.ascontiguousarray(rhs_source, dtype=numpy.float64)
+            rhs_ptr = rhs_source.ctypes.data_as(c_double_ptr)
         error_flag = c_int()
-        tokamaker_vac_solve(psi,ctypes.byref(error_flag))
+        tokamaker_vac_solve(psi,rhs_ptr,ctypes.byref(error_flag))
         return psi, error_flag.value
 
     def get_stats(self,lcfs_pad=0.01,li_normalization='std',geom_type='max'):

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -58,9 +58,9 @@ tokamaker_reset = ctypes_subroutine(oftpy_lib.tokamaker_reset,
 tokamaker_set_settings = ctypes_subroutine(oftpy_lib.tokamaker_set_settings,
     [ctypes.POINTER(tokamaker_settings_struct)])
 
-# G-S init function (r0,z0,a,kappa,delta)
+# tokamaker_init_psi(r0,z0,a,kappa,delta,rhs_source,ierr)
 tokamaker_init_psi = ctypes_subroutine(oftpy_lib.tokamaker_init_psi,
-    [c_double, c_double, c_double, c_double, c_double, c_int_ptr])
+    [c_double, c_double, c_double, c_double, c_double, c_double_ptr, c_int_ptr])
 
 # G-S load flux functions (f_file,f_offset,p_file)
 tokamaker_load_profiles = ctypes_subroutine(oftpy_lib.tokamaker_load_profiles,
@@ -70,10 +70,9 @@ tokamaker_load_profiles = ctypes_subroutine(oftpy_lib.tokamaker_load_profiles,
 tokamaker_solve = ctypes_subroutine(oftpy_lib.tokamaker_solve, 
     [c_int_ptr])
 
-# tokamaker_vac_solve(psi_in,error_flag)
+# tokamaker_vac_solve(psi_in,rhs_source,error_flag)
 tokamaker_vac_solve = ctypes_subroutine(oftpy_lib.tokamaker_vac_solve, 
-    [ctypes_numpy_array(float64,1),  c_int_ptr])
-
+    [ctypes_numpy_array(float64,1), c_double_ptr,  c_int_ptr])
 
 # G-S info function
 tokamaker_analyze = ctypes_subroutine(oftpy_lib.tokamaker_analyze)


### PR DESCRIPTION
This pull request adds support for specifying general current source terms in `vac_solve()` and `init_psi()`.

Additionally, the following changes were also made.
 - TokaMaker: Respect cell curvature (always linear for now) in G-S integrals
 - Fix OpenMP bug in `bscal_surf_int`
 
This pull request **does not** introduce breaking changes with any existing APIs or input files. This pull request **does** add new arguments to `OpenFUSIONToolkit.TokaMaker.TokaMaker.vac_solve()` and `OpenFUSIONToolkit.TokaMaker.TokaMaker.init_psi()`.