### PR TITLE
TokMaker: Add support for specifying a non-zero LCFS pressure in EQDSK output

### DIFF
--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -1042,7 +1042,7 @@ end subroutine gs_save_decon
 !---------------------------------------------------------------------------
 !> Save equilibrium to General Atomics gEQDSK file
 !---------------------------------------------------------------------------
-subroutine gs_save_eqdsk(gseq,filename,nr,nz,rbounds,zbounds,run_info,limiter_file,psi_pad,rcentr_in,trunc_eq,error_str)
+subroutine gs_save_eqdsk(gseq,filename,nr,nz,rbounds,zbounds,run_info,limiter_file,psi_pad,rcentr_in,trunc_eq,lcfs_press,error_str)
 class(gs_eq), intent(inout) :: gseq !< Equilibrium to save
 CHARACTER(LEN=OFT_PATH_SLEN), intent(in) :: filename 
 integer(4), intent(in) :: nr !< Number of radial points for flux/psi grid
@@ -1054,6 +1054,7 @@ CHARACTER(LEN=OFT_PATH_SLEN), intent(in) :: limiter_file !< Path to limiter file
 REAL(8), intent(in) :: psi_pad !< Padding at LCFS in normalized units
 REAL(8), optional, intent(in) :: rcentr_in !< Value to use for RCENTR (otherwise geometric center is used)
 LOGICAL, OPTIONAL, INTENT(in) :: trunc_eq !< Truncate equilibrium at psi_pad
+REAL(8), optional, intent(in) :: lcfs_press !< LCFS pressure
 CHARACTER(LEN=OFT_ERROR_SLEN), OPTIONAL, INTENT(out) :: error_str
 !
 real(8) :: psi_surf,rmax,x1,x2,raxis,zaxis,xr,psi_trace
@@ -1229,6 +1230,7 @@ IF(PRESENT(error_str))THEN
     RETURN
   END IF
 END IF
+IF(PRESENT(lcfs_press))pres=pres+lcfs_press
 !---Extrapolate q on axis
 f(1) = x2
 f(2) = x2 - xr*(1.d0/REAL(nr-1,8))

--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -929,7 +929,7 @@ do j=1,npsi-1
   END IF
   pt=pt_last
   !$omp critical
-  CALL gs_psi2r(gseq,psi_surf(1),pt)
+  CALL gs_psi2r(gseq,psi_surf(1),pt,psi_int=psi_int)
   !$omp end critical
   CALL tracinginv_fs(pt,ptout)
   pt_last=pt
@@ -979,6 +979,7 @@ end do
 CALL active_tracer%delete
 DEALLOCATE(ptout)
 !$omp end parallel
+CALL psi_int%delete()
 IF(PRESENT(error_str))THEN
   IF(error_str/="")THEN
     DEALLOCATE(cout,rout,zout)
@@ -1150,7 +1151,7 @@ do j=1,nr
   IF(j>1)THEN
     pt=pt_last
     !$omp critical
-    CALL gs_psi2r(gseq,psi_trace,pt)
+    CALL gs_psi2r(gseq,psi_trace,pt,psi_int=psi_int)
     !$omp end critical
     IF(j==nr)THEN
       ALLOCATE(ptout(3,active_tracer%maxsteps+1))
@@ -1260,6 +1261,7 @@ DO i=1,nr
     psirz(i,j)=psi_tmp(1)
   END DO
 END DO
+CALL psi_int%delete()
 !---------------------------------------------------------------------------
 ! Create output file
 !---------------------------------------------------------------------------
@@ -1465,7 +1467,7 @@ do j=1,nr
   !
   pt=pt_last
   ! !$omp critical
-  CALL gs_psi2r(gseq,psi_surf,pt)
+  CALL gs_psi2r(gseq,psi_surf,pt,psi_int=psi_int)
   ! !$omp end critical
   IF(gseq%mode==0)THEN
     field%f_surf=gseq%alam*gseq%I%f(psi_surf)+gseq%I%f_offset
