### PR TITLE
TokaMaker: Sort eigenvalues to ensure proper ordering in `eig_wall()` and `eig_td()`

### DIFF
--- a/src/physics/grad_shaf_td.F90
+++ b/src/physics/grad_shaf_td.F90
@@ -338,8 +338,10 @@ CLASS(oft_vector), POINTER :: eig_vec
 TYPE(oft_lusolver), TARGET :: adv_pre
 TYPE(oft_iram_eigsolver) :: arsolver
 TYPE(eig_wrapper), TARGET :: wrap_mat
-REAL(8) :: lam0
 INTEGER(4) :: i,j
+INTEGER(4), ALLOCATABLE, DIMENSION(:) :: sort_tmp
+REAL(8) :: lam0
+REAL(8), ALLOCATABLE, DIMENSION(:) :: eig_tmp
 type(oft_tmaker_td_mfop) :: eig_mfop !< NL operator object
 !
 CALL eig_mfop%setup(eq_in)
@@ -360,10 +362,24 @@ arsolver%which='LM'
 CALL oft_blagrange%vec_create(eig_vec)
 CALL arsolver%apply(eig_vec,lam0)
 
-DO i=1,neigs
-    eigs(:,i)=1.d0/arsolver%eig_val(:,i)+omega
-    eig_vecs(:,i)=arsolver%eig_vec(:,i)
-END DO
+IF(arsolver%info>=0)THEN
+  !---Sort eigenvalues
+  ALLOCATE(sort_tmp(arsolver%nev),eig_tmp(arsolver%nev))
+  eig_tmp=ABS(1.d0/arsolver%eig_val(1,1:arsolver%nev)+omega)
+  sort_tmp=[(i,i=1,arsolver%nev)]
+  CALL sort_array(eig_tmp,sort_tmp,arsolver%nev)
+  DEALLOCATE(eig_tmp)
+  !---Copy output
+  DO i=1,neigs
+    j = sort_tmp(i)
+    eigs(:,i)=1.d0/arsolver%eig_val(:,j)+omega
+    eig_vecs(:,i)=arsolver%eig_vec(:,j)
+  END DO
+  DEALLOCATE(sort_tmp)
+ELSE
+    eigs=-1.d99
+    eig_vecs=0.d0
+END IF
 
 !---Cleanup
 CALL adv_pre%delete

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1372,6 +1372,8 @@ class TokaMaker():
         eig_vals = numpy.zeros((neigs,2),dtype=numpy.float64)
         eig_vecs = numpy.zeros((neigs,self.np),dtype=numpy.float64)
         tokamaker_eig_wall(c_int(neigs),eig_vals,eig_vecs,pm)
+        if (eig_vals[0,0] < -1.E98) and (eig_vals[0,1] < -1.E98):
+            raise ValueError("Error in eigenvalue solve")
         return eig_vals, eig_vecs
 
     def eig_td(self,omega=-1.E4,neigs=4,include_bounds=True,pm=False):
@@ -1386,6 +1388,8 @@ class TokaMaker():
         eig_vals = numpy.zeros((neigs,2),dtype=numpy.float64)
         eig_vecs = numpy.zeros((neigs,self.np),dtype=numpy.float64)
         tokamaker_eig_td(c_double(omega),c_int(neigs),eig_vals,eig_vecs,c_bool(include_bounds),pm)
+        if (eig_vals[0,0] < -1.E98) and (eig_vals[0,1] < -1.E98):
+            raise ValueError("Error in eigenvalue solve")
         return eig_vals, eig_vecs
 
     def setup_td(self,dt,lin_tol,nl_tol,pre_plasma=False):


### PR DESCRIPTION
This pull request adds sorting to the result of eigenvalue solves within `eig_wall()` and `eig_td()` to ensure proper ordering of results. Additionally, checks were added to catch and report failure of the eigenvalue solver in these subroutines, which may produce erroneous results.

This pull request **does not** modify any existing APIs or input files.