### PR TITLE
TokaMaker: Fix plasma resistivity handling for vloop, fixes #129

### DIFF
--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -695,6 +695,7 @@ real(8) :: psitmp(1) !< magnetic flux coordinate
 real(8) :: gpsitmp(3) !< needs docs
 integer(4) :: i,m
 !---
+CALL self%eta%update(self) ! Make sure eta is up to date with current equilibrium
 psi_eval%u=>self%psi
 CALL psi_eval%setup
 CALL psi_geval%shared_setup(psi_eval)


### PR DESCRIPTION
This pull request fixes a bug where the plasma resistivity profile was not being evaluated properly, leading to invalid results from `OpenFUSIONToolkit.TokaMaker.TokaMaker.calc_loopvoltage()` and `gs_calc_vloop`.

This pull request **does not** modify any existing APIs or input files.