@@ -1506,5 +1508,6 @@ CALL field%delete
 CALL active_tracer%delete
 DEALLOCATE(ptout)
 ! !$omp end parallel
+CALL psi_int%delete()
 end subroutine sauter_fc
 END MODULE oft_gs_util

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1380,7 +1380,7 @@ class TokaMaker():
         return numpy.ctypeslib.as_array(pts_loc,shape=(npts.value, 2)), \
             numpy.ctypeslib.as_array(flux_loc,shape=(npts.value,))
 
-    def save_eqdsk(self,filename,nr=65,nz=65,rbounds=None,zbounds=None,run_info='',lcfs_pad=0.01,rcentr=None,truncate_eq=True,limiter_file=''):
+    def save_eqdsk(self,filename,nr=65,nz=65,rbounds=None,zbounds=None,run_info='',lcfs_pad=0.01,rcentr=None,truncate_eq=True,limiter_file='',lcfs_pressure=0.0):
         r'''! Save current equilibrium to gEQDSK format
 
         @param filename Filename to save equilibrium to
@@ -1393,6 +1393,7 @@ class TokaMaker():
         @param rcentr `RCENTR` value for gEQDSK file (if `None`, geometric axis is used)
         @param truncate_eq Truncate equilibrium at `lcfs_pad`, if `False` \f$ q(\hat{\psi} > 1-pad) = q(1-pad) \f$
         @param limiter_file File containing limiter contour to use instead of TokaMaker limiter
+        @param lcfs_pressure Plasma pressure on the LCFS (zero by default)
         '''
         cfilename = self._oft_env.path2c(filename)
         lim_filename = self._oft_env.path2c(limiter_file)
@@ -1410,7 +1411,7 @@ class TokaMaker():
         if rcentr is None:
             rcentr = -1.0
         error_string = self._oft_env.get_c_errorbuff()
