### PR TITLE
TokaMaker: Add optional damping term for linear calculations to limit maximum growth rate

### DIFF
--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1428,18 +1428,20 @@ class TokaMaker():
             raise ValueError("Error in eigenvalue solve")
         return eig_vals, eig_vecs
 
-    def eig_td(self,omega=-1.E4,neigs=4,include_bounds=True,pm=False):
+    def eig_td(self,omega=-1.E4,neigs=4,include_bounds=True,pm=False,damping_scale=-1.0):
         '''! Compute eigenvalues for the linearized time-dependent system
 
         @param omega Growth rate localization point (eigenvalues closest to this value will be found)
         @param neigs Number of eigenvalues to compute
         @param include_bounds Include bounding flux terms for constant normalized profiles?
         @param pm Print solver statistics and raw eigenvalues?
+        @param damping_scale Scale factor for damping term to artificially limit growth rate (negative to disable)?
         @result eigenvalues[neigs], eigenvectors[neigs,:]
         '''
         eig_vals = numpy.zeros((neigs,2),dtype=numpy.float64)
         eig_vecs = numpy.zeros((neigs,self.np),dtype=numpy.float64)
-        tokamaker_eig_td(c_double(omega),c_int(neigs),eig_vals,eig_vecs,c_bool(include_bounds),pm)
+        damp_coeff = abs(omega)*damping_scale
+        tokamaker_eig_td(c_double(omega),c_int(neigs),eig_vals,eig_vecs,c_bool(include_bounds),c_double(damp_coeff),pm)
         if (eig_vals[0,0] < -1.E98) and (eig_vals[0,1] < -1.E98):
             raise ValueError("Error in eigenvalue solve")
         return eig_vals, eig_vecs

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -83,7 +83,7 @@ tokamaker_setup_td = ctypes_subroutine(oftpy_lib.tokamaker_setup_td,
 
 # G-S time-dependent run function
 tokamaker_eig_td = ctypes_subroutine(oftpy_lib.tokamaker_eig_td,
-    [c_double, c_int, ctypes_numpy_array(numpy.float64,2), ctypes_numpy_array(numpy.float64,2), c_bool, c_bool])
+    [c_double, c_int, ctypes_numpy_array(numpy.float64,2), ctypes_numpy_array(numpy.float64,2), c_bool, c_double, c_bool])
 
 # G-S time-dependent run function
 tokamaker_step_td = ctypes_subroutine(oftpy_lib.tokamaker_step_td,

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -395,19 +395,20 @@ END SUBROUTINE tokamaker_setup_td
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-SUBROUTINE tokamaker_eig_td(omega,neigs,eigs,eig_vecs,include_bounds,pm) BIND(C,NAME="tokamaker_eig_td")
+SUBROUTINE tokamaker_eig_td(omega,neigs,eigs,eig_vecs,include_bounds,eta_plasma,pm) BIND(C,NAME="tokamaker_eig_td")
 REAL(c_double), VALUE, INTENT(in) :: omega !< Needs docs
 INTEGER(c_int), VALUE, INTENT(in) :: neigs !< Needs docs
 TYPE(c_ptr), VALUE, INTENT(in) :: eigs !< Needs docs
 TYPE(c_ptr), VALUE, INTENT(in) :: eig_vecs !< Needs docs
 LOGICAL(c_bool), VALUE, INTENT(in) :: include_bounds !< Needs docs
+REAL(c_double), VALUE, INTENT(in) :: eta_plasma !< Needs docs
 LOGICAL(c_bool), VALUE, INTENT(in) :: pm !< Needs docs
 REAL(8), POINTER :: eigs_tmp(:,:),eig_vecs_tmp(:,:)
 LOGICAL :: pm_save
 CALL c_f_pointer(eigs, eigs_tmp, [2,neigs])
 CALL c_f_pointer(eig_vecs, eig_vecs_tmp, [gs_global%psi%n,neigs])
 pm_save=oft_env%pm; oft_env%pm=pm
-CALL eig_gs_td(gs_global,neigs,eigs_tmp,eig_vecs_tmp,omega,LOGICAL(include_bounds))
+CALL eig_gs_td(gs_global,neigs,eigs_tmp,eig_vecs_tmp,omega,LOGICAL(include_bounds),eta_plasma)
 oft_env%pm=pm_save
 END SUBROUTINE tokamaker_eig_td
 !------------------------------------------------------------------------------
@@ -426,7 +427,7 @@ CALL c_f_pointer(eig_vecs, eig_vecs_tmp, [gs_global%psi%n,neigs])
 alam_save=gs_global%alam; gs_global%alam=0.d0
 pnorm_save=gs_global%pnorm; gs_global%pnorm=0.d0
 pm_save=oft_env%pm; oft_env%pm=pm
-CALL eig_gs_td(gs_global,neigs,eigs_tmp,eig_vecs_tmp,0.d0,.FALSE.)
+CALL eig_gs_td(gs_global,neigs,eigs_tmp,eig_vecs_tmp,0.d0,.FALSE.,-1.d0)
 oft_env%pm=pm_save
 gs_global%alam=alam_save
 gs_global%pnorm=pnorm_save


### PR DESCRIPTION
This pull request adds an optional damping term for linear calculations, designed to limit maximum growth rate and avoid or easily check cases that are erroneously identified as stable due to ideal-wall instability. Damping is applied by introducing a uniform resistivity (equal to `damping_scale*abs(omega)`) across the plasma region in the linearized operator.

This pull request **does not** introduce breaking changes for any existing APIs or input files.