### PR TITLE
Fix CD build following addition of oneAPI binary

### DIFF
--- a/.github/workflows/cd_nightly.yaml
+++ b/.github/workflows/cd_nightly.yaml
@@ -68,7 +68,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: libs
-        key: ${{ matrix.config.os }}-nightly-${{ hashFiles('src/utilities/build_libs.py') }}
+        key: ${{ matrix.config.os }}-${{ matrix.config.cc }}-nightly-${{ hashFiles('src/utilities/build_libs.py') }}
 
     - name: Get OS version (Linux)
       if: startsWith(matrix.config.os, 'ubuntu')

--- a/.github/workflows/cd_nightly.yaml
+++ b/.github/workflows/cd_nightly.yaml
@@ -25,14 +25,16 @@ jobs:
             os: ubuntu-22.04,
             cc: "gcc-12",cxx: "g++-12", fc: "gfortran-12",
             python: "python3",
-            build_libs_flags: "--build_umfpack=1 --oblas_dynamic_arch"
+            build_libs_flags: "--build_umfpack=1 --oblas_dynamic_arch",
+            cache_key: "openmp"
           }
         - {
             name: "Linux-x86_64-Intel",
             os: ubuntu-22.04,
             cc: "icx",cxx: "icx", fc: "ifx",
             python: "python3",
-            build_libs_flags: "--use_mkl --mkl_root=$MKLROOT"
+            build_libs_flags: "--use_mkl --mkl_root=$MKLROOT",
+            cache_key: "openmp"
           }
         - {
             name: "macOS-x86_64",
@@ -40,7 +42,8 @@ jobs:
             cc: "gcc-12", cxx: "g++-12", fc: "gfortran-12",
             python: "python3.12",
             xcode_path: "/Applications/Xcode_14.2.app/Contents/Developer",
-            build_libs_flags: "--build_umfpack=1"
+            build_libs_flags: "--build_umfpack=1",
+            cache_key: "openmp"
           }
         - {
             name: "macOS-x86_64-Rosetta",
@@ -48,7 +51,8 @@ jobs:
             cc: "gcc-12", cxx: "g++-12", fc: "gfortran-12",
             python: "python3.12",
             xcode_path: "/Applications/Xcode_14.2.app/Contents/Developer",
-            build_libs_flags: "--build_umfpack=1 --oblas_no_avx"
+            build_libs_flags: "--build_umfpack=1 --oblas_no_avx",
+            cache_key: "openmp_noavx"
           }
         - {
             name: "macOS-arm64",
@@ -56,7 +60,8 @@ jobs:
             cc: "gcc-13", cxx: "g++-13", fc: "gfortran-13",
             python: "python3.12",
             xcode_path: "/Applications/Xcode_15.4.app/Contents/Developer",
-            build_libs_flags: "--build_umfpack=1"
+            build_libs_flags: "--build_umfpack=1",
+            cache_key: "openmp"
         }
 
     steps:
@@ -68,7 +73,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: libs
-        key: ${{ matrix.config.os }}-${{ matrix.config.cc }}-nightly-${{ hashFiles('src/utilities/build_libs.py') }}
+        key: ${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.cache_key }}-${{ hashFiles('src/utilities/build_libs.py') }}
 
     - name: Get OS version (Linux)
       if: startsWith(matrix.config.os, 'ubuntu')

--- a/.github/workflows/ci_build.yaml
+++ b/.github/workflows/ci_build.yaml
@@ -26,29 +26,23 @@ jobs:
         - {
             name: "Ubuntu 22.04 GCC 12",
             os: ubuntu-22.04,
-            cc: "gcc-12",
-            cxx: "g++-12",
-            fc: "gfortran-12",
+            cc: "gcc-12", cxx: "g++-12", fc: "gfortran-12",
             python: "python3",
-            build_flags: "--ref_blas --build_umfpack=1 --build_superlu=1",
-            mpi_build_flags: "--ref_blas --build_umfpack=1 --build_superlu=1 --build_superlu_dist=1"
+            build_flags: "--oblas_dynamic_arch --build_umfpack=1 --build_superlu=1",
+            mpi_build_flags: "--oblas_dynamic_arch --build_umfpack=1 --build_superlu=1 --build_superlu_dist=1"
           }
         - {
             name: "Ubuntu 24.04 GCC 14",
             os: ubuntu-24.04,
-            cc: "gcc-14",
-            cxx: "g++-14",
-            fc: "gfortran-14",
+            cc: "gcc-14", cxx: "g++-14", fc: "gfortran-14",
             python: "python3",
-            build_flags: "--ref_blas --build_umfpack=1 --build_superlu=1",
-            mpi_build_flags: "--ref_blas --build_umfpack=1 --build_superlu=1 --build_superlu_dist=1"
+            build_flags: "--oblas_dynamic_arch --build_umfpack=1 --build_superlu=1",
+            mpi_build_flags: "--oblas_dynamic_arch --build_umfpack=1 --build_superlu=1 --build_superlu_dist=1"
           }
         - {
             name: "Ubuntu 24.04 Intel",
             os: ubuntu-24.04,
-            cc: "icx",
-            cxx: "icx",
-            fc: "ifx",
+            cc: "icx", cxx: "icx", fc: "ifx",
             python: "python3",
             build_flags: "--use_mkl --mkl_root=$MKLROOT",
             mpi_build_flags: "--use_mkl --mkl_root=$MKLROOT"
@@ -56,23 +50,19 @@ jobs:
         - {
             name: "macOS Ventura GCC 12",
             os: macos-13,
-            cc: "gcc-12",
-            cxx: "g++-12",
-            fc: "gfortran-12",
+            cc: "gcc-12", cxx: "g++-12", fc: "gfortran-12",
             python: "python3.12",
-            build_flags: "--ref_blas --build_umfpack=1 --build_superlu=1",
-            mpi_build_flags: "--ref_blas --build_umfpack=1 --build_superlu=1 --build_superlu_dist=1",
+            build_flags: "--build_umfpack=1 --build_superlu=1",
+            mpi_build_flags: "--build_umfpack=1 --build_superlu=1 --build_superlu_dist=1",
             xcode_path: "/Applications/Xcode_14.2.app/Contents/Developer"
           }
         - {
             name: "macOS Sonoma GCC 13",
             os: macos-14,
-            cc: "gcc-13",
-            cxx: "g++-13",
-            fc: "gfortran-13",
+            cc: "gcc-13", cxx: "g++-13", fc: "gfortran-13",
             python: "python3.12",
-            build_flags: "--ref_blas --build_umfpack=1 --build_superlu=1",
-            mpi_build_flags: "--ref_blas --build_umfpack=1 --build_superlu=1 --build_superlu_dist=1",
+            build_flags: "--build_umfpack=1 --build_superlu=1",
+            mpi_build_flags: "--build_umfpack=1 --build_superlu=1 --build_superlu_dist=1",
             xcode_path: "/Applications/Xcode_15.4.app/Contents/Developer"
           }
         exclude:
@@ -138,7 +128,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: libs
-        key: ${{ matrix.config.os }}-build-${{ matrix.parallel }}-${{ matrix.config.cc }}-${{ hashFiles('src/utilities/build_libs.py') }}
+        key: ${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.parallel }}-${{ hashFiles('src/utilities/build_libs.py') }}
 
     - name: Create build dir
       if: ${{ steps.cache-ext-libs.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
This pull request fixes the CD build, following addition of an Intel oneAPI binary in b3242e5.

Additionally, this pull request adjust the CI/CD builds to share common GitHub action caches when possible.

This pull request **does not** modify any existing APIs or input files.