-        tokamaker_save_eqdsk(cfilename,c_int(nr),c_int(nz),rbounds,zbounds,crun_info,c_double(lcfs_pad),c_double(rcentr),c_bool(truncate_eq),lim_filename,error_string)
+        tokamaker_save_eqdsk(cfilename,c_int(nr),c_int(nz),rbounds,zbounds,crun_info,c_double(lcfs_pad),c_double(rcentr),c_bool(truncate_eq),lim_filename,lcfs_pressure,error_string)
         if error_string.value != b'':
             raise Exception(error_string.value)
 

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -201,8 +201,9 @@ tokamaker_get_vfixed = ctypes_subroutine(oftpy_lib.tokamaker_get_vfixed, #(npts,
 tokamaker_get_limiter = ctypes_subroutine(oftpy_lib.tokamaker_get_limiter, #(np,r_loc)
     [c_int_ptr,c_double_ptr_ptr,c_int_ptr,c_int_ptr_ptr])
 
-tokamaker_save_eqdsk = ctypes_subroutine(oftpy_lib.tokamaker_save_eqdsk, #(filename,nr,nz,rbounds,zbounds,run_info,psi_pad,rcentr,error_str)
-    [c_char_p, c_int, c_int, ctypes_numpy_array(numpy.float64,1), ctypes_numpy_array(numpy.float64,1), c_char_p, c_double, c_double, c_bool, c_char_p, c_char_p])
+tokamaker_save_eqdsk = ctypes_subroutine(oftpy_lib.tokamaker_save_eqdsk, #(filename,nr,nz,rbounds,zbounds,run_info,psi_pad,rcentr,lcfs_press,error_str)
+    [c_char_p, c_int, c_int, ctypes_numpy_array(numpy.float64,1), ctypes_numpy_array(numpy.float64,1), c_char_p,
+     c_double, c_double, c_bool, c_char_p, c_double, c_char_p])
 ## @endcond
 
 

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -995,7 +995,7 @@ END SUBROUTINE tokamaker_set_coil_vsc
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-SUBROUTINE tokamaker_save_eqdsk(filename,nr,nz,rbounds,zbounds,run_info,psi_pad,rcentr,trunc_eq,lim_filename,error_str) BIND(C,NAME="tokamaker_save_eqdsk")
+SUBROUTINE tokamaker_save_eqdsk(filename,nr,nz,rbounds,zbounds,run_info,psi_pad,rcentr,trunc_eq,lim_filename,lcfs_press,error_str) BIND(C,NAME="tokamaker_save_eqdsk")
 CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Needs docs
 CHARACTER(KIND=c_char), INTENT(in) :: run_info(40) !< Needs docs
 INTEGER(c_int), VALUE, INTENT(in) :: nr !< Needs docs
@@ -1006,6 +1006,7 @@ REAL(c_double), VALUE, INTENT(in) :: psi_pad !< Needs docs
 REAL(c_double), VALUE, INTENT(in) :: rcentr !< Needs docs
 LOGICAL(c_bool), VALUE, INTENT(in) :: trunc_eq !< Needs docs
 CHARACTER(KIND=c_char), INTENT(in) :: lim_filename(OFT_PATH_SLEN) !< Needs docs
+REAL(c_double), VALUE, INTENT(in) :: lcfs_press !< Needs docs
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Needs docs
 CHARACTER(LEN=40) :: run_info_f
 CHARACTER(LEN=OFT_PATH_SLEN) :: filename_tmp,lim_file
@@ -1015,10 +1016,10 @@ CALL copy_string_rev(filename,filename_tmp)
 CALL copy_string_rev(lim_filename,lim_file)
 IF(rcentr>0.d0)THEN
   CALL gs_save_eqdsk(gs_global,filename_tmp,nr,nz,rbounds,zbounds,run_info_f,lim_file,psi_pad, &
-    rcentr_in=rcentr,trunc_eq=LOGICAL(trunc_eq),error_str=error_flag)
+    rcentr_in=rcentr,trunc_eq=LOGICAL(trunc_eq),lcfs_press=lcfs_press,error_str=error_flag)
 ELSE
   CALL gs_save_eqdsk(gs_global,filename_tmp,nr,nz,rbounds,zbounds,run_info_f,lim_file,psi_pad, &
-    trunc_eq=LOGICAL(trunc_eq),error_str=error_flag)
+    trunc_eq=LOGICAL(trunc_eq),lcfs_press=lcfs_press,error_str=error_flag)
 END IF
 CALL copy_string(TRIM(error_flag),error_str)
 END SUBROUTINE tokamaker_save_eqdsk

--- a/src/tests/physics/test_TokaMaker.py
+++ b/src/tests/physics/test_TokaMaker.py
@@ -444,6 +444,7 @@ def run_ITER_case(mesh_resolution,fe_order,eig_test,stability_test,mp_q):
         eig_vals, _ = mygs.eig_td(-1.E2,10,False)
         mp_q.put([{'gamma': eig_vals[:5,0]}])
         return
+    mygs.save_eqdsk('test.eqdsk',lcfs_pressure=6.E4)
     eq_info = mygs.get_stats(li_normalization='ITER')
     Lmat = mygs.get_coil_Lmat()
     eq_info['LCS1'] = Lmat[mygs.coil_sets['CS1U']['id'],mygs.coil_sets['CS1U']['id']]
@@ -598,6 +599,7 @@ def run_LTX_case(fe_order,eig_test,stability_test,mp_q):
     Ip_target = 9.0E4
     mygs.set_targets(Ip=Ip_target,Ip_ratio=2.0)
     mygs.solve()
+    mygs.save_eqdsk('test.eqdsk')
     #
     mp_q.put([mygs.get_stats()])
     oftpy_dump_cov()


### PR DESCRIPTION
This pull request adds support for specifying a non-zero LCFS pressure in `save_eqdsk()`, fixes #95

This pull request **does not** introduce breaking changes for any existing APIs or input files.