### PR TITLE
Marklin: Remove restriction on single Marklin instance

### DIFF
--- a/src/base/oft_io.F90
+++ b/src/base/oft_io.F90
@@ -689,11 +689,11 @@ call h5close_f(error)
 DEBUG_STACK_POP
 end subroutine hdf5_create_group
 !---------------------------------------------------------------------------
-!> Create HDF5 group in existing file
+!> Delete HDF5 object in existing file
 !---------------------------------------------------------------------------
 subroutine hdf5_delete_obj(filename,obj_path)
 character(LEN=*), intent(in) :: filename !< Name of HDF5 file
-character(LEN=*), intent(in) :: obj_path !< Group path
+character(LEN=*), intent(in) :: obj_path !< Object path
 integer :: error
 integer(HID_T) :: file_id,grp_id
 DEBUG_STACK_PUSH
@@ -794,6 +794,11 @@ integer(i4), parameter :: one=1
 integer(HID_T) :: file_id,dspace_id,dset_id
 INTEGER(HSIZE_T), DIMENSION(1) :: dims
 DEBUG_STACK_PUSH
+!---Remove field if it already exists
+IF(hdf5_field_exist(filename,path))THEN
+  CALL oft_warn('Overwriting existing object "'//TRIM(path)//'" in file '//TRIM(filename))
+  CALL hdf5_delete_obj(filename,path)
+END IF
 !---Write at lower precision?
 write_single=.FALSE.
 IF(PRESENT(single_prec))write_single=single_prec
@@ -834,6 +839,11 @@ integer(i4), parameter :: one=1
 integer(HID_T) :: file_id,dspace_id,dset_id
 INTEGER(HSIZE_T), DIMENSION(1) :: dims
 DEBUG_STACK_PUSH
+!---Remove field if it already exists
+IF(hdf5_field_exist(filename,path))THEN
+  CALL oft_warn('Overwriting existing object "'//TRIM(path)//'" in file '//TRIM(filename))
+  CALL hdf5_delete_obj(filename,path)
+END IF
 !---Initialize HDF5 and open file
 call h5open_f(error)
 call h5fopen_f(TRIM(filename), H5F_ACC_RDWR_F, file_id, error)
@@ -866,6 +876,11 @@ integer(i4), parameter :: two=2
 integer(HID_T) :: file_id,dspace_id,dset_id
 INTEGER(HSIZE_T), DIMENSION(2) :: dims
 DEBUG_STACK_PUSH
+!---Remove field if it already exists
+IF(hdf5_field_exist(filename,path))THEN
+  CALL oft_warn('Overwriting existing object "'//TRIM(path)//'" in file '//TRIM(filename))
+  CALL hdf5_delete_obj(filename,path)
+END IF
 !---Write at lower precision?
 write_single=.FALSE.
 IF(PRESENT(single_prec))write_single=single_prec
@@ -907,6 +922,11 @@ integer(HID_T) :: file_id
 integer(HID_T) :: dspace_id,dset_id
 INTEGER(HSIZE_T), DIMENSION(2) :: dims
 DEBUG_STACK_PUSH
+!---Remove field if it already exists
+IF(hdf5_field_exist(filename,path))THEN
+  CALL oft_warn('Overwriting existing object "'//TRIM(path)//'" in file '//TRIM(filename))
+  CALL hdf5_delete_obj(filename,path)
+END IF
 !---Initialize HDF5 and open file
 call h5open_f(error)
 call h5fopen_f(TRIM(filename), H5F_ACC_RDWR_F, file_id, error)
@@ -928,11 +948,10 @@ end subroutine hdf5_write_2d_i4
 !---------------------------------------------------------------------------
 !> FE vector implementation of \ref oft_io::hdf5_write
 !---------------------------------------------------------------------------
-subroutine hdf5_write_rst(rst_info,filename,path,append)
+subroutine hdf5_write_rst(rst_info,filename,path)
 type(hdf5_rst), intent(in) :: rst_info !< Restart data (structure containing data and mapping)
 character(LEN=*), intent(in) :: filename !< Path to file
 character(LEN=*), intent(in) :: path !< Variable path in file
-logical, optional, intent(in) :: append !< Append to or create file? (optional)
 integer(i4) :: i,error,one=1
 integer(HID_T) :: file_id
 integer(HID_T) :: dset_id
@@ -947,8 +966,15 @@ integer(HID_T) :: plist_id
 integer(i4) :: j
 #endif
 DEBUG_STACK_PUSH
-CALL oft_mpi_barrier(error)
 if(oft_debug_print(2))write(*,'(3A)')oft_indent,'Writing FE vector to file: ',TRIM(filename)
+!---Remove field if it already exists
+IF(oft_env%head_proc)THEN
+  IF(hdf5_field_exist(filename,path))THEN
+    CALL oft_warn('Overwriting existing object "'//TRIM(path)//'" in file '//TRIM(filename))
+    CALL hdf5_delete_obj(filename,path)
+  END IF
+END IF
+CALL oft_mpi_barrier(error)
 !---Setup local chunk
 dims=rst_info%dim
 count=rst_info%count
@@ -1316,7 +1342,7 @@ if(rst_info%full)then
   CALL h5dread_f(dset_id, H5T_NATIVE_DOUBLE, data, count, error)
   IF(error/=0)THEN
     IF(PRESENT(success))GOTO 100
-    CALL oft_abort('Error in HDF5 read','hdf5_read_rst',__FILE__)
+    CALL oft_abort('Error reading dataset','hdf5_read_rst',__FILE__)
   END IF
   !---Close dataset
   CALL h5sclose_f(memspace, error)
@@ -1374,7 +1400,7 @@ else
     file_space_id=filespace, mem_space_id=memspace, xfer_prp=plist_id)
   IF(error/=0)THEN
     IF(PRESENT(success))GOTO 100
-    CALL oft_abort('Error in HDF5 read','hdf5_read_rst',__FILE__)
+    CALL oft_abort('Error reading dataset','hdf5_read_rst',__FILE__)
   END IF
   !---Write out cell data
   CALL h5sclose_f(filespace, error)
@@ -1400,24 +1426,24 @@ else
       !---
       call h5fopen_f(TRIM(filename), access_flag, file_id, error)
       IF(error/=0)THEN
-        ! IF(PRESENT(success))GOTO 102
+        IF(PRESENT(success))GOTO 103
         CALL oft_abort('Error opening file','hdf5_read_rst',__FILE__)
       END IF
       !---
       CALL h5dopen_f(file_id, "/"//TRIM(path), dset_id, error)
       IF(error/=0)THEN
-        ! IF(PRESENT(success))GOTO 101
+        IF(PRESENT(success))GOTO 102
         CALL oft_abort('Error opening dataset','hdf5_read_rst',__FILE__)
       END IF
       !---Check size
       CALL h5dget_space_f(dset_id, memspace, error)
       CALL h5sget_simple_extent_npoints_f(memspace, space_count, error)
       IF(error/=0)THEN
-        ! IF(PRESENT(success))GOTO 100
+        IF(PRESENT(success))GOTO 101
         CALL oft_abort('Could not read dataset size','hdf5_read_rst',__FILE__)
       END IF
       IF(space_count/=rst_info%dim)THEN
-        ! IF(PRESENT(success))GOTO 100
+        IF(PRESENT(success))GOTO 101
         CALL oft_abort('Dataset size does not match','hdf5_read_rst',__FILE__)
       END IF
       !---
@@ -1428,8 +1454,8 @@ else
       CALL h5dread_f(dset_id, H5T_NATIVE_DOUBLE, data, count, error, &
         file_space_id=filespace, mem_space_id=memspace)
       IF(error/=0)THEN
-        ! IF(PRESENT(success))GOTO 100
-        CALL oft_abort('Error in HDF5 read','hdf5_read_rst',__FILE__)
+        IF(PRESENT(success))GOTO 100
+        CALL oft_abort('Error reading dataset','hdf5_read_rst',__FILE__)
       END IF
       !---Close dataset
       CALL h5sclose_f(filespace, error)
@@ -1447,25 +1473,37 @@ else
   call oft_abort("Requested distributed read without MPI","hdf5_read_rst",__FILE__)
 #endif
 end if
-! DEBUG_STACK_POP
 IF(PRESENT(success))THEN
   success=.TRUE.
   CALL h5eset_auto_f(one, error)
 END IF
+! DEBUG_STACK_POP
 RETURN
 100 CALL h5sclose_f(memspace, error)
 #ifdef HAVE_MPI
-#ifdef HAVE_PHDF5
 IF(.NOT.rst_info%full)THEN
+#ifdef HAVE_PHDF5
   CALL h5pclose_f(plist_id, error)
+#endif
   CALL h5sclose_f(filespace, error)
 END IF
-#endif
 #endif
 101 CALL h5dclose_f(dset_id, error)
 102 CALL h5fclose_f(file_id, error)
 103 CALL h5close_f(error)
 IF(PRESENT(success))CALL h5eset_auto_f(one, error)
+#ifdef HAVE_MPI
+IF(.NOT.rst_info%full)THEN
+#ifdef HAVE_PHDF5
+  CALL oft_mpi_barrier(error)
+#else
+  do i=oft_env%rank+1,oft_env%nprocs
+    CALL oft_mpi_barrier(error)
+  end do
+#endif
+END IF
+#endif
+! DEBUG_STACK_POP
 end subroutine hdf5_read_rst
 !---------------------------------------------------------------------------
 !> Deallocate internal storage fields created for HDF5 collective I/O

--- a/src/base/oft_io.F90
+++ b/src/base/oft_io.F90
@@ -1453,7 +1453,7 @@ IF(PRESENT(success))THEN
   CALL h5eset_auto_f(one, error)
 END IF
 RETURN
-100 CALL h5dclose_f(dset_id, error)
+100 CALL h5sclose_f(memspace, error)
 #ifdef HAVE_MPI
 #ifdef HAVE_PHDF5
 IF(.NOT.rst_info%full)THEN
@@ -1462,7 +1462,7 @@ IF(.NOT.rst_info%full)THEN
 END IF
 #endif
 #endif
-101 CALL h5sclose_f(memspace, error)
+101 CALL h5dclose_f(dset_id, error)
 102 CALL h5fclose_f(file_id, error)
 103 CALL h5close_f(error)
 IF(PRESENT(success))CALL h5eset_auto_f(one, error)

--- a/src/bin/marklin_eigs.F90
+++ b/src/bin/marklin_eigs.F90
@@ -27,6 +27,8 @@ USE multigrid_build, ONLY: multigrid_construct
 USE oft_la_base, ONLY: oft_vector, oft_matrix
 USE oft_solver_base, ONLY: oft_solver
 USE oft_solver_utils, ONLY: create_cg_solver, create_diag_pre
+!
+USE fem_composite, ONLY: oft_ml_fem_comp_type
 !---Lagrange FE space
 USE oft_lag_basis, ONLY: oft_lag_setup
 USE oft_lag_operators, ONLY: lag_lop_eigs, lag_setup_interp, lag_mloptions, &
@@ -36,8 +38,7 @@ USE oft_hcurl_basis, ONLY: oft_hcurl_setup
 USE oft_hcurl_operators, ONLY: oft_hcurl_cinterp, hcurl_setup_interp, &
   hcurl_mloptions
 !---Taylor state
-USE taylor, ONLY: taylor_minlev, taylor_hmodes, taylor_hffa, ML_oft_lagrange, &
-  ML_oft_vlagrange, ML_oft_hcurl
+USE taylor, ONLY: taylor_hmodes, oft_taylor_eigs
 IMPLICIT NONE
 #include "local.h"
 !---Lagrange mass solver
@@ -52,6 +53,8 @@ TYPE(oft_hcurl_cinterp) :: Bfield
 CHARACTER(LEN=3) :: pltnum
 TYPE(xdmf_plot_file) :: plot_file
 TYPE(multigrid_mesh) :: mg_mesh
+TYPE(oft_ml_fem_comp_type) :: ML_vlagrange
+TYPE(oft_taylor_eigs) :: hmodes
 INTEGER(i4) :: order = 2
 INTEGER(i4) :: nmodes = 1
 INTEGER(i4) :: minlev = 1
@@ -73,43 +76,44 @@ CALL plot_file%setup("marklin_eigs")
 CALL mg_mesh%mesh%setup_io(plot_file,order)
 !
 IF(minlev<0)THEN
-  taylor_minlev=ML_oft_hcurl%level
+  hmodes%minlev=mg_mesh%mgdim+(order-1)
 ELSE
-  taylor_minlev=minlev
-  IF(oft_env%nprocs>1)taylor_minlev=MAX(oft_env%nbase+1,minlev)
+  hmodes%minlev=minlev
+  IF(oft_env%nprocs>1)hmodes%minlev=MAX(oft_env%nbase+1,minlev)
 END IF
+ALLOCATE(hmodes%ML_hcurl,hmodes%ML_lagrange)
 !---Lagrange
-CALL oft_lag_setup(mg_mesh,order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange,minlev=taylor_minlev)
-CALL lag_setup_interp(ML_oft_lagrange)
+CALL oft_lag_setup(mg_mesh,order,hmodes%ML_lagrange,ML_vlag_obj=ML_vlagrange,minlev=hmodes%minlev)
+CALL lag_setup_interp(hmodes%ML_lagrange)
 CALL lag_mloptions
 !---H(Curl) subspace
-CALL oft_hcurl_setup(mg_mesh,order,ML_oft_hcurl,minlev=taylor_minlev)
-CALL hcurl_setup_interp(ML_oft_hcurl)
-CALL hcurl_mloptions(ML_oft_hcurl)
+CALL oft_hcurl_setup(mg_mesh,order,hmodes%ML_hcurl,minlev=hmodes%minlev)
+CALL hcurl_setup_interp(hmodes%ML_hcurl)
+CALL hcurl_mloptions(hmodes%ML_hcurl)
 oft_env%pm=.TRUE.
-CALL taylor_hmodes(nmodes)
+CALL taylor_hmodes(hmodes,nmodes)
 !---Construct operator
 NULLIFY(lmop)
-CALL oft_lag_vgetmop(ML_oft_vlagrange%current_level,lmop,'none')
+CALL oft_lag_vgetmop(ML_vlagrange%current_level,lmop,'none')
 !---Setup solver
 CALL create_cg_solver(lminv)
 CALL create_diag_pre(lminv%pre)
 lminv%A=>lmop
 lminv%its=-2
 !---Create solver fields
-CALL ML_oft_vlagrange%vec_create(u)
-CALL ML_oft_vlagrange%vec_create(v)
+CALL ML_vlagrange%vec_create(u)
+CALL ML_vlagrange%vec_create(v)
 ALLOCATE(bvout(3,u%n/3))
 !---Save modes
 DO i=1,nmodes
   WRITE(pltnum,'(I3.3)')i
-  CALL ML_oft_hcurl%current_level%vec_save(taylor_hffa(i,ML_oft_hcurl%level)%f, &
+  CALL hmodes%ML_hcurl%current_level%vec_save(hmodes%hffa(i,hmodes%ML_hcurl%level)%f, &
                           'marklin_eigs.rst','A_'//pltnum, append=(i/=1))
   !---Setup field interpolation
-  Bfield%u=>taylor_hffa(i,ML_oft_hcurl%level)%f
-  CALL Bfield%setup(ML_oft_hcurl%current_level)
+  Bfield%u=>hmodes%hffa(i,hmodes%ML_hcurl%level)%f
+  CALL Bfield%setup(hmodes%ML_hcurl%current_level)
   !---Project field
-  CALL oft_lag_vproject(ML_oft_lagrange%current_level,Bfield,v)
+  CALL oft_lag_vproject(hmodes%ML_lagrange%current_level,Bfield,v)
   CALL u%set(0.d0)
   CALL lminv%apply(u,v)
   !---Retrieve local values and save

--- a/src/bin/marklin_eigs.F90
+++ b/src/bin/marklin_eigs.F90
@@ -38,7 +38,7 @@ USE oft_hcurl_basis, ONLY: oft_hcurl_setup
 USE oft_hcurl_operators, ONLY: oft_hcurl_cinterp, hcurl_setup_interp, &
   hcurl_mloptions
 !---Taylor state
-USE taylor, ONLY: taylor_hmodes, oft_taylor_eigs
+USE taylor, ONLY: taylor_hmodes, oft_taylor_hmodes
 IMPLICIT NONE
 #include "local.h"
 !---Lagrange mass solver
@@ -54,7 +54,7 @@ CHARACTER(LEN=3) :: pltnum
 TYPE(xdmf_plot_file) :: plot_file
 TYPE(multigrid_mesh) :: mg_mesh
 TYPE(oft_ml_fem_comp_type) :: ML_vlagrange
-TYPE(oft_taylor_eigs) :: hmodes
+TYPE(oft_taylor_hmodes) :: hmodes
 INTEGER(i4) :: order = 2
 INTEGER(i4) :: nmodes = 1
 INTEGER(i4) :: minlev = 1

--- a/src/examples/MUG/Spheromak_heating/MUG_sph_heat.F90
+++ b/src/examples/MUG/Spheromak_heating/MUG_sph_heat.F90
@@ -46,7 +46,7 @@ USE oft_h1_operators, ONLY: oft_h1_getlop, oft_h1_zerogrnd
 USE oft_hcurl_basis, ONLY: oft_hcurl_setup, oft_hcurl_grad_setup
 USE oft_hcurl_grad_operators, ONLY: oft_hcurl_grad_divout, hcurl_grad_mc
 !---Physics
-USE taylor, ONLY: taylor_hmodes, oft_taylor_eigs
+USE taylor, ONLY: taylor_hmodes, oft_taylor_hmodes
 USE xmhd, ONLY: xmhd_run, xmhd_plot, xmhd_taxis, vel_scale, den_scale, &
   den_floor, temp_floor, xmhd_sub_fields, xmhd_ML_hcurl, &
   xmhd_ML_H1, xmhd_ML_hcurl_grad, xmhd_ML_H1grad, xmhd_ML_lagrange, xmhd_ML_vlagrange
@@ -63,7 +63,7 @@ INTEGER(i4) :: ierr,io_unit
 REAL(r8), POINTER, DIMENSION(:) :: tmp => NULL()
 TYPE(xmhd_sub_fields) :: ic_fields
 TYPE(multigrid_mesh) :: mg_mesh
-TYPE(oft_taylor_eigs) :: taylor_states
+TYPE(oft_taylor_hmodes) :: taylor_states
 TYPE(oft_h1_zerogrnd), TARGET :: h1_zerogrnd
 !---Runtime options
 INTEGER(i4) :: order = 2

--- a/src/examples/MUG/Spheromak_heating/MUG_sph_heat.F90
+++ b/src/examples/MUG/Spheromak_heating/MUG_sph_heat.F90
@@ -46,10 +46,10 @@ USE oft_h1_operators, ONLY: oft_h1_getlop, oft_h1_zerogrnd
 USE oft_hcurl_basis, ONLY: oft_hcurl_setup, oft_hcurl_grad_setup
 USE oft_hcurl_grad_operators, ONLY: oft_hcurl_grad_divout, hcurl_grad_mc
 !---Physics
-USE taylor, ONLY: taylor_hmodes, taylor_hffa, taylor_hlam
+USE taylor, ONLY: taylor_hmodes, oft_taylor_eigs
 USE xmhd, ONLY: xmhd_run, xmhd_plot, xmhd_taxis, vel_scale, den_scale, &
-  den_floor, temp_floor, xmhd_sub_fields, ML_oft_hcurl, &
-  ML_oft_h1, ML_hcurl_grad, ML_h1grad, ML_oft_lagrange, ML_oft_vlagrange
+  den_floor, temp_floor, xmhd_sub_fields, xmhd_ML_hcurl, &
+  xmhd_ML_H1, xmhd_ML_hcurl_grad, xmhd_ML_H1grad, xmhd_ML_lagrange, xmhd_ML_vlagrange
 IMPLICIT NONE
 !!\subsection doc_mug_sph_ex2_code_vars Local Variables
 !! Next we define the local variables needed to initialize our case and
@@ -63,6 +63,7 @@ INTEGER(i4) :: ierr,io_unit
 REAL(r8), POINTER, DIMENSION(:) :: tmp => NULL()
 TYPE(xmhd_sub_fields) :: ic_fields
 TYPE(multigrid_mesh) :: mg_mesh
+TYPE(oft_taylor_eigs) :: taylor_states
 TYPE(oft_h1_zerogrnd), TARGET :: h1_zerogrnd
 !---Runtime options
 INTEGER(i4) :: order = 2
@@ -87,14 +88,14 @@ CALL multigrid_construct(mg_mesh,[2.d0,0.d0,0.d0])
 ! Build FE structures
 !---------------------------------------------------------------------------
 !--- Lagrange
-CALL oft_lag_setup(mg_mesh,order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange,minlev=-1)
+CALL oft_lag_setup(mg_mesh,order,xmhd_ML_lagrange,ML_vlag_obj=xmhd_ML_vlagrange,minlev=-1)
 !--- Grad(H^1) subspace
-CALL oft_h1_setup(mg_mesh,order+1,ML_oft_h1,minlev=-1)
+CALL oft_h1_setup(mg_mesh,order+1,xmhd_ML_H1,minlev=-1)
 !--- H(Curl) subspace
-CALL oft_hcurl_setup(mg_mesh,order,ML_oft_hcurl,minlev=-1)
+CALL oft_hcurl_setup(mg_mesh,order,xmhd_ML_hcurl,minlev=-1)
 !--- Full H(Curl) space
-CALL oft_hcurl_grad_setup(ML_oft_hcurl,ML_oft_h1,ML_hcurl_grad,ML_h1grad,-1)
-h1_zerogrnd%ML_H1_rep=>ML_h1grad
+CALL oft_hcurl_grad_setup(xmhd_ML_hcurl,xmhd_ML_H1,xmhd_ML_hcurl_grad,xmhd_ML_H1grad,-1)
+h1_zerogrnd%ML_H1_rep=>xmhd_ML_H1grad
 !!\subsection doc_mug_sph_ex2_code_plot Perform post-processing
 !!
 !! To visualize the solution fields once a simulation has completed the \ref xmhd::xmhd_plot
@@ -113,8 +114,9 @@ END IF
 !! For this simulation we only need the spheromak mode, which is the lowest
 !! force-free eignstate in this geometry. As a result the initial condition
 !! is stable to all types of mode activity.
-CALL taylor_hmodes(1)
-CALL ML_oft_lagrange%set_level(ML_oft_lagrange%nlevels)
+CALL taylor_states%setup(xmhd_ML_hcurl,xmhd_ML_lagrange)
+CALL taylor_hmodes(taylor_states,1)
+CALL xmhd_ML_lagrange%set_level(xmhd_ML_lagrange%nlevels)
 !! As in \ref doc_mug_sph_ex1 we must transform the gauge of the Taylor
 !! state solution to the appropriate magnetic field BCs. For more information
 !! on this see the description in \ref doc_mug_sph_ex1_ic of that example.
@@ -122,7 +124,7 @@ CALL ML_oft_lagrange%set_level(ML_oft_lagrange%nlevels)
 ! Create divergence cleaner
 !---------------------------------------------------------------------------
 NULLIFY(lop)
-CALL oft_h1_getlop(ML_oft_h1%current_level,lop,"grnd")
+CALL oft_h1_getlop(xmhd_ML_H1%current_level,lop,"grnd")
 CALL create_cg_solver(linv)
 linv%A=>lop
 linv%its=-2
@@ -136,8 +138,8 @@ divout%keep_boundary=.TRUE.
 !---------------------------------------------------------------------------
 ! Setup initial conditions
 !---------------------------------------------------------------------------
-CALL ML_hcurl_grad%vec_create(ic_fields%B)
-CALL taylor_hffa(1,ML_oft_hcurl%level)%f%get_local(tmp)
+CALL xmhd_ML_hcurl_grad%vec_create(ic_fields%B)
+CALL taylor_states%hffa(1,xmhd_ML_hcurl%level)%f%get_local(tmp)
 CALL ic_fields%B%restore_local(tmp,1)
 CALL divout%apply(ic_fields%B)
 NULLIFY(divout%solver)
@@ -160,20 +162,20 @@ DEALLOCATE(linv)
 !! the residual calculations. In general these scale factors should be set to
 !! the order of magnitude expected for the corresponding variables, \f$ km/s \f$ and
 !! \f$ 10^{19} m^{-3} \f$ in this simulation.
-CALL ic_fields%B%scale(b0_scale*taylor_hlam(1,ML_oft_hcurl%level))
+CALL ic_fields%B%scale(b0_scale*taylor_states%hlam(1,xmhd_ML_hcurl%level))
 !---Clean up temporary matrices and fields
 CALL lop%delete
 DEALLOCATE(tmp,lop)
 !---Create velocity field
-CALL ML_oft_vlagrange%vec_create(ic_fields%V)
+CALL xmhd_ML_vlagrange%vec_create(ic_fields%V)
 vel_scale = 1.d3
 !---Create density field
-CALL ML_oft_lagrange%vec_create(ic_fields%Ne)
+CALL xmhd_ML_lagrange%vec_create(ic_fields%Ne)
 CALL ic_fields%Ne%set(n0)
 den_scale = n0
 den_floor = n0*1.d-2
 !---Create temperature field
-CALL ML_oft_lagrange%vec_create(ic_fields%Ti)
+CALL xmhd_ML_lagrange%vec_create(ic_fields%Ti)
 CALL ic_fields%Ti%set(t0)
 temp_floor = t0*1.d-2
 !!\subsection doc_mug_sph_ex2_code_run Run Simulation

--- a/src/examples/MUG/Spheromak_tilt/MUG_sph_tilt.F90
+++ b/src/examples/MUG/Spheromak_tilt/MUG_sph_tilt.F90
@@ -43,7 +43,7 @@ USE oft_h1_operators, ONLY: oft_h1_getlop, oft_h1_zerogrnd
 USE oft_hcurl_basis, ONLY: oft_hcurl_setup, oft_hcurl_grad_setup
 USE oft_hcurl_grad_operators, ONLY: oft_hcurl_grad_divout, hcurl_grad_mc
 !---Physics
-USE taylor, ONLY: taylor_hmodes, oft_taylor_eigs
+USE taylor, ONLY: taylor_hmodes, oft_taylor_hmodes
 USE xmhd, ONLY: xmhd_run, xmhd_lin_run, xmhd_plot, xmhd_taxis, xmhd_sub_fields, &
   xmhd_ML_hcurl, xmhd_ML_H1, xmhd_ML_hcurl_grad, xmhd_ML_H1grad, xmhd_ML_lagrange, xmhd_ML_vlagrange
 IMPLICIT NONE
@@ -59,7 +59,7 @@ INTEGER(i4) :: ierr,io_unit
 REAL(r8), POINTER, DIMENSION(:) :: tmp => NULL()
 TYPE(xmhd_sub_fields) :: ic_fields,pert_fields
 TYPE(multigrid_mesh) :: mg_mesh
-TYPE(oft_taylor_eigs) :: taylor_states
+TYPE(oft_taylor_hmodes) :: taylor_states
 TYPE(oft_h1_zerogrnd), TARGET :: h1_zerogrnd
 !---Runtime options
 INTEGER(i4) :: order = 2

--- a/src/examples/MUG/Spheromak_tilt/MUG_sph_tilt.F90
+++ b/src/examples/MUG/Spheromak_tilt/MUG_sph_tilt.F90
@@ -43,9 +43,9 @@ USE oft_h1_operators, ONLY: oft_h1_getlop, oft_h1_zerogrnd
 USE oft_hcurl_basis, ONLY: oft_hcurl_setup, oft_hcurl_grad_setup
 USE oft_hcurl_grad_operators, ONLY: oft_hcurl_grad_divout, hcurl_grad_mc
 !---Physics
-USE taylor, ONLY: taylor_hmodes, taylor_hffa, taylor_hlam
+USE taylor, ONLY: taylor_hmodes, oft_taylor_eigs
 USE xmhd, ONLY: xmhd_run, xmhd_lin_run, xmhd_plot, xmhd_taxis, xmhd_sub_fields, &
-  ML_oft_hcurl, ML_oft_h1, ML_hcurl_grad, ML_h1grad, ML_oft_lagrange, ML_oft_vlagrange
+  xmhd_ML_hcurl, xmhd_ML_H1, xmhd_ML_hcurl_grad, xmhd_ML_H1grad, xmhd_ML_lagrange, xmhd_ML_vlagrange
 IMPLICIT NONE
 !!\subsection doc_mug_sph_ex1_code_vars Local Variables
 !! Next we define the local variables needed to initialize our case and
@@ -59,6 +59,7 @@ INTEGER(i4) :: ierr,io_unit
 REAL(r8), POINTER, DIMENSION(:) :: tmp => NULL()
 TYPE(xmhd_sub_fields) :: ic_fields,pert_fields
 TYPE(multigrid_mesh) :: mg_mesh
+TYPE(oft_taylor_eigs) :: taylor_states
 TYPE(oft_h1_zerogrnd), TARGET :: h1_zerogrnd
 !---Runtime options
 INTEGER(i4) :: order = 2
@@ -85,14 +86,14 @@ CALL multigrid_construct(mg_mesh,[2.d0,0.d0,0.d0])
 ! Build FE structures
 !---------------------------------------------------------------------------
 !--- Lagrange
-CALL oft_lag_setup(mg_mesh,order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange,minlev=-1)
+CALL oft_lag_setup(mg_mesh,order,xmhd_ML_lagrange,ML_vlag_obj=xmhd_ML_vlagrange,minlev=-1)
 !--- Grad(H^1) subspace
-CALL oft_h1_setup(mg_mesh,order+1,ML_oft_h1,minlev=-1)
+CALL oft_h1_setup(mg_mesh,order+1,xmhd_ML_H1,minlev=-1)
 !--- H(Curl) subspace
-CALL oft_hcurl_setup(mg_mesh,order,ML_oft_hcurl,minlev=-1)
+CALL oft_hcurl_setup(mg_mesh,order,xmhd_ML_hcurl,minlev=-1)
 !--- Full H(Curl) space
-CALL oft_hcurl_grad_setup(ML_oft_hcurl,ML_oft_h1,ML_hcurl_grad,ML_h1grad,-1)
-h1_zerogrnd%ML_H1_rep=>ML_h1grad
+CALL oft_hcurl_grad_setup(xmhd_ML_hcurl,xmhd_ML_H1,xmhd_ML_hcurl_grad,xmhd_ML_H1grad,-1)
+h1_zerogrnd%ML_H1_rep=>xmhd_ML_H1grad
 !!\subsection doc_mug_sph_ex1_code_plot Perform post-processing
 !!
 !! To visualize the solution fields once a simulation has completed, the \ref xmhd::xmhd_plot
@@ -118,8 +119,9 @@ END IF
 !! that will drive the configuration toward one of these minimum energy states.
 !! This also leads us to our choice of an intial perturbation to the equilibrium,
 !! which we will chose to match field of the lowest eigenstate.
-CALL taylor_hmodes(3)
-CALL ML_oft_lagrange%set_level(ML_oft_lagrange%nlevels)
+CALL taylor_states%setup(xmhd_ML_hcurl,xmhd_ML_lagrange)
+CALL taylor_hmodes(taylor_states,3)
+CALL xmhd_ML_lagrange%set_level(xmhd_ML_lagrange%nlevels)
 !! The \ref taylor::taylor_hmodes "taylor_hmodes" subroutine computes the vector
 !! potential for each of the requested eignestates. However, the MHD
 !! solver uses magnetic field as the primary variable. With force-free eigenstate
@@ -139,7 +141,7 @@ CALL ML_oft_lagrange%set_level(ML_oft_lagrange%nlevels)
 ! Create divergence cleaner
 !---------------------------------------------------------------------------
 NULLIFY(lop)
-CALL oft_h1_getlop(ML_oft_h1%current_level,lop,"grnd")
+CALL oft_h1_getlop(xmhd_ML_H1%current_level,lop,"grnd")
 CALL create_cg_solver(linv)
 linv%A=>lop
 linv%its=-2
@@ -153,13 +155,13 @@ divout%pm=.TRUE.
 ! Setup initial conditions
 !---------------------------------------------------------------------------
 !---Apply to equilibrium field
-CALL ML_hcurl_grad%vec_create(ic_fields%B)
-CALL taylor_hffa(3,ML_oft_hcurl%level)%f%get_local(tmp)
+CALL xmhd_ML_hcurl_grad%vec_create(ic_fields%B)
+CALL taylor_states%hffa(3,xmhd_ML_hcurl%level)%f%get_local(tmp)
 CALL ic_fields%B%restore_local(tmp,1)
 CALL divout%apply(ic_fields%B)
 !---Apply to perturbation field
-CALL ML_hcurl_grad%vec_create(pert_fields%B)
-CALL taylor_hffa(1,ML_oft_hcurl%level)%f%get_local(tmp)
+CALL xmhd_ML_hcurl_grad%vec_create(pert_fields%B)
+CALL taylor_states%hffa(1,xmhd_ML_hcurl%level)%f%get_local(tmp)
 CALL pert_fields%B%restore_local(tmp,1)
 CALL divout%apply(pert_fields%B)
 !---Clean up solver
@@ -178,24 +180,24 @@ DEALLOCATE(linv)
 !! density fields are also created. The velocity field is initialized to zero everywhere,
 !! while the temperature and density fields, which are not evolved in this case, are set to
 !! uniform values for the equilibrium and zero for the perturbation.
-CALL ic_fields%B%scale(b0_scale*taylor_hlam(3,ML_oft_hcurl%level))
-CALL pert_fields%B%scale(b1_scale*taylor_hlam(1,ML_oft_hcurl%level))
+CALL ic_fields%B%scale(b0_scale*taylor_states%hlam(3,xmhd_ML_hcurl%level))
+CALL pert_fields%B%scale(b1_scale*taylor_states%hlam(1,xmhd_ML_hcurl%level))
 IF(.NOT.linear)THEN
   CALL ic_fields%B%add(1.d0,1.d0,pert_fields%B)
   CALL pert_fields%B%delete
   DEALLOCATE(pert_fields%B)
 END IF
 !---Create velocity field
-CALL ML_oft_vlagrange%vec_create(ic_fields%V)
-IF(linear)CALL ML_oft_vlagrange%vec_create(pert_fields%V)
+CALL xmhd_ML_vlagrange%vec_create(ic_fields%V)
+IF(linear)CALL xmhd_ML_vlagrange%vec_create(pert_fields%V)
 !---Create static density/temperature
-CALL ML_oft_lagrange%vec_create(ic_fields%Ne)
-CALL ML_oft_lagrange%vec_create(ic_fields%Ti)
+CALL xmhd_ML_lagrange%vec_create(ic_fields%Ne)
+CALL xmhd_ML_lagrange%vec_create(ic_fields%Ti)
 CALL ic_fields%Ne%set(n0)
 CALL ic_fields%Ti%set(t0)
 IF(linear)THEN
-  CALL ML_oft_lagrange%vec_create(pert_fields%Ne)
-  CALL ML_oft_lagrange%vec_create(pert_fields%Ti)
+  CALL xmhd_ML_lagrange%vec_create(pert_fields%Ne)
+  CALL xmhd_ML_lagrange%vec_create(pert_fields%Ti)
 END IF
 !---Clean up temporary matrices and fields
 CALL lop%delete

--- a/src/examples/example3.F90
+++ b/src/examples/example3.F90
@@ -187,7 +187,7 @@ USE oft_hcurl_basis, ONLY: oft_hcurl_setup
 USE oft_hcurl_operators, ONLY: oft_hcurl_cinterp, hcurl_setup_interp, &
   hcurl_mloptions
 !---Taylor state
-USE taylor, ONLY: taylor_hmodes, oft_taylor_eigs
+USE taylor, ONLY: taylor_hmodes, oft_taylor_hmodes
 IMPLICIT NONE
 #include "local.h"
 !!\subsection ex3_code_vars Variable Definitions
@@ -211,7 +211,7 @@ TYPE(oft_hcurl_cinterp) :: Bfield
 TYPE(xdmf_plot_file) :: plot_file
 TYPE(multigrid_mesh) :: mg_mesh
 TYPE(oft_ml_fem_comp_type) :: ML_vlagrange
-TYPE(oft_taylor_eigs) :: taylor_states
+TYPE(oft_taylor_hmodes) :: taylor_states
 !!\subsection doc_ex3_code_grid Setup Grid
 !!
 !!As in the previous \ref ex1 "examples" the runtime environment, grid and plotting files must be setup

--- a/src/examples/example3.F90
+++ b/src/examples/example3.F90
@@ -176,6 +176,8 @@ USE multigrid_build, ONLY: multigrid_construct
 USE oft_la_base, ONLY: oft_vector, oft_matrix
 USE oft_solver_base, ONLY: oft_solver
 USE oft_solver_utils, ONLY: create_cg_solver, create_diag_pre
+!
+USE fem_composite, ONLY: oft_ml_fem_comp_type
 !---Lagrange FE space
 USE oft_lag_basis, ONLY: oft_lag_setup
 USE oft_lag_operators, ONLY: lag_lop_eigs, lag_setup_interp, lag_mloptions, &
@@ -185,8 +187,7 @@ USE oft_hcurl_basis, ONLY: oft_hcurl_setup
 USE oft_hcurl_operators, ONLY: oft_hcurl_cinterp, hcurl_setup_interp, &
   hcurl_mloptions
 !---Taylor state
-USE taylor, ONLY: taylor_minlev, taylor_hmodes, taylor_hffa, ML_oft_hcurl, &
-  ML_oft_lagrange, ML_oft_vlagrange
+USE taylor, ONLY: taylor_hmodes, oft_taylor_eigs
 IMPLICIT NONE
 #include "local.h"
 !!\subsection ex3_code_vars Variable Definitions
@@ -209,6 +210,8 @@ CLASS(oft_vector), POINTER :: u,v,check
 TYPE(oft_hcurl_cinterp) :: Bfield
 TYPE(xdmf_plot_file) :: plot_file
 TYPE(multigrid_mesh) :: mg_mesh
+TYPE(oft_ml_fem_comp_type) :: ML_vlagrange
+TYPE(oft_taylor_eigs) :: taylor_states
 !!\subsection doc_ex3_code_grid Setup Grid
 !!
 !!As in the previous \ref ex1 "examples" the runtime environment, grid and plotting files must be setup
@@ -224,13 +227,15 @@ CALL mg_mesh%mesh%setup_io(plot_file,order)
 !!As in \ref ex2 "example 2" we construct the finite element space, MG vector cache, and interpolation
 !!operators. In this case the setup procedure is done for each required finite element space.
 !---Lagrange
-CALL oft_lag_setup(mg_mesh,order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange)
-CALL lag_setup_interp(ML_oft_lagrange)
+ALLOCATE(taylor_states%ML_lagrange)
+CALL oft_lag_setup(mg_mesh,order,taylor_states%ML_lagrange,ML_vlag_obj=ML_vlagrange)
+CALL lag_setup_interp(taylor_states%ML_lagrange)
 CALL lag_mloptions
 !---H(Curl) space
-CALL oft_hcurl_setup(mg_mesh,order,ML_oft_hcurl)
-CALL hcurl_setup_interp(ML_oft_hcurl)
-CALL hcurl_mloptions(ML_oft_hcurl)
+ALLOCATE(taylor_states%ML_hcurl)
+CALL oft_hcurl_setup(mg_mesh,order,taylor_states%ML_hcurl)
+CALL hcurl_setup_interp(taylor_states%ML_hcurl)
+CALL hcurl_mloptions(taylor_states%ML_hcurl)
 !!\subsection doc_ex3_code_taylor Compute Taylor state
 !!
 !!The eigenstate is now computed using the \ref taylor::taylor_hmodes "taylor_hmodes" subroutine. The
@@ -242,10 +247,10 @@ CALL hcurl_mloptions(ML_oft_hcurl)
 !!\ref taylor::taylor_minlev "taylor_minlev".
 !!
 !!\note For our parallel example we increase the minimum level by 1 to use distributed levels only.
-taylor_minlev=1
-IF(oft_env%nprocs>1)taylor_minlev=2
+taylor_states%minlev=1
+IF(oft_env%nprocs>1)taylor_states%minlev=2
 oft_env%pm=.TRUE.
-CALL taylor_hmodes(1)
+CALL taylor_hmodes(taylor_states,1)
 !!\subsection doc_ex3_code_project Project Solution for Plotting
 !!
 !!In order to output the solution for plotting the field must be converted to a nodal, Lagrange,
@@ -262,20 +267,20 @@ CALL taylor_hmodes(1)
 !!\f$ B = \nabla \times A \f$.
 !---Construct operator
 NULLIFY(lmop)
-CALL oft_lag_vgetmop(ML_oft_vlagrange%current_level,lmop,'none')
+CALL oft_lag_vgetmop(ML_vlagrange%current_level,lmop,'none')
 !---Setup solver
 CALL create_cg_solver(lminv)
 lminv%A=>lmop
 lminv%its=-2
 CALL create_diag_pre(lminv%pre) ! Setup Preconditioner
 !---Create solver fields
-CALL ML_oft_vlagrange%vec_create(u)
-CALL ML_oft_vlagrange%vec_create(v)
+CALL ML_vlagrange%vec_create(u)
+CALL ML_vlagrange%vec_create(v)
 !---Setup field interpolation
-Bfield%u=>taylor_hffa(1,ML_oft_hcurl%level)%f
-CALL Bfield%setup(ML_oft_hcurl%current_level)
+Bfield%u=>taylor_states%hffa(1,taylor_states%ML_hcurl%level)%f
+CALL Bfield%setup(taylor_states%ML_hcurl%current_level)
 !---Project field
-CALL oft_lag_vproject(ML_oft_lagrange%current_level,Bfield,v)
+CALL oft_lag_vproject(taylor_states%ML_lagrange%current_level,Bfield,v)
 CALL u%set(0.d0)
 CALL lminv%apply(u,v)
 !---Retrieve local values and save

--- a/src/examples/example4.F90
+++ b/src/examples/example4.F90
@@ -40,7 +40,7 @@ USE oft_hcurl_operators, ONLY: oft_hcurl_cinterp, hcurl_setup_interp, &
   hcurl_mloptions
 !---Taylor state
 USE taylor, ONLY: taylor_hmodes, oft_taylor_rinterp, taylor_vacuum, &
-  taylor_injectors, oft_taylor_eigs, oft_taylor_inhomo, taylor_tag_size
+  taylor_injectors, oft_taylor_hmodes, oft_taylor_ifield, taylor_tag_size
 !---Tracing
 USE tracing, ONLY: oft_tracer, create_tracer, tracing_poincare
 IMPLICIT NONE
@@ -67,8 +67,8 @@ CLASS(oft_tracer), POINTER :: tracer
 TYPE(xdmf_plot_file) :: plot_file
 TYPE(multigrid_mesh) :: mg_mesh
 TYPE(oft_ml_fem_comp_type) :: ML_vlagrange
-TYPE(oft_taylor_eigs) :: hmodes
-TYPE(oft_taylor_inhomo) :: ff_obj
+TYPE(oft_taylor_hmodes) :: hmodes
+TYPE(oft_taylor_ifield) :: ff_obj
 !!\subsection doc_ex4_code_grid Setup Grid
 !!
 !!As in the previous \ref ex1 "examples" the runtime environment, grid and plotting

--- a/src/examples/example4.F90
+++ b/src/examples/example4.F90
@@ -24,7 +24,9 @@ USE multigrid_build, ONLY: multigrid_construct
 !---Linear Algebra
 USE oft_la_base, ONLY: oft_vector, oft_matrix
 USE oft_solver_base, ONLY: oft_solver
-USE oft_solver_utils, ONLY: create_cg_solver, create_diag_pre
+USE oft_solver_utils, ONLY: create_cg_solver, create_diag_pre\
+!
+USE fem_composite, ONLY: oft_ml_fem_comp_type
 !---Lagrange FE space
 USE oft_lag_basis, ONLY: oft_lag_setup
 USE oft_lag_operators, ONLY: lag_lop_eigs, lag_setup_interp, lag_mloptions, &
@@ -37,10 +39,8 @@ USE oft_hcurl_basis, ONLY: oft_hcurl_setup, oft_hcurl_grad_setup
 USE oft_hcurl_operators, ONLY: oft_hcurl_cinterp, hcurl_setup_interp, &
   hcurl_mloptions
 !---Taylor state
-USE taylor, ONLY: taylor_minlev, taylor_hmodes, oft_taylor_rinterp, taylor_vacuum, &
-  taylor_injectors, taylor_hffa, taylor_hlam, taylor_hvac, taylor_gffa, taylor_htor, &
-  taylor_tag_size, ML_oft_hcurl, ML_oft_h1, &
-  ML_hcurl_grad, ML_h1grad, ML_oft_lagrange, ML_oft_vlagrange
+USE taylor, ONLY: taylor_hmodes, oft_taylor_rinterp, taylor_vacuum, &
+  taylor_injectors, oft_taylor_eigs, oft_taylor_inhomo, taylor_tag_size
 !---Tracing
 USE tracing, ONLY: oft_tracer, create_tracer, tracing_poincare
 IMPLICIT NONE
@@ -66,6 +66,9 @@ TYPE(oft_taylor_rinterp), TARGET :: Bfield
 CLASS(oft_tracer), POINTER :: tracer
 TYPE(xdmf_plot_file) :: plot_file
 TYPE(multigrid_mesh) :: mg_mesh
+TYPE(oft_ml_fem_comp_type) :: ML_vlagrange
+TYPE(oft_taylor_eigs) :: hmodes
+TYPE(oft_taylor_inhomo) :: ff_obj
 !!\subsection doc_ex4_code_grid Setup Grid
 !!
 !!As in the previous \ref ex1 "examples" the runtime environment, grid and plotting
@@ -81,27 +84,34 @@ CALL mg_mesh%mesh%setup_io(plot_file,order)
 !!As in \ref ex2 "example 2" we construct the finite element space, MG vector cache, and interpolation
 !!operators. In this case the setup procedure is done for each required finite element space.
 !--- Lagrange
-CALL oft_lag_setup(mg_mesh,order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange)
-CALL lag_setup_interp(ML_oft_lagrange)
+ALLOCATE(hmodes%ML_lagrange)
+ff_obj%ML_lagrange=>hmodes%ML_lagrange
+CALL oft_lag_setup(mg_mesh,order,hmodes%ML_lagrange,ML_vlag_obj=ML_vlagrange)
+CALL lag_setup_interp(hmodes%ML_lagrange)
 CALL lag_mloptions
 !--- Grad(H^1) subspace
-CALL oft_h1_setup(mg_mesh,order+1,ML_oft_h1)
-CALL h1_setup_interp(ML_oft_h1)
+ALLOCATE(ff_obj%ML_H1)
+CALL oft_h1_setup(mg_mesh,order+1,ff_obj%ML_H1)
+CALL h1_setup_interp(ff_obj%ML_H1)
 CALL h1_mloptions
 !--- H(Curl) subspace
-CALL oft_hcurl_setup(mg_mesh,order,ML_oft_hcurl)
-CALL hcurl_setup_interp(ML_oft_hcurl)
-CALL hcurl_mloptions(ML_oft_hcurl)
+ALLOCATE(hmodes%ML_hcurl)
+ff_obj%ML_hcurl=>hmodes%ML_hcurl
+CALL oft_hcurl_setup(mg_mesh,order,hmodes%ML_hcurl)
+CALL hcurl_setup_interp(hmodes%ML_hcurl)
+CALL hcurl_mloptions(hmodes%ML_hcurl)
 !--- Full H(Curl) space
-CALL oft_hcurl_grad_setup(ML_oft_hcurl,ML_oft_h1,ML_hcurl_grad,ML_h1grad)
+ALLOCATE(ff_obj%ML_hcurl_grad,ff_obj%ML_h1grad)
+CALL oft_hcurl_grad_setup(hmodes%ML_hcurl,ff_obj%ML_H1,ff_obj%ML_hcurl_grad,ff_obj%ML_h1grad)
 !!\subsection doc_ex4_code_taylor Compute Taylor state
 !!
 !!For composite Taylor states the lowest eigenmode is used used in addition to the injector fields. This
 !!is possible in HIT-SI due to decoupling of the injector vacuum field and lowest eigenmode. The lowest
 !!eigenmode is computed as in \ref ex3 "example 3" using \ref taylor::taylor_hmodes "taylor_hmodes".
-taylor_minlev=1
-IF(oft_env%nprocs>1)taylor_minlev=2
-CALL taylor_hmodes(1)
+hmodes%minlev=1
+IF(oft_env%nprocs>1)hmodes%minlev=2
+ff_obj%minlev=hmodes%minlev
+CALL taylor_hmodes(hmodes,1)
 !!\subsection doc_ex4_code_jumps Injector Cut Planes
 !!
 !!The ideal MHD equilibrium solvers with inhomogeneous source terms require vacuum fields to use as the
@@ -133,18 +143,18 @@ htags(2)='Yinj'
 !!the injector, and \f$ \vec{B}^i_{gffa} \f$ is the plasma component of the inhomogeneous equilibrium field. The
 !!interpolation object \ref taylor::oft_taylor_rinterp "oft_taylor_rinterp" is designed to support this type of field
 !!and is populated once the subfields are computed.
-CALL taylor_vacuum(nh,hcpc,hcpv,htags)
-CALL taylor_injectors(taylor_hlam(1,ML_oft_hcurl%level))
+CALL taylor_vacuum(ff_obj,nh,hcpc,hcpv,htags,hmodes=hmodes)
+CALL taylor_injectors(ff_obj,hmodes,hmodes%hlam(1,hmodes%ML_hcurl%level))
 !---Setup field interpolation object
 fluxes=(/1.d0,0.d0/)
-CALL ML_hcurl_grad%vec_create(Bfield%uvac)
+CALL ff_obj%ML_hcurl_grad%vec_create(Bfield%uvac)
 DO i=1,nh
-  CALL Bfield%uvac%add(1.d0,fluxes(i),taylor_hvac(i,ML_hcurl_grad%level)%f)
+  CALL Bfield%uvac%add(1.d0,fluxes(i),ff_obj%hvac(i,ff_obj%ML_hcurl_grad%level)%f)
 END DO
-CALL ML_oft_hcurl%vec_create(Bfield%ua)
-CALL Bfield%ua%add(0.d0,fr/taylor_htor(1,ML_oft_hcurl%level),taylor_hffa(1,ML_oft_hcurl%level)%f)
+CALL hmodes%ML_hcurl%vec_create(Bfield%ua)
+CALL Bfield%ua%add(0.d0,fr/hmodes%htor(1,hmodes%ML_hcurl%level),hmodes%hffa(1,hmodes%ML_hcurl%level)%f)
 DO i=1,nh
-  CALL Bfield%ua%add(1.d0,fluxes(i),taylor_gffa(i,ML_hcurl_grad%level)%f)
+  CALL Bfield%ua%add(1.d0,fluxes(i),ff_obj%gffa(i,ff_obj%ML_hcurl_grad%level)%f)
 END DO
 !!\subsection doc_ex4_code_project Project Solution for Plotting
 !!
@@ -152,19 +162,19 @@ END DO
 !!\ref ex3 "example 3".
 !---Construct operator
 NULLIFY(lmop)
-CALL oft_lag_vgetmop(ML_oft_vlagrange%current_level,lmop,'none')
+CALL oft_lag_vgetmop(ML_vlagrange%current_level,lmop,'none')
 !---Setup solver
 CALL create_cg_solver(lminv)
 lminv%A=>lmop
 lminv%its=-2
 CALL create_diag_pre(lminv%pre) ! Setup Preconditioner
 !---Create solver fields
-CALL ML_oft_vlagrange%vec_create(u)
-CALL ML_oft_vlagrange%vec_create(v)
+CALL ML_vlagrange%vec_create(u)
+CALL ML_vlagrange%vec_create(v)
 !---Setup field interpolation
-CALL Bfield%setup(ML_oft_hcurl%current_level,ML_oft_h1%current_level)
+CALL Bfield%setup(hmodes%ML_hcurl%current_level,ff_obj%ML_H1%current_level)
 !---Project field
-CALL oft_lag_vproject(ML_oft_lagrange%current_level,Bfield,v)
+CALL oft_lag_vproject(hmodes%ML_lagrange%current_level,Bfield,v)
 CALL u%set(0.d0)
 CALL lminv%apply(u,v)
 !---Retrieve local values and save

--- a/src/examples/example4.F90
+++ b/src/examples/example4.F90
@@ -143,18 +143,19 @@ htags(2)='Yinj'
 !!the injector, and \f$ \vec{B}^i_{gffa} \f$ is the plasma component of the inhomogeneous equilibrium field. The
 !!interpolation object \ref taylor::oft_taylor_rinterp "oft_taylor_rinterp" is designed to support this type of field
 !!and is populated once the subfields are computed.
-CALL taylor_vacuum(ff_obj,nh,hcpc,hcpv,htags,hmodes=hmodes)
+CALL ff_obj%setup(nh,hcpc,hcpv,htags)
+CALL taylor_vacuum(ff_obj,hmodes=hmodes)
 CALL taylor_injectors(ff_obj,hmodes,hmodes%hlam(1,hmodes%ML_hcurl%level))
 !---Setup field interpolation object
 fluxes=(/1.d0,0.d0/)
 CALL ff_obj%ML_hcurl_grad%vec_create(Bfield%uvac)
 DO i=1,nh
-  CALL Bfield%uvac%add(1.d0,fluxes(i),ff_obj%hvac(i,ff_obj%ML_hcurl_grad%level)%f)
+  CALL Bfield%uvac%add(1.d0,fluxes(i),ff_obj%hvac(i)%f)
 END DO
 CALL hmodes%ML_hcurl%vec_create(Bfield%ua)
 CALL Bfield%ua%add(0.d0,fr/hmodes%htor(1,hmodes%ML_hcurl%level),hmodes%hffa(1,hmodes%ML_hcurl%level)%f)
 DO i=1,nh
-  CALL Bfield%ua%add(1.d0,fluxes(i),ff_obj%gffa(i,ff_obj%ML_hcurl_grad%level)%f)
+  CALL Bfield%ua%add(1.d0,fluxes(i),ff_obj%gffa(i)%f)
 END DO
 !!\subsection doc_ex4_code_project Project Solution for Plotting
 !!

--- a/src/fem/fem_base.F90
+++ b/src/fem/fem_base.F90
@@ -1514,10 +1514,10 @@ logical :: do_append
 DEBUG_STACK_PUSH
 do_append=.FALSE.
 IF(PRESENT(append))do_append=append
-IF(do_append)THEN
-  IF(.NOT.hdf5_field_exist(filename,fem_idx_path))CALL hdf5_write(fem_idx_ver,filename,fem_idx_path)
-ELSE
-  IF(oft_env%head_proc)THEN
+IF(oft_env%head_proc)THEN
+  IF(do_append)THEN
+    IF(.NOT.hdf5_field_exist(filename,fem_idx_path))CALL hdf5_write(fem_idx_ver,filename,fem_idx_path)
+  ELSE
     CALL hdf5_create_file(filename)
     CALL hdf5_write(fem_idx_ver,filename,fem_idx_path)
   END IF

--- a/src/fem/fem_composite.F90
+++ b/src/fem/fem_composite.F90
@@ -202,8 +202,10 @@ logical :: do_append
 DEBUG_STACK_PUSH
 do_append=.FALSE.
 IF(PRESENT(append))do_append=append
-IF(.NOT.do_append)THEN
-  IF(oft_env%head_proc)THEN
+IF(oft_env%head_proc)THEN
+  IF(do_append)THEN
+    IF(.NOT.hdf5_field_exist(filename,fem_idx_path))CALL hdf5_write(fem_idx_ver,filename,fem_idx_path)
+  ELSE
     CALL hdf5_create_file(filename)
     CALL hdf5_write(fem_idx_ver,filename,fem_idx_path)
   END IF

--- a/src/fem/fem_composite.F90
+++ b/src/fem/fem_composite.F90
@@ -12,7 +12,8 @@
 MODULE fem_composite
 USE oft_base
 USE oft_stitching, ONLY: oft_seam, seam_list
-USE oft_io, ONLY: hdf5_rst, hdf5_write, hdf5_read, hdf5_rst_destroy, hdf5_create_file
+USE oft_io, ONLY: hdf5_rst, hdf5_write, hdf5_read, hdf5_rst_destroy, hdf5_create_file, &
+  hdf5_field_exist
 !---
 USE oft_la_base, ONLY: oft_vector, oft_map, map_list, oft_graph_ptr, &
   oft_matrix, oft_matrix_ptr, oft_local_mat, oft_ml_vecspace

--- a/src/physics/taylor.F90
+++ b/src/physics/taylor.F90
@@ -65,42 +65,93 @@ contains
   !> Reconstruct field
   procedure :: interp => taylor_rinterp
 end type oft_taylor_rinterp
-!---Force-free eigenmode variables
-integer(i4) :: taylor_minlev=-1 !< Lowest FE level for MG solvers
-integer(i4) :: taylor_nm=0 !< Number of force-free fields to be computed
-real(r8), pointer, dimension(:,:) :: taylor_hlam => NULL() !< Homogeneous force-free lambdas
-real(r8), pointer, dimension(:,:) :: taylor_htor => NULL() !< Homogeneous force-free toroidal fluxes
-type(oft_vector_ptr), pointer, dimension(:,:) :: taylor_hffa => NULL() !< Homogeneous force-free fields
-!---Inhomogeneous fields
-integer(i4) :: taylor_nh=2 !< Number of jump planes in current geometry
-real(r8), pointer, dimension(:,:)  :: taylor_hcpc => NULL() !< Center points of jump planes
-real(r8), pointer, dimension(:,:)  :: taylor_hcpv => NULL() !< Normal vectors for jump planes
-real(r8)  :: taylor_jtol = 1.d-6 !< Tolerance for identifying edges on jump plane
+!---------------------------------------------------------------------------
+!> Force-free eigenmode object
+!---------------------------------------------------------------------------
+type, public :: oft_taylor_eigs
+  integer(i4) :: minlev = -1 !< Lowest FE level for MG solvers
+  integer(i4) :: nm = 0 !< Number of force-free fields to be computed
+  real(r8), pointer, dimension(:,:) :: hlam => NULL() !< Homogeneous force-free lambdas
+  real(r8), pointer, dimension(:,:) :: htor => NULL() !< Homogeneous force-free toroidal fluxes
+  type(oft_vector_ptr), pointer, dimension(:,:) :: hffa => NULL() !< Homogeneous force-free fields
+  type(oft_hcurl_orthog), pointer :: orthog => NULL()
+  TYPE(oft_ml_fem_type), POINTER :: ML_hcurl => NULL()
+  TYPE(oft_ml_fem_type), POINTER :: ML_lagrange => NULL()
+CONTAINS
+  PROCEDURE :: setup => eigs_setup
+end type oft_taylor_eigs
 integer(i4), parameter :: taylor_tag_size = 4 !< Size of  jump planes character tags
-character(LEN=taylor_tag_size), pointer, dimension(:) :: taylor_htag => NULL() !< Injector names
-type(oft_vector_ptr), pointer, dimension(:,:) :: taylor_hvac => NULL() !< Vacuum magnetic fields
-type(oft_vector_ptr), pointer, dimension(:,:) :: taylor_hcur => NULL() !< Inhomogeneous source fields
-type(oft_vector_ptr), pointer, dimension(:,:) :: taylor_gffa => NULL() !< Inhomogeneous force-free fields
-!---
-TYPE(oft_ml_fem_type), TARGET :: ML_oft_lagrange
-TYPE(oft_ml_fem_type), TARGET :: ML_oft_h1,ML_h1grad
-TYPE(oft_ml_fem_type), TARGET :: ML_oft_hcurl
-TYPE(oft_ml_fem_comp_type), TARGET :: ML_hcurl_grad,ML_oft_vlagrange
-!---General
-logical :: taylor_rst=.TRUE. !< Save solutions to data files
+!---------------------------------------------------------------------------
+!> Force-free vacuum source object
+!---------------------------------------------------------------------------
+type, public :: oft_taylor_inhomo
+  integer(i4) :: minlev = -1 !< Lowest FE level for MG solvers
+  integer(i4) :: nh = 2 !< Number of jump planes in current geometry
+  real(r8)  :: jtol = 1.d-6 !< Tolerance for identifying edges on jump plane
+  real(r8), pointer, dimension(:,:)  :: hcpc => NULL() !< Center points of jump planes
+  real(r8), pointer, dimension(:,:)  :: hcpv => NULL() !< Normal vectors for jump planes
+  character(LEN=taylor_tag_size), pointer, dimension(:) :: htag => NULL() !< Injector names
+  type(oft_vector_ptr), pointer, dimension(:,:) :: hvac => NULL() !< Vacuum magnetic fields
+  type(oft_vector_ptr), pointer, dimension(:,:) :: hcur => NULL() !< Inhomogeneous source fields
+  type(oft_vector_ptr), pointer, dimension(:,:) :: gffa => NULL() !< Inhomogeneous force-free fields
+  TYPE(oft_ml_fem_type), POINTER :: ML_lagrange => NULL()
+  TYPE(oft_ml_fem_type), POINTER :: ML_h1 => NULL()
+  TYPE(oft_ml_fem_type), POINTER :: ML_h1grad => NULL()
+  TYPE(oft_ml_fem_type), POINTER :: ML_hcurl => NULL()
+  TYPE(oft_ml_fem_comp_type), POINTER :: ML_hcurl_grad => NULL()
+CONTAINS
+  PROCEDURE :: setup => ff_setup
+end type oft_taylor_inhomo
 contains
+!---------------------------------------------------------------------------
+!> Setup eigenmodes object
+!---------------------------------------------------------------------------
+subroutine eigs_setup(self,ML_hcurl,ML_lagrange,minlev)
+class(oft_taylor_eigs), intent(inout) :: self
+TYPE(oft_ml_fem_type), TARGET, INTENT(in) :: ML_hcurl
+TYPE(oft_ml_fem_type), TARGET, INTENT(in) :: ML_lagrange
+integer(i4), optional, intent(in) :: minlev
+self%ML_hcurl=>ML_hcurl
+self%ML_lagrange=>ML_lagrange
+!
+self%minlev=-1
+IF(PRESENT(minlev))self%minlev=minlev
+IF(self%minlev<0)self%minlev=self%ML_hcurl%level
+end subroutine eigs_setup
+!---------------------------------------------------------------------------
+!> Setup eigenmodes object
+!---------------------------------------------------------------------------
+subroutine ff_setup(self,ML_hcurl,ML_h1,ML_hcurl_grad,ML_h1grad,ML_lagrange,minlev)
+class(oft_taylor_inhomo), intent(inout) :: self
+TYPE(oft_ml_fem_type), TARGET, INTENT(in) :: ML_hcurl
+TYPE(oft_ml_fem_type), TARGET, INTENT(in) :: ML_h1
+TYPE(oft_ml_fem_comp_type), TARGET, INTENT(in) :: ML_hcurl_grad
+TYPE(oft_ml_fem_type), TARGET, INTENT(in) :: ML_h1grad
+TYPE(oft_ml_fem_type), TARGET, INTENT(in) :: ML_lagrange
+integer(i4), optional, intent(in) :: minlev
+self%ML_hcurl=>ML_hcurl
+self%ML_h1=>ML_h1
+self%ML_hcurl_grad=>ML_hcurl_grad
+self%ML_h1grad=>ML_h1grad
+self%ML_lagrange=>ML_lagrange
+!
+self%minlev=-1
+IF(PRESENT(minlev))self%minlev=minlev
+IF(self%minlev<0)self%minlev=self%ML_hcurl%level
+end subroutine ff_setup
 !---------------------------------------------------------------------------
 !> Compute 'taylor_nm' Force-Free eignemodes.
 !!
 !! @note When `taylor_rst=.TRUE.` one restart files will be generated for
 !! each computed mode on each MG level `hffa_*.rst`
 !---------------------------------------------------------------------------
-subroutine taylor_hmodes(nm)
+subroutine taylor_hmodes(self,nm,rst_filename)
+type(oft_taylor_eigs), intent(inout) :: self
 integer(i4), optional, intent(in) :: nm !< Number of modes to compute (optional: 1)
+character(LEN=OFT_PATH_SLEN), optional, intent(in) :: rst_filename
 class(oft_vector), pointer :: u,tmp
 !--- Taylor eigenvalue solver
 TYPE(oft_native_cg_eigsolver) :: eigsolver
-type(oft_hcurl_orthog), target :: orthog
 !--- Divergence cleaner
 CLASS(oft_solver), POINTER :: linv => NULL()
 TYPE(oft_hcurl_divout) :: divout
@@ -116,9 +167,8 @@ class(oft_matrix), pointer :: lop => NULL()
 type(oft_hcurl_cinterp) :: Bfield
 real(r8) :: alam,elapsed_time
 integer(i4) :: i,j,k,ierr
-character(2) :: pnum,mnum
-character(40) :: filename
-logical :: rst
+character(LEN=16) :: field_name
+logical :: save_rst
 type(oft_timer) :: mytimer
 type(oft_hcurl_zerob), target :: hcurl_zerob
 type(oft_lag_zerob), target :: lag_zerob
@@ -126,10 +176,12 @@ type(oft_lag_zerob), target :: lag_zerob
 DEBUG_STACK_PUSH
 IF(PRESENT(nm))THEN
   IF(nm<=0.OR.nm>20)CALL oft_abort("Invalid number of modes requested.", "taylor_hmodes", __FILE__)
-  taylor_nm=nm
+  self%nm=nm
 ELSE
-  taylor_nm=1
+  self%nm=1
 END IF
+save_rst=.FALSE.
+IF(PRESENT(rst_filename))save_rst=.TRUE.
 IF(oft_env%head_proc)THEN
   WRITE(*,*)
   WRITE(*,'(A)')'============================'
@@ -138,52 +190,52 @@ IF(oft_env%head_proc)THEN
   WRITE(*,*)
   CALL mytimer%tick
 END IF
-IF(taylor_minlev<0)taylor_minlev=ML_oft_hcurl%level
 !---Allocate storage
-ALLOCATE(taylor_hffa(taylor_nm,ML_oft_hcurl%level))
-ALLOCATE(taylor_hlam(taylor_nm,ML_oft_hcurl%level))
-ALLOCATE(taylor_htor(taylor_nm,ML_oft_hcurl%level))
+ALLOCATE(self%hffa(self%nm,self%ML_hcurl%level))
+ALLOCATE(self%hlam(self%nm,self%ML_hcurl%level))
+ALLOCATE(self%htor(self%nm,self%ML_hcurl%level))
 !---Setup orthogonalization
-orthog%ML_hcurl_rep=>ML_oft_hcurl
-orthog%orthog=>taylor_hffa
+ALLOCATE(self%orthog)
+self%orthog%ML_hcurl_rep=>self%ML_hcurl
+self%orthog%orthog=>self%hffa
 !---------------------------------------------------------------------------
 ! Create ML Matrices
 !---------------------------------------------------------------------------
-nlevels_wop=ML_oft_hcurl%nlevels-taylor_minlev+1
-nlevels_lop=ML_oft_lagrange%ml_mesh%mgdim-taylor_minlev+1
+nlevels_wop=self%ML_hcurl%nlevels-self%minlev+1
+nlevels_lop=self%ML_lagrange%ml_mesh%mgdim-self%minlev+1
 ALLOCATE(ml_wop(nlevels_wop),ml_lop(nlevels_lop))
 DO i=1,nlevels_wop
-  CALL ML_oft_hcurl%set_level(taylor_minlev+i-1)
+  CALL self%ML_hcurl%set_level(self%minlev+i-1)
   NULLIFY(ml_wop(i)%M)
-  CALL oft_hcurl_getwop(ML_oft_hcurl%current_level,ml_wop(i)%M,'zerob')
-  IF(ML_oft_hcurl%level<=ML_oft_lagrange%ml_mesh%mgdim)THEN
-    CALL ML_oft_lagrange%set_level(ML_oft_hcurl%level)
+  CALL oft_hcurl_getwop(self%ML_hcurl%current_level,ml_wop(i)%M,'zerob')
+  IF(self%ML_hcurl%level<=self%ML_lagrange%ml_mesh%mgdim)THEN
+    CALL self%ML_lagrange%set_level(self%ML_hcurl%level)
     NULLIFY(ml_lop(i)%M)
-    CALL oft_lag_getlop(ML_oft_lagrange%current_level,ml_lop(i)%M,"zerob")
+    CALL oft_lag_getlop(self%ML_lagrange%current_level,ml_lop(i)%M,"zerob")
   END IF
 END DO
-CALL ML_oft_hcurl%set_level(ML_oft_hcurl%level)
+CALL self%ML_hcurl%set_level(self%ML_hcurl%level)
 !---------------------------------------------------------------------------
 ! Loop over desired number of modes
 !---------------------------------------------------------------------------
-hcurl_zerob%ML_hcurl_rep=>ML_oft_hcurl
-lag_zerob%ML_lag_rep=>ML_oft_lagrange
-do k=1,taylor_nm
-  orthog%nm=k-1
-  call ML_oft_hcurl%set_level(taylor_minlev)
+hcurl_zerob%ML_hcurl_rep=>self%ML_hcurl
+lag_zerob%ML_lag_rep=>self%ML_lagrange
+do k=1,self%nm
+  self%orthog%nm=k-1
+  call self%ML_hcurl%set_level(self%minlev)
   !---Loop over levels for each mode
-  do i=taylor_minlev,ML_oft_hcurl%nlevels
+  do i=self%minlev,self%ML_hcurl%nlevels
     !---Build level field
-    call ML_oft_hcurl%set_level(i)
-    call ML_oft_hcurl%vec_create(taylor_hffa(k,i)%f,i)
+    call self%ML_hcurl%set_level(i)
+    call self%ML_hcurl%vec_create(self%hffa(k,i)%f,i)
     !---Alias to general field
-    u=>taylor_hffa(k,i)%f
-    if((i>taylor_minlev).AND.(ML_oft_hcurl%level==ML_oft_hcurl%blevel+1))cycle
+    u=>self%hffa(k,i)%f
+    if((i>self%minlev).AND.(self%ML_hcurl%level==self%ML_hcurl%blevel+1))cycle
     !---Setup Solver
-    wop=>ml_wop(i-taylor_minlev+1)%M
-    orthog%wop=>wop
+    wop=>ml_wop(i-self%minlev+1)%M
+    self%orthog%wop=>wop
     NULLIFY(kop)
-    CALL oft_hcurl_getkop(ML_oft_hcurl%current_level,kop,"zerob")
+    CALL oft_hcurl_getkop(self%ML_hcurl%current_level,kop,"zerob")
 !---------------------------------------------------------------------------
 ! Create eigenvalue solver
 !---------------------------------------------------------------------------
@@ -191,10 +243,10 @@ do k=1,taylor_nm
     eigsolver%M=>kop
     eigsolver%its=-2
     eigsolver%bc=>hcurl_zerob
-    eigsolver%orthog=>orthog
+    eigsolver%orthog=>self%orthog
     IF(k>1)THEN
       eigsolver%nrestarts=4
-      IF(i==taylor_minlev)THEN
+      IF(i==self%minlev)THEN
         eigsolver%ninner=1000
       ELSE
         eigsolver%ninner=100
@@ -203,45 +255,44 @@ do k=1,taylor_nm
 !---------------------------------------------------------------------------
 ! Setup preconditioner
 !---------------------------------------------------------------------------
-    if(i==taylor_minlev)then ! Lowest level uses diag precond
+    if(i==self%minlev)then ! Lowest level uses diag precond
       !---Setup Preconditioner
       CALL create_diag_pre(eigsolver%pre)
       call u%set(1.d0,random=.TRUE.) ! Initialize guess
     else ! Higher levels use MG
-      CALL hcurl_getwop_pre(ML_oft_hcurl,eigsolver%pre,ml_wop,nlevels=i-taylor_minlev+1)
+      CALL hcurl_getwop_pre(self%ML_hcurl,eigsolver%pre,ml_wop,nlevels=i-self%minlev+1)
       SELECT TYPE(this=>eigsolver%pre)
         CLASS IS(oft_ml_precond)
-          call ML_oft_hcurl%set_level(i-1)
-          call this%ml_vecspace%interp(taylor_hffa(k,i-1)%f,u)
+          call self%ML_hcurl%set_level(i-1)
+          call this%ml_vecspace%interp(self%hffa(k,i-1)%f,u)
         CLASS DEFAULT
-          CALL oft_abort("Invalid ML preconditioner","taylor_hmodes",__FILE__)
+          CALL oft_abort("Invalid ML preconditioner","self%hmodes",__FILE__)
       END SELECT
-      ! call hcurl_interp(taylor_hffa(k,i-1)%f,u)
+      ! call hcurl_interp(self%hffa(k,i-1)%f,u)
       if(k/=1)call u%set(1.d0,random=.TRUE.)
     end if
 !---------------------------------------------------------------------------
 ! Initialize guess
 !---------------------------------------------------------------------------
-    ! if(i==taylor_minlev)then
+    ! if(i==self%minlev)then
     !   call u%set(1.d0,random=.TRUE.)
     ! else
-    !   call hcurl_interp(taylor_hffa(k,i-1)%f,u)
+    !   call hcurl_interp(self%hffa(k,i-1)%f,u)
     !   if(k/=1)call u%set(1.d0,random=.TRUE.)
     !   if(ML_oft_hcurl%level==ML_oft_hcurl%blevel+1)cycle
     ! end if
-    if(taylor_rst)then
-      write(pnum,'(I2.2)')ML_oft_hcurl%current_level%order
-      write(mnum,'(I2.2)')k
-      filename='hffa_r'//ML_oft_hcurl%ml_mesh%rlevel//'_p'//pnum//'_m'//mnum//'.rst'
-      if(oft_file_exist(filename))then
-        CALL ML_oft_hcurl%current_level%vec_load(u,filename,'hffa')
+    if(save_rst)then
+      if(oft_file_exist(rst_filename))then
+        WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'hffa_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_m',k
+        WRITE(*,*)field_name
+        IF(hdf5_field_exist(rst_filename,field_name))CALL self%ML_hcurl%current_level%vec_load(u,rst_filename,field_name)
       end if
     end if
 !---------------------------------------------------------------------------
 ! Solve
 !---------------------------------------------------------------------------
     CALL hcurl_zerob%apply(u) ! Apply BC
-    CALL eigsolver%apply(u,taylor_hlam(k,i))
+    CALL eigsolver%apply(u,self%hlam(k,i))
     CALL eigsolver%pre%delete
     DEALLOCATE(eigsolver%pre)
     CALL eigsolver%delete
@@ -249,29 +300,29 @@ do k=1,taylor_nm
     DEALLOCATE(kop)
     !---
     Bfield%u=>u
-    CALL Bfield%setup(ML_oft_hcurl%current_level)
-    taylor_htor(k,i) = tfluxfun(Bfield%mesh,Bfield,ML_oft_hcurl%current_level%quad%order)
+    CALL Bfield%setup(self%ML_hcurl%current_level)
+    self%htor(k,i) = tfluxfun(Bfield%mesh,Bfield,self%ML_hcurl%current_level%quad%order)
     CALL Bfield%delete
 !---------------------------------------------------------------------------
 ! Create divergence cleaner
 !---------------------------------------------------------------------------
-    CALL ML_oft_lagrange%set_level(MIN(ML_oft_hcurl%level,ML_oft_lagrange%ml_mesh%mgdim))
+    CALL self%ML_lagrange%set_level(MIN(self%ML_hcurl%level,self%ML_lagrange%ml_mesh%mgdim))
     IF(nlevels_lop<=0)THEN
       NULLIFY(lop)
-      CALL oft_lag_getlop(ML_oft_lagrange%current_level,lop,"zerob")
+      CALL oft_lag_getlop(self%ML_lagrange%current_level,lop,"zerob")
     ELSE
-      lop=>ml_lop(ML_oft_lagrange%level-taylor_minlev+1)%M
+      lop=>ml_lop(self%ML_lagrange%level-self%minlev+1)%M
     END IF
-    if(ML_oft_lagrange%level<=taylor_minlev)then ! Lowest level uses diag precond
+    if(self%ML_lagrange%level<=self%minlev)then ! Lowest level uses diag precond
       CALL create_cg_solver(linv)
       CALL create_diag_pre(linv%pre)
     else ! Higher levels use MG
       CALL create_cg_solver(linv, force_native=.TRUE.)
-      CALL lag_getlop_pre(ML_oft_lagrange,linv%pre,ml_lop,nlevels=ML_oft_lagrange%level-taylor_minlev+1)
+      CALL lag_getlop_pre(self%ML_lagrange,linv%pre,ml_lop,nlevels=self%ML_lagrange%level-self%minlev+1)
     end if
     linv%A=>lop
     linv%its=-2
-    CALL divout%setup(ML_oft_hcurl,ML_oft_lagrange,bc='zero',solver=linv)
+    CALL divout%setup(self%ML_hcurl,self%ML_lagrange,bc='zero',solver=linv)
     ! divout%ML_hcurl_rep=>ML_oft_hcurl
     ! divout%ML_lag_rep=>ML_oft_lagrange
     ! divout%solver=>linv
@@ -286,22 +337,20 @@ do k=1,taylor_nm
 !---------------------------------------------------------------------------
 ! Write restart files
 !---------------------------------------------------------------------------
-    if(taylor_rst)then
-      write(pnum,'(I2.2)')ML_oft_hcurl%current_level%order
-      write(mnum,'(I2.2)')k
-      filename='hffa_r'//ML_oft_hcurl%ml_mesh%rlevel//'_p'//pnum//'_m'//mnum//'.rst'
-      if(.NOT.oft_file_exist(filename))then
+    if(save_rst)then
+      if(.NOT.oft_file_exist(rst_filename))then
         CALL oft_mpi_barrier(ierr)
-        CALL ML_oft_hcurl%current_level%vec_save(u,filename,'hffa')
+        WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'hffa_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_m',k
+        CALL self%ML_hcurl%current_level%vec_save(u,rst_filename,field_name)
       end if
     end if
   end do ! End level loop
 end do ! End mode loop
 if(oft_env%head_proc)then
-  DO i=taylor_minlev,ML_oft_hcurl%nlevels
+  DO i=self%minlev,self%ML_hcurl%nlevels
     WRITE(*,'(2X,A,I3)')'Level =',i
-    DO k=1,taylor_nm
-      WRITE(*,'(4X,A,I4,A,ES14.6)')'Mode =',k,'   Lambda = ',taylor_hlam(k,i)
+    DO k=1,self%nm
+      WRITE(*,'(4X,A,I4,A,ES14.6)')'Mode =',k,'   Lambda = ',self%hlam(k,i)
     END DO
   END DO
   elapsed_time=mytimer%tock()
@@ -320,7 +369,7 @@ DO i=1,nlevels_wop
   END IF
 END DO
 DEALLOCATE(ml_wop,ml_lop)
-CALL ML_oft_lagrange%set_level(ML_oft_lagrange%nlevels)
+CALL self%ML_lagrange%set_level(self%ML_lagrange%nlevels)
 DEBUG_STACK_POP
 end subroutine taylor_hmodes
 !---------------------------------------------------------------------------
@@ -329,12 +378,15 @@ end subroutine taylor_hmodes
 !! @note When `taylor_rst=.TRUE.` two restart files will be generated for
 !! each jump plane `hvac_*.rst` and `hcur_*.rst`
 !---------------------------------------------------------------------------
-subroutine taylor_vacuum(nh,hcpc,hcpv,htags,energy)
+subroutine taylor_vacuum(self,nh,hcpc,hcpv,htags,energy,hmodes,rst_filename)
+type(oft_taylor_inhomo), intent(inout) :: self
 integer(i4), intent(in) :: nh !< Number of jump planes
 real(r8), intent(in) :: hcpc(3,nh) !< Jump plane center possitions [3,nh]
 real(r8), intent(in) :: hcpv(3,nh) !< Jump plane normal vectors [3,nh]
 character(LEN=taylor_tag_size), optional, intent(in) :: htags(nh) !< Names for each jump plane [LEN=taylor_tag_size,nh] (optional)
 real(r8), optional, intent(out) :: energy(nh) !< Vacuum energy for each jump plan (optional)
+type(oft_taylor_eigs), optional, intent(inout) :: hmodes
+character(LEN=OFT_PATH_SLEN), optional, intent(in) :: rst_filename
 !---H(Curl) full space divergence cleaner
 CLASS(oft_solver), POINTER :: linv => NULL()
 TYPE(oft_hcurl_grad_divout) :: divout
@@ -360,56 +412,54 @@ class(oft_vector), pointer :: u,b,tmp
 real(r8), pointer, dimension(:) :: vals => NULL()
 real(r8) :: alam,venergy
 integer(i4) :: i,j,k,nlevels,ierr
-logical :: rst=.FALSE.
-character(2) :: pnum,mnum
-character(40) :: filename
+logical :: have_rst,save_rst
+character(LEN=16) :: field_name
 type(oft_hcurl_zerob), target :: hcurl_zerob
 type(oft_lag_zerob), target :: lag_zerob
 DEBUG_STACK_PUSH
 NULLIFY(lop,lop_lag,mop,mop_hcurl,wop)
 NULLIFY(ml_int,ml_lop,ml_wop)
 !---Create taylor module variables
-taylor_nh=nh
-ALLOCATE(taylor_hcpc(3,taylor_nh),taylor_hcpv(3,taylor_nh))
-taylor_hcpc=hcpc
-taylor_hcpv=hcpv
-ALLOCATE(taylor_htag(taylor_nh))
+self%nh=nh
+ALLOCATE(self%hcpc(3,self%nh),self%hcpv(3,self%nh))
+self%hcpc=hcpc
+self%hcpv=hcpv
+ALLOCATE(self%htag(self%nh))
 IF(PRESENT(htags))THEN
-  taylor_htag=htags
+  self%htag=htags
 ELSE
-  DO i=1,taylor_nh
-    WRITE(taylor_htag(i),'(A3,I1)')'INJ',i
+  DO i=1,self%nh
+    WRITE(self%htag(i),'(A3,I1)')'INJ',i
   END DO
 END IF
-hcurl_zerob%ML_hcurl_rep=>ML_oft_hcurl
-lag_zerob%ML_lag_rep=>ML_oft_lagrange
+hcurl_zerob%ML_hcurl_rep=>self%ML_hcurl
+lag_zerob%ML_lag_rep=>self%ML_lagrange
 !---Loop over cut planes
-IF(taylor_rst)THEN
-  rst=.TRUE.
-  DO i=1,taylor_nh
-    WRITE(pnum,'(I2.2)')ML_oft_hcurl%current_level%order
-    WRITE(mnum,'(I2.2)')i
-    filename='hvac_r'//ML_oft_hcurl%ml_mesh%rlevel//'_p'//pnum//'_h'//mnum//'.rst'
-    rst=rst.AND.oft_file_exist(filename)
-    filename='hcur_r'//ML_oft_hcurl%ml_mesh%rlevel//'_p'//pnum//'_h'//mnum//'.rst'
-    rst=rst.AND.oft_file_exist(filename)
+save_rst=.FALSE.
+IF(PRESENT(rst_filename))save_rst=.TRUE.
+IF(save_rst)THEN
+  have_rst=oft_file_exist(TRIM(rst_filename))
+  DO i=1,self%nh
+    WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'hvac_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_h',i
+    have_rst=have_rst.AND.hdf5_field_exist(rst_filename,field_name)
+    WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'hcur_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_h',i
+    have_rst=have_rst.AND.hdf5_field_exist(rst_filename,field_name)
   END DO
 ELSE
-  rst=.FALSE.
+  have_rst=.FALSE.
 END IF
-IF(taylor_minlev<0)taylor_minlev=ML_oft_hcurl%nlevels
-IF(.NOT.rst)THEN
+IF(.NOT.have_rst)THEN
 !---------------------------------------------------------------------------
 ! Setup H^1::LOP preconditioner
 !---------------------------------------------------------------------------
-  if(taylor_minlev==ML_oft_h1%nlevels-1)then ! Lowest level uses diag precond
-    CALL oft_h1_getlop(ML_oft_h1%current_level,lop,'grnd')
+  if(self%minlev==self%ML_h1%nlevels-1)then ! Lowest level uses diag precond
+    CALL oft_h1_getlop(self%ML_h1%current_level,lop,'grnd')
     CALL create_cg_solver(linv)
     CALL create_diag_pre(linv%pre)
   else ! Nested levels use MG
     CALL create_cg_solver(linv, force_native=.TRUE.)
-    CALL h1_getlop_pre(ML_oft_h1,linv%pre,ml_lop,'grnd',nlevels=ML_oft_h1%nlevels-taylor_minlev+1)
-      lop=>ml_lop(ML_oft_h1%nlevels-taylor_minlev+1)%M
+    CALL h1_getlop_pre(self%ML_h1,linv%pre,ml_lop,'grnd',nlevels=self%ML_h1%nlevels-self%minlev+1)
+      lop=>ml_lop(self%ML_h1%nlevels-self%minlev+1)%M
   end if
 !---------------------------------------------------------------------------
 ! Create divergence cleaner
@@ -417,7 +467,7 @@ IF(.NOT.rst)THEN
   linv%A=>lop
   linv%its=-2
   ! divout%solver=>linv
-  CALL divout%setup(ML_hcurl_grad,'grnd',solver=linv)
+  CALL divout%setup(self%ML_hcurl_grad,'grnd',solver=linv)
 ELSE
   CALL create_cg_solver(linv)
   CALL create_diag_pre(linv%pre)
@@ -426,13 +476,13 @@ END IF
 ! Setup H(Curl)::WOP preconditioner
 !---------------------------------------------------------------------------
 CALL create_cg_solver(winv, force_native=.TRUE.)
-IF((taylor_minlev==ML_oft_hcurl%level).OR.rst)THEN ! Lowest level uses diag precond
+IF((self%minlev==self%ML_hcurl%level).OR.have_rst)THEN ! Lowest level uses diag precond
   NULLIFY(wop)
-  CALL oft_hcurl_getwop(ML_oft_hcurl%current_level,wop,'zerob')
+  CALL oft_hcurl_getwop(self%ML_hcurl%current_level,wop,'zerob')
   CALL create_diag_pre(winv%pre)
 ELSE ! Nested levels use MG
-  CALL hcurl_getwop_pre(ML_oft_hcurl,winv%pre,ml_wop,nlevels=ML_oft_hcurl%level-taylor_minlev+1)
-  wop=>ml_wop(ML_oft_hcurl%level-taylor_minlev+1)%M
+  CALL hcurl_getwop_pre(self%ML_hcurl,winv%pre,ml_wop,nlevels=self%ML_hcurl%level-self%minlev+1)
+  wop=>ml_wop(self%ML_hcurl%level-self%minlev+1)%M
 END IF
 !---------------------------------------------------------------------------
 ! Create H(Curl)::WOP solver
@@ -449,8 +499,8 @@ END SELECT
 !---------------------------------------------------------------------------
 ! Create H(Curl) divergence cleaner
 !---------------------------------------------------------------------------
-CALL ML_oft_lagrange%set_level(MIN(ML_oft_hcurl%level,ML_oft_lagrange%ml_mesh%mgdim))
-CALL oft_lag_getlop(ML_oft_lagrange%current_level,lop_lag,"zerob")
+CALL self%ML_lagrange%set_level(MIN(self%ML_hcurl%level,self%ML_lagrange%ml_mesh%mgdim))
+CALL oft_lag_getlop(self%ML_lagrange%current_level,lop_lag,"zerob")
 CALL create_cg_solver(linv_lag)
 linv_lag%A=>lop_lag
 !linv_lag%its=-2
@@ -458,43 +508,43 @@ CALL create_diag_pre(linv_lag%pre)
 linv_lag%its=40
 hcurl_divout%solver=>linv_lag
 ! hcurl_divout%bc=>lag_zerob
-CALL hcurl_divout%setup(ML_oft_hcurl,ML_oft_lagrange,bc='zero',solver=linv_lag)
+CALL hcurl_divout%setup(self%ML_hcurl,self%ML_lagrange,bc='zero',solver=linv_lag)
 hcurl_divout%app_freq=2
-CALL oft_hcurl_getmop(ML_oft_hcurl%current_level,mop_hcurl,'zerob')
+CALL oft_hcurl_getmop(self%ML_hcurl%current_level,mop_hcurl,'zerob')
 hcurl_divout%mop=>mop_hcurl
 !---------------------------------------------------------------------------
 !
 !---------------------------------------------------------------------------
 NULLIFY(tmp)
 !---Get H(Curl) + Grad(H^1) mass matrix
-CALL hcurl_grad_getmop(ML_hcurl_grad%current_level,mop,'none')
+CALL hcurl_grad_getmop(self%ML_hcurl_grad%current_level,mop,'none')
 !---Allocate vacuum and current field containers
-ALLOCATE(taylor_hvac(taylor_nh,ML_hcurl_grad%nlevels))
-ALLOCATE(taylor_hcur(taylor_nh,ML_hcurl_grad%nlevels))
+ALLOCATE(self%hvac(self%nh,self%ML_hcurl_grad%nlevels))
+ALLOCATE(self%hcur(self%nh,self%ML_hcurl_grad%nlevels))
 !---Create temporary H(Curl) vector
-CALL ML_oft_hcurl%vec_create(b)
+CALL self%ML_hcurl%vec_create(b)
 !---Loop over cut planes
-DO i=1,taylor_nh
+DO i=1,self%nh
 !---------------------------------------------------------------------------
 ! Compute vacuum fields
 !---------------------------------------------------------------------------
   !---Setup level fields
-  CALL ML_hcurl_grad%vec_create(taylor_hvac(i,ML_hcurl_grad%level)%f)
-  u=>taylor_hvac(i,ML_hcurl_grad%level)%f
+  CALL self%ML_hcurl_grad%vec_create(self%hvac(i,self%ML_hcurl_grad%level)%f)
+  u=>self%hvac(i,self%ML_hcurl_grad%level)%f
   IF(.NOT.ASSOCIATED(tmp))CALL u%new(tmp)
-  rst=.FALSE.
-  IF(taylor_rst)THEN
-    WRITE(pnum,'(I2.2)')ML_oft_hcurl%current_level%order
-    WRITE(mnum,'(I2.2)')i
-    filename='hvac_r'//ML_oft_hcurl%ml_mesh%rlevel//'_p'//pnum//'_h'//mnum//'.rst'
-    IF(oft_file_exist(filename))THEN
-      CALL ML_hcurl_grad%current_level%vec_load(u,filename,'hvac')
-      rst=.TRUE.
+  have_rst=.FALSE.
+  IF(save_rst)THEN
+    IF(oft_file_exist(rst_filename))THEN
+      WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'hvac_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_h',i
+      IF(hdf5_field_exist(rst_filename,field_name))THEN
+        CALL self%ML_hcurl_grad%current_level%vec_load(u,rst_filename,field_name)
+        have_rst=.TRUE.
+      END IF
     END IF
   END IF
   !---Compute jump and solve
-  IF(.NOT.rst)THEN
-    CALL hcurl_grad_mc(ML_oft_hcurl%ml_mesh%mesh,u,taylor_hcpc(:,i),taylor_hcpv(:,i),taylor_jtol)
+  IF(.NOT.have_rst)THEN
+    CALL hcurl_grad_mc(self%ML_hcurl%ml_mesh%mesh,u,self%hcpc(:,i),self%hcpv(:,i),self%jtol)
     venergy=u%dot(u)
     IF(venergy<1.d-12)CALL oft_abort('Plane does not intersect mesh.','taylor_vacuum',__FILE__)
     divout%pm=oft_env%pm
@@ -503,13 +553,11 @@ DO i=1,taylor_nh
 !---------------------------------------------------------------------------
 ! Write restart file
 !---------------------------------------------------------------------------
-  IF(taylor_rst)THEN
-    WRITE(pnum,'(I2.2)')ML_oft_hcurl%current_level%order
-    WRITE(mnum,'(I2.2)')i
-    filename='hvac_r'//ML_oft_hcurl%ml_mesh%rlevel//'_p'//pnum//'_h'//mnum//'.rst'
-    IF(.NOT.oft_file_exist(filename))THEN
+  IF(save_rst)THEN
+    IF(.NOT.oft_file_exist(rst_filename))THEN
+      WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'hvac_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_h',i
       CALL oft_mpi_barrier(ierr)
-      CALL ML_hcurl_grad%current_level%vec_save(u,filename,'hvac')
+      CALL self%ML_hcurl_grad%current_level%vec_save(u,rst_filename,field_name)
     END IF
   END IF
   !---Compute field energy
@@ -517,7 +565,7 @@ DO i=1,taylor_nh
   venergy=u%dot(tmp)
   CALL u%scale(1.d0/venergy)
   IF(oft_env%head_proc)THEN
-    WRITE(*,*)'Injector      = ',taylor_htag(i)
+    WRITE(*,*)'Injector      = ',self%htag(i)
     WRITE(*,*)'Vacuum Energy = ',1.d0/venergy
   END IF
   IF(PRESENT(energy))energy(i)=1.d0/venergy
@@ -526,19 +574,19 @@ DO i=1,taylor_nh
 !---------------------------------------------------------------------------
   !---Use vacuum field as source term
   call tmp%scale(1.d0/venergy)
-  call ML_oft_hcurl%vec_create(taylor_hcur(i,ML_oft_hcurl%level)%f)
-  u=>taylor_hcur(i,ML_oft_hcurl%level)%f
-  rst=.FALSE.
-  IF(taylor_rst)THEN
-    WRITE(pnum,'(I2.2)')ML_oft_hcurl%current_level%order
-    WRITE(mnum,'(I2.2)')i
-    filename='hcur_r'//ML_oft_hcurl%ml_mesh%rlevel//'_p'//pnum//'_h'//mnum//'.rst'
-    IF(oft_file_exist(filename))THEN
-      CALL ML_oft_hcurl%current_level%vec_load(u,filename,'hcur')
-      rst=.TRUE.
+  call self%ML_hcurl%vec_create(self%hcur(i,self%ML_hcurl%level)%f)
+  u=>self%hcur(i,self%ML_hcurl%level)%f
+  have_rst=.FALSE.
+  IF(save_rst)THEN
+    IF(oft_file_exist(rst_filename))THEN
+      WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'hcur_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_h',i
+      IF(hdf5_field_exist(rst_filename,field_name))THEN
+        CALL self%ML_hcurl%current_level%vec_load(u,rst_filename,field_name)
+        have_rst=.TRUE.
+      END IF
     END IF
   END IF
-  IF(.NOT.rst)THEN
+  IF(.NOT.have_rst)THEN
     !---Copy H(Curl) subpace into new vector
     CALL b%set(0.d0)
     NULLIFY(vals)
@@ -556,21 +604,21 @@ DO i=1,taylor_nh
   hcurl_divout%pm=.TRUE.
   CALL hcurl_divout%apply(u)
   !---
-  DO j=1,taylor_nm
-    CALL wop%apply(taylor_hffa(j,ML_oft_hcurl%level)%f,b)
-    venergy = u%dot(b)
-    IF(oft_env%head_proc)WRITE(*,'(A,I3,A,E10.3)')'Mode ',j,' Coupling = ',venergy
-  END DO
+  IF(PRESENT(hmodes))THEN
+    DO j=1,hmodes%nm
+      CALL wop%apply(hmodes%hffa(j,self%ML_hcurl%level)%f,b)
+      venergy = u%dot(b)
+      IF(oft_env%head_proc)WRITE(*,'(A,I3,A,E10.3)')'Mode ',j,' Coupling = ',venergy
+    END DO
+  END IF
 !---------------------------------------------------------------------------
 ! Write restart file
 !---------------------------------------------------------------------------
-  IF(taylor_rst)THEN
-    WRITE(pnum,'(I2.2)')ML_oft_hcurl%current_level%order
-    WRITE(mnum,'(I2.2)')i
-    filename='hcur_r'//ML_oft_hcurl%ml_mesh%rlevel//'_p'//pnum//'_h'//mnum//'.rst'
-    IF(.NOT.oft_file_exist(filename))THEN
+  IF(save_rst)THEN
+    IF(.NOT.oft_file_exist(rst_filename))THEN
       CALL oft_mpi_barrier(ierr)
-      CALL ML_oft_hcurl%current_level%vec_save(u,filename,'hcur')
+      WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'hcur_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_h',i
+      CALL self%ML_hcurl%current_level%vec_save(u,rst_filename,field_name)
     END IF
   END IF
 END DO
@@ -608,7 +656,7 @@ CALL linv_lag%pre%delete
 DEALLOCATE(linv_lag%pre)
 CALL linv_lag%delete
 DEALLOCATE(linv_lag)
-CALL ML_oft_lagrange%set_level(ML_oft_lagrange%nlevels)
+CALL self%ML_lagrange%set_level(self%ML_lagrange%nlevels)
 DEBUG_STACK_POP
 end subroutine taylor_vacuum
 !---------------------------------------------------------------------------
@@ -618,8 +666,11 @@ end subroutine taylor_vacuum
 !! @note When `taylor_rst=.TRUE.` one restart files will be generated for
 !! each jump plane `gffa_*.rst`
 !---------------------------------------------------------------------------
-subroutine taylor_injectors(lambda)
+subroutine taylor_injectors(self,hmodes,lambda,rst_filename)
+type(oft_taylor_inhomo), intent(inout) :: self
+type(oft_taylor_eigs), intent(inout) :: hmodes
 real(r8), intent(in) :: lambda !< Desired lambda for force-free state
+character(LEN=OFT_PATH_SLEN), optional, intent(in) :: rst_filename
 CLASS(oft_matrix), POINTER :: lop_lag => NULL()
 TYPE(oft_matrix_ptr), POINTER, DIMENSION(:) :: ml_jmlb => NULL()
 TYPE(oft_matrix_ptr), POINTER, DIMENSION(:) :: ml_wop => NULL()
@@ -634,53 +685,50 @@ CLASS(oft_solver), POINTER :: linv_lag => NULL()
 TYPE(oft_hcurl_divout), TARGET :: hcurl_divout
 !---
 class(oft_vector), pointer :: u,b,tmp
-type(oft_hcurl_orthog), target :: orthog
 real(r8) :: venergy,lam_file
 integer(i4) :: i,k,ierr
-logical :: do_orthog,rst
-character(2) :: pnum,mnum
-character(40) :: filename
+logical :: do_orthog,have_rst,save_rst
+character(LEN=16) :: field_name
 type(oft_hcurl_zerob), target :: hcurl_zerob
 type(oft_lag_zerob), target :: lag_zerob
 DEBUG_STACK_PUSH
-IF(.NOT.ASSOCIATED(taylor_hcpc))CALL oft_abort("Vacuum fields not available", &
+IF(.NOT.ASSOCIATED(self%hcpc))CALL oft_abort("Vacuum fields not available", &
 "taylor_injectors", __FILE__)
-IF(taylor_rst)THEN
-  rst=.TRUE.
-  DO i=1,taylor_nh
-    WRITE(pnum,'(I2.2)')ML_oft_hcurl%current_level%order
-    WRITE(mnum,'(I2.2)')i
-    filename='gffa_r'//ML_oft_hcurl%ml_mesh%rlevel//'_p'//pnum//'_h'//mnum//'.rst'
-    rst=rst.AND.oft_file_exist(filename)
+!
+save_rst=.FALSE.
+IF(PRESENT(rst_filename))save_rst=.TRUE.
+IF(save_rst)THEN
+  have_rst=oft_file_exist(rst_filename)
+  DO i=1,self%nh
+    WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'gffa_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_h',i
+    have_rst=have_rst.AND.hdf5_field_exist(rst_filename,field_name)
   END DO
 ELSE
-  rst=.FALSE.
+  have_rst=.FALSE.
 END IF
-hcurl_zerob%ML_hcurl_rep=>ML_oft_hcurl
-lag_zerob%ML_lag_rep=>ML_oft_lagrange
-IF(taylor_minlev<0)taylor_minlev=ML_oft_hcurl%nlevels
+hcurl_zerob%ML_hcurl_rep=>self%ML_hcurl
+lag_zerob%ML_lag_rep=>self%ML_lagrange
 NULLIFY(mop,kop,wop,jmlb_mat,ml_jmlb)
-IF(.NOT.rst)THEN
+IF(.NOT.have_rst)THEN
   !---Orthogonalize (if within 5% of Taylor state)
   do_orthog=.FALSE.
-  IF(taylor_nm>0)THEN
-    IF(ABS((lambda-taylor_hlam(1,ML_oft_hcurl%level))/taylor_hlam(1,ML_oft_hcurl%level))<5.d-2)THEN
-      CALL oft_hcurl_getwop(ML_oft_hcurl%current_level,wop,'zerob')
-      orthog%orthog=>taylor_hffa
-      orthog%nm=1
-      orthog%wop=>wop
+  IF(hmodes%nm>0)THEN
+    IF(ABS((lambda-hmodes%hlam(1,self%ML_hcurl%level))/hmodes%hlam(1,self%ML_hcurl%level))<5.d-2)THEN
+      CALL oft_hcurl_getwop(self%ML_hcurl%current_level,wop,'zerob')
+      hmodes%orthog%nm=1
+      hmodes%orthog%wop=>wop
       do_orthog=.TRUE.
     END IF
   END IF
 !---------------------------------------------------------------------------
 ! Setup H(Curl)::WOP preconditioner
 !---------------------------------------------------------------------------
-  IF(taylor_minlev==ML_oft_hcurl%nlevels)THEN ! Lowest level uses diag precond
-    CALL oft_hcurl_getjmlb(ML_oft_hcurl%current_level,jmlb_mat,lambda,'zerob')
+  IF(self%minlev==self%ML_hcurl%nlevels)THEN ! Lowest level uses diag precond
+    CALL oft_hcurl_getjmlb(self%ML_hcurl%current_level,jmlb_mat,lambda,'zerob')
     CALL create_diag_pre(jmlb_inv%pre)
   ELSE ! Nested levels use MG
-    CALL hcurl_getjmlb_pre(ML_oft_hcurl,jmlb_inv%pre,ml_jmlb,lambda,nlevels=ML_oft_hcurl%level-taylor_minlev+1)
-    jmlb_mat=>ml_jmlb(ML_oft_hcurl%level-taylor_minlev+1)%M
+    CALL hcurl_getjmlb_pre(self%ML_hcurl,jmlb_inv%pre,ml_jmlb,lambda,nlevels=self%ML_hcurl%level-self%minlev+1)
+    jmlb_mat=>ml_jmlb(self%ML_hcurl%level-self%minlev+1)%M
   END IF
 !---------------------------------------------------------------------------
 ! Create H(Curl)::WOP solver
@@ -695,49 +743,50 @@ END IF
 !---------------------------------------------------------------------------
 ! Create H(Curl) divergence cleaner
 !---------------------------------------------------------------------------
-CALL ML_oft_lagrange%set_level(MIN(ML_oft_hcurl%level,ML_oft_lagrange%ml_mesh%mgdim))
-CALL oft_lag_getlop(ML_oft_lagrange%current_level,lop_lag,"zerob")
+CALL self%ML_lagrange%set_level(MIN(self%ML_hcurl%level,self%ML_lagrange%ml_mesh%mgdim))
+CALL oft_lag_getlop(self%ML_lagrange%current_level,lop_lag,"zerob")
 CALL create_cg_solver(linv_lag)
 linv_lag%A=>lop_lag
 linv_lag%its=-2
 CALL create_diag_pre(linv_lag%pre)
 linv_lag%its=40
 hcurl_divout%solver=>linv_lag
-CALL hcurl_divout%setup(ML_oft_hcurl,ML_oft_lagrange,bc='zero',solver=linv_lag)
+CALL hcurl_divout%setup(self%ML_hcurl,self%ML_lagrange,bc='zero',solver=linv_lag)
 ! hcurl_divout%bc=>lag_zerob
 hcurl_divout%app_freq=10
-CALL oft_hcurl_getmop(ML_oft_hcurl%current_level,mop,'zerob')
+CALL oft_hcurl_getmop(self%ML_hcurl%current_level,mop,'zerob')
 hcurl_divout%mop=>mop
 !jmlb_inv%cleaner=>hcurl_divout
 !---------------------------------------------------------------------------
 !
 !---------------------------------------------------------------------------
-call ML_hcurl_grad%set_level(ML_hcurl_grad%nlevels,propogate=.TRUE.)
+call self%ML_hcurl_grad%set_level(self%ML_hcurl_grad%nlevels,propogate=.TRUE.)
 !---
-call ML_oft_hcurl%vec_create(tmp)
-allocate(taylor_gffa(taylor_nh,ML_hcurl_grad%nlevels))
-IF(.NOT.rst)CALL oft_hcurl_getkop(ML_oft_hcurl%current_level,kop,'zerob')
+call self%ML_hcurl%vec_create(tmp)
+allocate(self%gffa(self%nh,self%ML_hcurl_grad%nlevels))
+IF(.NOT.have_rst)CALL oft_hcurl_getkop(self%ML_hcurl%current_level,kop,'zerob')
 !---
-do i=1,taylor_nh
+do i=1,self%nh
   !---
-  CALL ML_oft_hcurl%vec_create(taylor_gffa(i,ML_hcurl_grad%level)%f)
-  u=>taylor_gffa(i,ML_hcurl_grad%level)%f
-  rst=.FALSE.
-  IF(taylor_rst)THEN
-    WRITE(pnum,'(I2.2)')ML_oft_hcurl%current_level%order
-    WRITE(mnum,'(I2.2)')i
-    filename='gffa_r'//ML_oft_hcurl%ml_mesh%rlevel//'_p'//pnum//'_h'//mnum//'.rst'
-    IF(oft_file_exist(filename))THEN
-      CALL hdf5_read(lam_file,filename,'lambda')
+  CALL self%ML_hcurl%vec_create(self%gffa(i,self%ML_hcurl_grad%level)%f)
+  u=>self%gffa(i,self%ML_hcurl_grad%level)%f
+  have_rst=.FALSE.
+  IF(save_rst)THEN
+    IF(oft_file_exist(rst_filename))THEN
+      lam_file=-1.d99
+      IF(hdf5_field_exist(rst_filename,'lambda'))CALL hdf5_read(lam_file,rst_filename,'lambda')
       IF(ABS(lam_file-lambda)<1.d-5)THEN
-        CALL ML_oft_hcurl%current_level%vec_load(u,filename,'gffa')
-        rst=.TRUE.
+        WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'gffa_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_h',i
+        IF(hdf5_field_exist(rst_filename,field_name))THEN
+          CALL self%ML_hcurl%current_level%vec_load(u,rst_filename,field_name)
+          have_rst=.TRUE.
+        END IF
       END IF
     END IF
   END IF
-  IF(.NOT.rst)THEN
-    CALL u%add(0.d0,1.d0,taylor_hcur(i,ML_hcurl_grad%level)%f)
-    IF(do_orthog)CALL orthog%apply(u)
+  IF(.NOT.have_rst)THEN
+    CALL u%add(0.d0,1.d0,self%hcur(i,self%ML_hcurl_grad%level)%f)
+    IF(do_orthog)CALL hmodes%orthog%apply(u)
     CALL kop%apply(u,tmp)
     !---Solve
     b=>tmp
@@ -753,18 +802,16 @@ do i=1,taylor_nh
 !---------------------------------------------------------------------------
 ! Write restart file
 !---------------------------------------------------------------------------
-  IF(taylor_rst)THEN
-    WRITE(pnum,'(I2.2)')ML_oft_hcurl%current_level%order
-    WRITE(mnum,'(I2.2)')i
-    filename='gffa_r'//ML_oft_hcurl%ml_mesh%rlevel//'_p'//pnum//'_h'//mnum//'.rst'
-    IF(.NOT.oft_file_exist(filename))THEN
+  IF(save_rst)THEN
+    IF(.NOT.oft_file_exist(rst_filename))THEN
+      WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'gffa_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_h',i
       CALL oft_mpi_barrier(ierr)
-      CALL ML_oft_hcurl%current_level%vec_save(u,filename,'gffa')
-      IF(oft_env%head_proc)CALL hdf5_write(lambda,filename,'lambda')
+      CALL self%ML_hcurl%current_level%vec_save(u,rst_filename,field_name)
+      IF(oft_env%head_proc)CALL hdf5_write(lambda,rst_filename,'lambda')
     END IF
   END IF
   !---
-  CALL u%add(lambda**2,lambda,taylor_hcur(i,ML_hcurl_grad%level)%f)
+  CALL u%add(lambda**2,lambda,self%hcur(i,self%ML_hcurl_grad%level)%f)
 end do
 !---
 CALL tmp%delete
@@ -793,15 +840,17 @@ ELSE
   END IF
 END IF
 !---
-IF(.NOT.rst)CALL jmlb_inv%pre%delete
-CALL ML_oft_lagrange%set_level(ML_oft_lagrange%nlevels)
+IF(.NOT.have_rst)CALL jmlb_inv%pre%delete
+CALL self%ML_lagrange%set_level(self%ML_lagrange%nlevels)
 DEBUG_STACK_POP
 end subroutine taylor_injectors
 !---------------------------------------------------------------------------
 !> Compute force-free plasma response to external fields generated by @ref
 !! taylor::taylor_vacuum "taylor_vacuum"
 !---------------------------------------------------------------------------
-subroutine taylor_injector_single(lambda,fluxes,gffa)
+subroutine taylor_injector_single(self,hmodes,lambda,fluxes,gffa)
+type(oft_taylor_inhomo), intent(inout) :: self
+type(oft_taylor_eigs), intent(inout) :: hmodes
 real(r8), intent(in) :: lambda !< Desired lambda for force-free state
 real(r8), intent(in) :: fluxes(:) !< Flux for each injector
 class(oft_vector), pointer, intent(inout) :: gffa !< Plasma component (non-vacuum) of injector field
@@ -818,7 +867,6 @@ CLASS(oft_solver), POINTER :: linv_lag => NULL()
 TYPE(oft_hcurl_divout), TARGET :: hcurl_divout
 !---
 class(oft_vector), pointer :: tmp
-type(oft_hcurl_orthog), target :: orthog
 real(r8) :: venergy,lam_file
 integer(i4) :: i,k
 character(2) :: pnum,mnum
@@ -826,22 +874,22 @@ character(40) :: filename
 type(oft_hcurl_zerob), target :: hcurl_zerob
 type(oft_lag_zerob), target :: lag_zerob
 DEBUG_STACK_PUSH
-IF(.NOT.ASSOCIATED(taylor_hcpc))CALL oft_abort("Vacuum fields not available", &
+IF(.NOT.ASSOCIATED(self%hcpc))CALL oft_abort("Vacuum fields not available", &
 "taylor_injector_single", __FILE__)
 NULLIFY(mop,kop,wop,ml_jmlb)
-IF(taylor_minlev<0)taylor_minlev=ML_oft_hcurl%nlevels
+! IF(taylor_minlev<0)taylor_minlev=taylor_ML_hcurl%nlevels
 !---------------------------------------------------------------------------
 ! Setup H(Curl)::WOP preconditioner
 !---------------------------------------------------------------------------
-IF(taylor_minlev==ML_oft_hcurl%nlevels)THEN ! Lowest level uses diag precond
-  CALL oft_hcurl_getjmlb(ML_oft_hcurl%current_level,jmlb_mat,lambda,'zerob')
+IF(self%minlev==self%ML_hcurl%nlevels)THEN ! Lowest level uses diag precond
+  CALL oft_hcurl_getjmlb(self%ML_hcurl%current_level,jmlb_mat,lambda,'zerob')
   CALL create_diag_pre(jmlb_inv%pre)
 ELSE ! Nested levels use MG
-  CALL hcurl_getjmlb_pre(ML_oft_hcurl,jmlb_inv%pre,ml_jmlb,lambda,nlevels=1)
+  CALL hcurl_getjmlb_pre(self%ML_hcurl,jmlb_inv%pre,ml_jmlb,lambda,nlevels=1)
   jmlb_mat=>ml_jmlb(1)%M
 END IF
-hcurl_zerob%ML_hcurl_rep=>ML_oft_hcurl
-lag_zerob%ML_lag_rep=>ML_oft_lagrange
+hcurl_zerob%ML_hcurl_rep=>self%ML_hcurl
+lag_zerob%ML_lag_rep=>self%ML_lagrange
 !---------------------------------------------------------------------------
 ! Create H(Curl)::WOP solver
 !---------------------------------------------------------------------------
@@ -854,46 +902,46 @@ jmlb_inv%itplot=1
 !---------------------------------------------------------------------------
 ! Create H(Curl) divergence cleaner
 !---------------------------------------------------------------------------
-CALL ML_oft_lagrange%set_level(MIN(ML_oft_hcurl%level,ML_oft_lagrange%ml_mesh%mgdim))
-CALL oft_lag_getlop(ML_oft_lagrange%current_level,lop_lag,"zerob")
+CALL self%ML_lagrange%set_level(MIN(self%ML_hcurl%level,self%ML_lagrange%ml_mesh%mgdim))
+CALL oft_lag_getlop(self%ML_lagrange%current_level,lop_lag,"zerob")
 CALL create_cg_solver(linv_lag)
 linv_lag%A=>lop_lag
 linv_lag%its=-2
 CALL create_diag_pre(linv_lag%pre)
 linv_lag%its=40
 hcurl_divout%solver=>linv_lag
-CALL hcurl_divout%setup(ML_oft_hcurl,ML_oft_lagrange,bc='zero',solver=linv_lag)
+CALL hcurl_divout%setup(self%ML_hcurl,self%ML_lagrange,bc='zero',solver=linv_lag)
 ! hcurl_divout%bc=>lag_zerob
 hcurl_divout%app_freq=10
-CALL oft_hcurl_getmop(ML_oft_hcurl%current_level,mop,'zerob')
+CALL oft_hcurl_getmop(self%ML_hcurl%current_level,mop,'zerob')
 hcurl_divout%mop=>mop
 !jmlb_inv%cleaner=>hcurl_divout
 !---------------------------------------------------------------------------
 !
 !---------------------------------------------------------------------------
-call ML_hcurl_grad%set_level(ML_hcurl_grad%nlevels,propogate=.TRUE.)
+call self%ML_hcurl_grad%set_level(self%ML_hcurl_grad%nlevels,propogate=.TRUE.)
 !---
-call ML_oft_hcurl%vec_create(gffa)
-call ML_oft_hcurl%vec_create(tmp)
+call self%ML_hcurl%vec_create(gffa)
+call self%ML_hcurl%vec_create(tmp)
 !---
 CALL gffa%set(0.d0)
-do i=1,taylor_nh
-  CALL gffa%add(1.d0,fluxes(i),taylor_hcur(i,ML_hcurl_grad%level)%f)
+do i=1,self%nh
+  CALL gffa%add(1.d0,fluxes(i),self%hcur(i,self%ML_hcurl_grad%level)%f)
 end do
 !---Orthogonalize (if within 5% of Taylor state)
-IF(taylor_nm>0)THEN
-  IF(ABS((lambda-taylor_hlam(1,ML_oft_hcurl%level))/taylor_hlam(1,ML_oft_hcurl%level))<5.d-2)THEN
-    CALL oft_hcurl_getwop(ML_oft_hcurl%current_level,wop,'zerob')
-    orthog%orthog=>taylor_hffa
-    orthog%nm=1
-    orthog%wop=>wop
-    CALL orthog%apply(gffa)
+IF(hmodes%nm>0)THEN
+  IF(ABS((lambda-hmodes%hlam(1,self%ML_hcurl%level))/hmodes%hlam(1,self%ML_hcurl%level))<5.d-2)THEN
+    CALL oft_hcurl_getwop(self%ML_hcurl%current_level,wop,'zerob')
+    ! orthog%orthog=>self%hffa
+    hmodes%orthog%nm=1
+    hmodes%orthog%wop=>wop
+    CALL hmodes%orthog%apply(gffa)
     CALL wop%delete
     DEALLOCATE(wop)
   END IF
 END IF
 !---Get H(Curl) helicity matrix
-CALL oft_hcurl_getkop(ML_oft_hcurl%current_level,kop,'zerob')
+CALL oft_hcurl_getkop(self%ML_hcurl%current_level,kop,'zerob')
 CALL kop%apply(gffa,tmp)
 CALL kop%delete
 DEALLOCATE(kop)
@@ -908,8 +956,8 @@ hcurl_divout%pm=.TRUE.
 CALL hcurl_divout%apply(gffa)
 !---
 CALL gffa%scale(lambda**2)
-do i=1,taylor_nh
-  CALL gffa%add(1.d0,fluxes(i)*lambda,taylor_hcur(i,ML_hcurl_grad%level)%f)
+do i=1,self%nh
+  CALL gffa%add(1.d0,fluxes(i)*lambda,self%hcur(i,self%ML_hcurl_grad%level)%f)
 end do
 !---
 CALL tmp%delete
@@ -928,7 +976,7 @@ ELSE
 END IF
 !---
 CALL jmlb_inv%pre%delete
-CALL ML_oft_lagrange%set_level(ML_oft_lagrange%nlevels)
+CALL self%ML_lagrange%set_level(self%ML_lagrange%nlevels)
 DEBUG_STACK_POP
 end subroutine taylor_injector_single
 !---------------------------------------------------------------------------

--- a/src/physics/taylor.F90
+++ b/src/physics/taylor.F90
@@ -275,7 +275,9 @@ ELSE
 END IF
 save_rst=.FALSE.
 rst_append=.FALSE.
-IF(PRESENT(rst_filename))save_rst=.TRUE.
+IF(PRESENT(rst_filename))THEN
+  IF(TRIM(rst_filename)/='')save_rst=.TRUE.
+END IF
 IF(oft_env%head_proc)THEN
   WRITE(*,*)
   WRITE(*,'(A)')'============================'
@@ -436,12 +438,10 @@ do k=1,self%nm
 ! Write restart files
 !---------------------------------------------------------------------------
     if(save_rst)then
-      if(.NOT.oft_file_exist(rst_filename))then
-        CALL oft_mpi_barrier(ierr)
-        WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'hffa_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_m',k
-        CALL self%ML_hcurl%current_level%vec_save(u,rst_filename,field_name,append=rst_append)
-        rst_append=.TRUE.
-      end if
+      CALL oft_mpi_barrier(ierr)
+      WRITE(field_name,'(A6,A2,A2,I2.2,A2,I2.2)')'hffa_g',self%ML_hcurl%ml_mesh%rlevel,'_p',self%ML_hcurl%current_level%order,'_m',k
+      CALL self%ML_hcurl%current_level%vec_save(u,rst_filename,field_name,append=rst_append)
+      rst_append=.TRUE.
     end if
   end do ! End level loop
 end do ! End mode loop

--- a/src/physics/xmhd.F90
+++ b/src/physics/xmhd.F90
@@ -386,10 +386,12 @@ REAL(r8), ALLOCATABLE, DIMENSION(:,:) :: neg_source,neg_flag
 CLASS(multigrid_mesh), POINTER :: mg_mesh
 CLASS(oft_mesh), POINTER :: mesh
 !
-TYPE(oft_ml_fem_type), TARGET, PUBLIC :: ML_oft_lagrange
-TYPE(oft_ml_fem_type), TARGET, PUBLIC :: ML_oft_h1,ML_h1grad
-TYPE(oft_ml_fem_type), TARGET, PUBLIC :: ML_oft_hcurl
-TYPE(oft_ml_fem_comp_type), TARGET, PUBLIC :: ML_hcurl_grad,ML_oft_vlagrange
+TYPE(oft_ml_fem_type), POINTER, PUBLIC :: xmhd_ML_lagrange => NULL()
+TYPE(oft_ml_fem_type), POINTER, PUBLIC :: xmhd_ML_H1 => NULL()
+TYPE(oft_ml_fem_type), POINTER, PUBLIC :: xmhd_ML_H1grad => NULL()
+TYPE(oft_ml_fem_type), POINTER, PUBLIC :: xmhd_ML_hcurl => NULL()
+TYPE(oft_ml_fem_comp_type), POINTER, PUBLIC :: xmhd_ML_hcurl_grad => NULL()
+TYPE(oft_ml_fem_comp_type), POINTER, PUBLIC :: xmhd_ML_vlagrange => NULL()
 !
 CLASS(oft_scalar_fem), POINTER :: oft_lagrange => NULL()
 CLASS(oft_hcurl_fem), POINTER :: oft_hcurl => NULL()
@@ -586,10 +588,10 @@ real(4) :: hist_r4(11)
 real(r8) :: lin_tol,nl_tol,scale_tmp(4)
 integer(i4) :: rst_ind,nsteps,rst_freq,nclean,maxextrap,ittarget
 DEBUG_STACK_PUSH
-mg_mesh=>ML_oft_hcurl%ml_mesh
-IF(.NOT.oft_3D_hcurl_cast(oft_hcurl,ML_oft_hcurl%current_level))CALL oft_abort("Invalid Curl FE object","xmhd_run",__FILE__)
-IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,ML_oft_lagrange%current_level))CALL oft_abort("Invalid Lagrange FE object","xmhd_run",__FILE__)
-IF(.NOT.oft_3D_h1_cast(oft_hgrad,ML_h1grad%current_level))CALL oft_abort("Invalid Grad FE object","xmhd_run",__FILE__)
+mg_mesh=>xmhd_ML_hcurl%ml_mesh
+IF(.NOT.oft_3D_hcurl_cast(oft_hcurl,xmhd_ML_hcurl%current_level))CALL oft_abort("Invalid Curl FE object","xmhd_run",__FILE__)
+IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,xmhd_ML_lagrange%current_level))CALL oft_abort("Invalid Lagrange FE object","xmhd_run",__FILE__)
+IF(.NOT.oft_3D_h1_cast(oft_hgrad,xmhd_ML_H1grad%current_level))CALL oft_abort("Invalid Grad FE object","xmhd_run",__FILE__)
 mesh=>oft_hcurl%mesh
 !---------------------------------------------------------------------------
 ! Read-in Parameters
@@ -623,8 +625,8 @@ END IF
 !---------------------------------------------------------------------------
 ! Create divergence cleaner
 !---------------------------------------------------------------------------
-call ML_hcurl_grad%vec_create(sub_fields%B)
-CALL divout%setup(ML_hcurl_grad,"grnd")
+call xmhd_ML_hcurl_grad%vec_create(sub_fields%B)
+CALL divout%setup(xmhd_ML_hcurl_grad,"grnd")
 divout%pm=.TRUE.
 IF(TRIM(bbc)=="ic")divout%keep_boundary=.TRUE.
 !---------------------------------------------------------------------------
@@ -735,7 +737,7 @@ IF(xmhd_monitor_div)THEN
   Bfield%u=>sub_fields%B
   CALL Bfield%setup(oft_hcurl,oft_hgrad)
   !---Compute jump error
-  jump_error=hcurl_grad_jump_error(ML_hcurl_grad%current_level,sub_fields%B,oft_hcurl%quad%order)
+  jump_error=hcurl_grad_jump_error(xmhd_ML_hcurl_grad%current_level,sub_fields%B,oft_hcurl%quad%order)
   divfield%u=>sub_fields%B
   CALL divfield%setup(oft_hcurl,oft_hgrad)
   derror=scal_energy(mesh,divfield,oft_hcurl%quad%order)
@@ -746,9 +748,9 @@ END IF
 !---Setup B-norm
 IF(.NOT.xmhd_bnorm_force)THEN
   IF(.NOT.xmhd_monitor_div)CALL oft_xmhd_pop(u,sub_fields)
-  CALL ML_h1grad%vec_create(divout%bnorm)
-  CALL hcurl_grad_div(ML_hcurl_grad%current_level,sub_fields%B,divout%bnorm)
-  h1_zeroi%ML_H1_rep=>ML_h1grad
+  CALL xmhd_ML_H1grad%vec_create(divout%bnorm)
+  CALL hcurl_grad_div(xmhd_ML_hcurl_grad%current_level,sub_fields%B,divout%bnorm)
+  h1_zeroi%ML_H1_rep=>xmhd_ML_H1grad
   CALL h1_zeroi%apply(divout%bnorm)
 END IF
 !---------------------------------------------------------------------------
@@ -1002,7 +1004,7 @@ DO i=1,nsteps
       Bfield%u=>sub_fields%B
       CALL Bfield%setup(oft_hcurl,oft_hgrad)
       !---Compute jump error
-      jump_error=hcurl_grad_jump_error(ML_hcurl_grad%current_level,sub_fields%B,oft_hcurl%quad%order)
+      jump_error=hcurl_grad_jump_error(xmhd_ML_hcurl_grad%current_level,sub_fields%B,oft_hcurl%quad%order)
       divfield%u=>sub_fields%B
       CALL divfield%setup(oft_hcurl,oft_hgrad)
       derror=scal_energy(mesh,divfield,oft_hcurl%quad%order)
@@ -1132,10 +1134,10 @@ logical :: rst
 real(r8) :: lin_tol,nl_tol
 integer(i4) :: rst_ind,nsteps,rst_freq,nclean,maxextrap,ittarget
 DEBUG_STACK_PUSH
-IF(.NOT.oft_3D_hcurl_cast(oft_hcurl,ML_oft_hcurl%current_level))CALL oft_abort("Invalid Curl FE object","xmhd_lin_run",__FILE__)
-IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,ML_oft_lagrange%current_level))CALL oft_abort("Invalid Lagrange FE object","xmhd_lin_run",__FILE__)
-IF(.NOT.oft_3D_h1_cast(oft_hgrad,ML_h1grad%current_level))CALL oft_abort("Invalid Grad FE object","xmhd_lin_run",__FILE__)
-mg_mesh=>ML_oft_hcurl%ml_mesh
+IF(.NOT.oft_3D_hcurl_cast(oft_hcurl,xmhd_ML_hcurl%current_level))CALL oft_abort("Invalid Curl FE object","xmhd_lin_run",__FILE__)
+IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,xmhd_ML_lagrange%current_level))CALL oft_abort("Invalid Lagrange FE object","xmhd_lin_run",__FILE__)
+IF(.NOT.oft_3D_h1_cast(oft_hgrad,xmhd_ML_H1grad%current_level))CALL oft_abort("Invalid Grad FE object","xmhd_lin_run",__FILE__)
+mg_mesh=>xmhd_ML_hcurl%ml_mesh
 mesh=>oft_hcurl%mesh
 !---------------------------------------------------------------------------
 ! Read-in Parameters
@@ -1179,8 +1181,8 @@ END IF
 !---------------------------------------------------------------------------
 ! Create divergence cleaner
 !---------------------------------------------------------------------------
-call ML_hcurl_grad%vec_create(sub_fields%B)
-CALL divout%setup(ML_hcurl_grad,"grnd")
+call xmhd_ML_hcurl_grad%vec_create(sub_fields%B)
+CALL divout%setup(xmhd_ML_hcurl_grad,"grnd")
 divout%pm=.TRUE.
 IF(TRIM(bbc)=="ic")divout%keep_boundary=.TRUE.
 !---------------------------------------------------------------------------
@@ -1283,7 +1285,7 @@ IF(xmhd_monitor_div)THEN
   Bfield%u=>sub_fields%B
   CALL Bfield%setup(oft_hcurl,oft_hgrad)
   !---Compute jump error
-  jump_error=hcurl_grad_jump_error(ML_hcurl_grad%current_level,sub_fields%B,oft_hcurl%quad%order)
+  jump_error=hcurl_grad_jump_error(xmhd_ML_hcurl_grad%current_level,sub_fields%B,oft_hcurl%quad%order)
   divfield%u=>sub_fields%B
   CALL divfield%setup(oft_hcurl,oft_hgrad)
   derror=scal_energy(mesh,divfield,oft_hcurl%quad%order)
@@ -1440,7 +1442,7 @@ DO i=1,nsteps
       Bfield%u=>sub_fields%B
       CALL Bfield%setup(oft_hcurl,oft_hgrad)
       !---Compute jump error
-      jump_error=hcurl_grad_jump_error(ML_hcurl_grad%current_level,sub_fields%B,oft_hcurl%quad%order)
+      jump_error=hcurl_grad_jump_error(xmhd_ML_hcurl_grad%current_level,sub_fields%B,oft_hcurl%quad%order)
       divfield%u=>sub_fields%B
       CALL divfield%setup(oft_hcurl,oft_hgrad)
       derror=scal_energy(mesh,divfield,oft_hcurl%quad%order)
@@ -2428,11 +2430,11 @@ DEBUG_STACK_PUSH
 !---------------------------------------------------------------------------
 ! Setup Operators and ML environment
 !---------------------------------------------------------------------------
-allocate(ml_J(ML_oft_hcurl%nlevels-xmhd_minlev+1),ml_int(ML_oft_hcurl%nlevels-xmhd_minlev))
-allocate(oft_xmhd_ops_ML(ML_oft_hcurl%nlevels))
-xmhd_blevel=ML_oft_hcurl%blevel
-xmhd_nlevels=ML_oft_hcurl%nlevels
-xmhd_level=ML_oft_hcurl%level
+allocate(ml_J(xmhd_ML_hcurl%nlevels-xmhd_minlev+1),ml_int(xmhd_ML_hcurl%nlevels-xmhd_minlev))
+allocate(oft_xmhd_ops_ML(xmhd_ML_hcurl%nlevels))
+xmhd_blevel=xmhd_ML_hcurl%blevel
+xmhd_nlevels=xmhd_ML_hcurl%nlevels
+xmhd_level=xmhd_ML_hcurl%level
 IF(oft_debug_print(1))WRITE(*,'(2X,A)')'Allocating xMHD structures'
 !---------------------------------------------------------------------------
 ! Setup matrix mask based on included physics
@@ -2558,7 +2560,7 @@ DO level=levelin,xmhd_minlev,-1
   !
   ALLOCATE(oft_xmhd_ops%solid_node(oft_lagrange%ne))
   oft_xmhd_ops%solid_node=.FALSE.
-  CALL ML_oft_vlagrange%vec_create(vectmp)
+  CALL xmhd_ML_vlagrange%vec_create(vectmp)
   CALL vectmp%set(0.d0)
   CALL vectmp%get_local(node_flag)
   !
@@ -3754,7 +3756,7 @@ end subroutine xmhd_diag
 subroutine xmhd_setup_rep
 IF(oft_debug_print(1))WRITE(*,'(2X,A)')'Creating xMHD FE type'
 !---Create FE representation
-ML_xmhd_rep%nlevels=ML_oft_hcurl%nlevels
+ML_xmhd_rep%nlevels=xmhd_ML_hcurl%nlevels
 ML_xmhd_rep%nfields=7
 IF(xmhd_two_temp)THEN
   ML_xmhd_rep%nfields=ML_xmhd_rep%nfields+1
@@ -3770,38 +3772,38 @@ IF(eta_hyper>0.d0)THEN
 END IF
 ALLOCATE(ML_xmhd_rep%ml_fields(ML_xmhd_rep%nfields))
 ALLOCATE(ML_xmhd_rep%field_tags(ML_xmhd_rep%nfields))
-ML_xmhd_rep%ml_fields(1)%ml=>ML_oft_hcurl
+ML_xmhd_rep%ml_fields(1)%ml=>xmhd_ML_hcurl
 ML_xmhd_rep%field_tags(1)='Bc'
-ML_xmhd_rep%ml_fields(2)%ml=>ML_h1grad
+ML_xmhd_rep%ml_fields(2)%ml=>xmhd_ML_H1grad
 ML_xmhd_rep%field_tags(2)='Bg'
-ML_xmhd_rep%ml_fields(3)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(3)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(3)='Vx'
-ML_xmhd_rep%ml_fields(4)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(4)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(4)='Vy'
-ML_xmhd_rep%ml_fields(5)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(5)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(5)='Vz'
-ML_xmhd_rep%ml_fields(6)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(6)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(6)='n'
-ML_xmhd_rep%ml_fields(7)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(7)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(7)='T'
 IF(xmhd_two_temp)THEN
-  ML_xmhd_rep%ml_fields(te_ind)%ml=>ML_oft_lagrange
+  ML_xmhd_rep%ml_fields(te_ind)%ml=>xmhd_ML_lagrange
   ML_xmhd_rep%field_tags(te_ind)='Te'
 END IF
 IF(n2_ind>0)THEN
-  ML_xmhd_rep%ml_fields(n2_ind)%ml=>ML_oft_lagrange
+  ML_xmhd_rep%ml_fields(n2_ind)%ml=>xmhd_ML_lagrange
   ML_xmhd_rep%field_tags(n2_ind)='n2'
 END IF
 IF(j2_ind>0)THEN
-  ML_xmhd_rep%ml_fields(j2_ind)%ml=>ML_oft_hcurl
+  ML_xmhd_rep%ml_fields(j2_ind)%ml=>xmhd_ML_hcurl
   ML_xmhd_rep%field_tags(j2_ind)='j2'
 END IF
 call ML_xmhd_rep%setup()
 xmhd_rep=>ML_xmhd_rep%current_level
 !---Declare legacy variables
-xmhd_blevel=ML_oft_hcurl%blevel
-xmhd_nlevels=ML_oft_hcurl%nlevels
-xmhd_level=ML_oft_hcurl%level
+xmhd_blevel=xmhd_ML_hcurl%blevel
+xmhd_nlevels=xmhd_ML_hcurl%nlevels
+xmhd_level=xmhd_ML_hcurl%level
 IF(xmhd_minlev<0)xmhd_minlev=xmhd_nlevels
 end subroutine xmhd_setup_rep
 !---------------------------------------------------------------------------
@@ -3809,7 +3811,7 @@ end subroutine xmhd_setup_rep
 !---------------------------------------------------------------------------
 subroutine xmhd_set_level(level)
 integer(i4), intent(in) :: level !< Desired level
-if(level>ML_oft_hcurl%nlevels.OR.level<=0)then
+if(level>xmhd_ML_hcurl%nlevels.OR.level<=0)then
   call oft_abort('Invalid FE level','xmhd_set_level',__FILE__)
 end if
 ! if(level<mg_mesh%mgdim)then
@@ -3820,11 +3822,11 @@ end if
 CALL ML_xmhd_rep%set_level(level)
 xmhd_rep=>ML_xmhd_rep%current_level
 !---
-CALL ML_oft_lagrange%set_level(level)
-IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,ML_oft_lagrange%current_level))CALL oft_abort("Invalid FE object","xmhd_set_level",__FILE__)
-CALL ML_hcurl_grad%set_level(level,propogate=.TRUE.)
-IF(.NOT.oft_3D_hcurl_cast(oft_hcurl,ML_oft_hcurl%current_level))CALL oft_abort("Invalid Curl FE object","xmhd_run",__FILE__)
-IF(.NOT.oft_3D_h1_cast(oft_hgrad,ML_h1grad%current_level))CALL oft_abort("Invalid Grad FE object","xmhd_run",__FILE__)
+CALL xmhd_ML_lagrange%set_level(level)
+IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,xmhd_ML_lagrange%current_level))CALL oft_abort("Invalid FE object","xmhd_set_level",__FILE__)
+CALL xmhd_ML_hcurl_grad%set_level(level,propogate=.TRUE.)
+IF(.NOT.oft_3D_hcurl_cast(oft_hcurl,xmhd_ML_hcurl%current_level))CALL oft_abort("Invalid Curl FE object","xmhd_run",__FILE__)
+IF(.NOT.oft_3D_h1_cast(oft_hgrad,xmhd_ML_H1grad%current_level))CALL oft_abort("Invalid Grad FE object","xmhd_run",__FILE__)
 xmhd_level=level
 ! xmhd_lev=oft_hcurl_lev
 oft_xmhd_ops=>oft_xmhd_ops_ML(xmhd_level)
@@ -4178,7 +4180,7 @@ do i=levelin,minlev,-1
     if(ASSOCIATED(fullcctmp))DEALLOCATE(fullcctmp)
     allocate(fullcctmp(nfields,mesh%nc))
     !---Transfer from distributed to local grid
-    if(ML_oft_lagrange%level==ML_oft_lagrange%blevel)then
+    if(xmhd_ML_lagrange%level==xmhd_ML_lagrange%blevel)then
       call multigrid_base_pushcc(mg_mesh,fullcc,fullcctmp,nfields)
     !---Average values to over child cells
     else
@@ -4605,7 +4607,7 @@ IF(oft_env%head_proc)THEN
   WRITE(*,'(A)')'============================'
   WRITE(*,'(2X,A)')'Starting xMHD post-processing'
 END IF
-mg_mesh=>ML_oft_hcurl%ml_mesh
+mg_mesh=>xmhd_ML_hcurl%ml_mesh
 mesh=>oft_hcurl%mesh
 file_list="none"
 open(NEWUNIT=io_unit,FILE=oft_env%ifile)
@@ -4668,7 +4670,7 @@ nsteps=rst_end
 !---Build composite representation if necessary
 IF(ML_xmhd_rep%nlevels==0)THEN
   CALL xmhd_setup_rep
-  ALLOCATE(oft_xmhd_ops_ML(ML_oft_hcurl%nlevels))
+  ALLOCATE(oft_xmhd_ops_ML(xmhd_ML_hcurl%nlevels))
 END IF
 !---------------------------------------------------------------------------
 ! Create solver fields
@@ -4680,23 +4682,23 @@ call oft_xmhd_create(up)
 ! Create plotting fields
 !---------------------------------------------------------------------------
 NULLIFY(hcvals)
-call ML_oft_lagrange%vec_create(x)
-call ML_oft_vlagrange%vec_create(ap)
-call ML_oft_vlagrange%vec_create(bp)
+call xmhd_ML_lagrange%vec_create(x)
+call xmhd_ML_vlagrange%vec_create(ap)
+call xmhd_ML_vlagrange%vec_create(bp)
 allocate(bvout(3,x%n))
 !---Allocate sub-fields
-call ML_hcurl_grad%vec_create(sub_fields%B)
-call ML_oft_vlagrange%vec_create(sub_fields%V)
-call ML_oft_lagrange%vec_create(sub_fields%Ne)
-call ML_oft_lagrange%vec_create(sub_fields%Ti)
-IF(xmhd_two_temp)call ML_oft_lagrange%vec_create(sub_fields%Te)
-IF(n2_ind>0)call ML_oft_lagrange%vec_create(sub_fields%N2)
-IF(j2_ind>0)call ML_oft_hcurl%vec_create(sub_fields%J2)
+call xmhd_ML_hcurl_grad%vec_create(sub_fields%B)
+call xmhd_ML_vlagrange%vec_create(sub_fields%V)
+call xmhd_ML_lagrange%vec_create(sub_fields%Ne)
+call xmhd_ML_lagrange%vec_create(sub_fields%Ti)
+IF(xmhd_two_temp)call xmhd_ML_lagrange%vec_create(sub_fields%Te)
+IF(n2_ind>0)call xmhd_ML_lagrange%vec_create(sub_fields%N2)
+IF(j2_ind>0)call xmhd_ML_hcurl%vec_create(sub_fields%J2)
 !---------------------------------------------------------------------------
 ! Setup Lagrange mass solver
 !---------------------------------------------------------------------------
 NULLIFY(lmop)
-CALL oft_lag_vgetmop(ML_oft_vlagrange%current_level,lmop,'none')
+CALL oft_lag_vgetmop(xmhd_ML_vlagrange%current_level,lmop,'none')
 CALL create_cg_solver(lminv)
 lminv%A=>lmop
 lminv%its=-2

--- a/src/physics/xmhd_lag.F90
+++ b/src/physics/xmhd_lag.F90
@@ -375,11 +375,11 @@ REAL(r8), CONTIGUOUS, POINTER, DIMENSION(:,:) :: xmhd_hcurl_cop => NULL()
 !$omp threadprivate(xmhd_lag_rop,xmhd_lag_gop,xmhd_hcurl_rop,xmhd_hcurl_cop)
 REAL(r8), ALLOCATABLE, DIMENSION(:,:) :: neg_source,neg_flag
 !
-CLASS(multigrid_mesh), POINTER :: mg_mesh
-CLASS(oft_mesh), POINTER :: mesh
-TYPE(oft_ml_fem_type), TARGET, PUBLIC :: ML_oft_lagrange
-TYPE(oft_ml_fem_type), TARGET, PUBLIC :: ML_oft_hcurl
-TYPE(oft_ml_fem_comp_type), TARGET, PUBLIC :: ML_oft_vlagrange
+CLASS(multigrid_mesh), POINTER :: mg_mesh => NULL()
+CLASS(oft_mesh), POINTER :: mesh => NULL()
+TYPE(oft_ml_fem_type), POINTER, PUBLIC :: xmhd_ML_lagrange => NULL()
+TYPE(oft_ml_fem_type), POINTER, PUBLIC :: xmhd_ML_hcurl => NULL()
+TYPE(oft_ml_fem_comp_type), POINTER, PUBLIC :: xmhd_ML_vlagrange => NULL()
 CLASS(oft_scalar_fem), POINTER :: oft_lagrange => NULL()
 CLASS(oft_hcurl_fem), POINTER :: oft_hcurl => NULL()
 !---------------------------------------------------------------------------
@@ -565,8 +565,8 @@ real(4) :: hist_r4(11)
 real(r8) :: lin_tol,nl_tol
 integer(i4) :: rst_ind,nsteps,rst_freq,nclean,maxextrap,ittarget
 DEBUG_STACK_PUSH
-mg_mesh=>ML_oft_lagrange%ml_mesh
-IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,ML_oft_lagrange%current_level))CALL oft_abort("Invalid lagrange FE object","xmhd_run",__FILE__)
+mg_mesh=>xmhd_ML_lagrange%ml_mesh
+IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,xmhd_ML_lagrange%current_level))CALL oft_abort("Invalid lagrange FE object","xmhd_run",__FILE__)
 mesh=>oft_lagrange%mesh
 !---------------------------------------------------------------------------
 ! Read-in Parameters
@@ -577,7 +577,7 @@ IF(den_scale<0.d0)den_scale=SQRT(initial_fields%Ne%dot(initial_fields%Ne)/REAL(i
 IF((d2_dens>0.d0).AND.(n2_scale<0.d0))n2_scale=den_scale*(REAL(oft_lagrange%order,8)/mesh%hrms)**2
 IF((eta_hyper>0.d0).AND.(j2_scale<0.d0))THEN
   j2_scale=(REAL(oft_lagrange%order,8)/mesh%hrms)**2
-  IF(.NOT.oft_3D_hcurl_cast(oft_hcurl,ML_oft_hcurl%current_level))CALL oft_abort("Invalid HCurl FE object","xmhd_run",__FILE__)
+  IF(.NOT.oft_3D_hcurl_cast(oft_hcurl,xmhd_ML_hcurl%current_level))CALL oft_abort("Invalid HCurl FE object","xmhd_run",__FILE__)
 END IF
 !---------------------------------------------------------------------------
 ! Setup ML environment
@@ -1047,8 +1047,8 @@ logical :: rst
 real(r8) :: lin_tol,nl_tol
 integer(i4) :: rst_ind,nsteps,rst_freq,nclean,maxextrap,ittarget
 DEBUG_STACK_PUSH
-mg_mesh=>ML_oft_lagrange%ml_mesh
-IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,ML_oft_lagrange%current_level))CALL oft_abort("Invalid lagrange FE object","xmhd_run",__FILE__)
+mg_mesh=>xmhd_ML_lagrange%ml_mesh
+IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,xmhd_ML_lagrange%current_level))CALL oft_abort("Invalid lagrange FE object","xmhd_run",__FILE__)
 mesh=>oft_lagrange%mesh
 !---------------------------------------------------------------------------
 ! Read-in Parameters
@@ -2300,11 +2300,11 @@ DEBUG_STACK_PUSH
 !---------------------------------------------------------------------------
 ! Setup Operators and ML environment
 !---------------------------------------------------------------------------
-allocate(ml_J(ML_oft_lagrange%nlevels-xmhd_minlev+1),ml_int(ML_oft_lagrange%nlevels-xmhd_minlev))
-allocate(oft_xmhd_ops_ML(ML_oft_lagrange%nlevels))
-xmhd_blevel=ML_oft_lagrange%blevel
-xmhd_nlevels=ML_oft_lagrange%nlevels
-xmhd_level=ML_oft_lagrange%level
+allocate(ml_J(xmhd_ML_lagrange%nlevels-xmhd_minlev+1),ml_int(xmhd_ML_lagrange%nlevels-xmhd_minlev))
+allocate(oft_xmhd_ops_ML(xmhd_ML_lagrange%nlevels))
+xmhd_blevel=xmhd_ML_lagrange%blevel
+xmhd_nlevels=xmhd_ML_lagrange%nlevels
+xmhd_level=xmhd_ML_lagrange%level
 IF(oft_debug_print(1))WRITE(*,'(2X,A)')'Allocating xMHD structures'
 !---------------------------------------------------------------------------
 ! Setup matrix mask based on included physics
@@ -2429,7 +2429,7 @@ DO level=levelin,xmhd_minlev,-1
   !
   ALLOCATE(oft_xmhd_ops%solid_node(oft_lagrange%ne))
   oft_xmhd_ops%solid_node=.FALSE.
-  CALL ML_oft_lagrange%vec_create(vectmp)
+  CALL xmhd_ML_lagrange%vec_create(vectmp)
   CALL vectmp%set(0.d0)
   CALL vectmp%get_local(node_flag)
   !
@@ -3672,7 +3672,7 @@ end subroutine xmhd_diag
 subroutine xmhd_setup_rep
 IF(oft_debug_print(1))WRITE(*,'(2X,A)')'Creating xMHD FE type'
 !---Create FE representation
-ML_xmhd_rep%nlevels=ML_oft_lagrange%nlevels
+ML_xmhd_rep%nlevels=xmhd_ML_lagrange%nlevels
 ML_xmhd_rep%nfields=8
 IF(xmhd_two_temp)THEN
   ML_xmhd_rep%nfields=ML_xmhd_rep%nfields+1
@@ -3683,54 +3683,54 @@ IF(d2_dens>0.d0)THEN
   n2_ind=ML_xmhd_rep%nfields
 END IF
 IF(eta_hyper>0.d0)THEN
-  IF(ML_oft_hcurl%nlevels==0)CALL oft_abort("Hyper-resistivity requires HCurl FE space", &
+  IF(xmhd_ML_hcurl%nlevels==0)CALL oft_abort("Hyper-resistivity requires HCurl FE space", &
     "xmhd_setup_rep", __FILE__)
   ML_xmhd_rep%nfields=ML_xmhd_rep%nfields+1
   j2_ind=ML_xmhd_rep%nfields
 END IF
 ALLOCATE(ML_xmhd_rep%ml_fields(ML_xmhd_rep%nfields))
 ALLOCATE(ML_xmhd_rep%field_tags(ML_xmhd_rep%nfields))
-ML_xmhd_rep%ml_fields(1)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(1)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(1)='Bx'
-ML_xmhd_rep%ml_fields(2)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(2)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(2)='By'
-ML_xmhd_rep%ml_fields(3)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(3)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(3)='Bz'
-ML_xmhd_rep%ml_fields(4)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(4)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(4)='Vx'
-ML_xmhd_rep%ml_fields(5)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(5)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(5)='Vy'
-ML_xmhd_rep%ml_fields(6)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(6)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(6)='Vz'
-ML_xmhd_rep%ml_fields(7)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(7)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(7)='n'
-ML_xmhd_rep%ml_fields(8)%ml=>ML_oft_lagrange
+ML_xmhd_rep%ml_fields(8)%ml=>xmhd_ML_lagrange
 ML_xmhd_rep%field_tags(8)='T'
 IF(xmhd_two_temp)THEN
-  ML_xmhd_rep%ml_fields(te_ind)%ml=>ML_oft_lagrange
+  ML_xmhd_rep%ml_fields(te_ind)%ml=>xmhd_ML_lagrange
   ML_xmhd_rep%field_tags(te_ind)='Te'
 END IF
 IF(n2_ind>0)THEN
-  ML_xmhd_rep%ml_fields(n2_ind)%ml=>ML_oft_lagrange
+  ML_xmhd_rep%ml_fields(n2_ind)%ml=>xmhd_ML_lagrange
   ML_xmhd_rep%field_tags(n2_ind)='n2'
 END IF
 IF(j2_ind>0)THEN
-  ML_xmhd_rep%ml_fields(j2_ind)%ml=>ML_oft_hcurl
+  ML_xmhd_rep%ml_fields(j2_ind)%ml=>xmhd_ML_hcurl
   ML_xmhd_rep%field_tags(j2_ind)='j2'
 END IF
 call ML_xmhd_rep%setup
 xmhd_rep=>ML_xmhd_rep%current_level
 !---Declare legacy variables
-xmhd_blevel=ML_oft_lagrange%blevel
-xmhd_nlevels=ML_oft_lagrange%nlevels
-xmhd_level=ML_oft_lagrange%level
+xmhd_blevel=xmhd_ML_lagrange%blevel
+xmhd_nlevels=xmhd_ML_lagrange%nlevels
+xmhd_level=xmhd_ML_lagrange%level
 end subroutine xmhd_setup_rep
 !---------------------------------------------------------------------------
 !> Set the current level for xMHD
 !---------------------------------------------------------------------------
 subroutine xmhd_set_level(level)
 integer(i4), intent(in) :: level !< Desired level
-if(level>ML_oft_lagrange%nlevels.OR.level<=0)then
+if(level>xmhd_ML_lagrange%nlevels.OR.level<=0)then
   call oft_abort('Invalid FE level','xmhd_set_level',__FILE__)
 end if
 ! if(level<mg_mesh%mgdim)then
@@ -3741,11 +3741,11 @@ end if
 CALL ML_xmhd_rep%set_level(level)
 xmhd_rep=>ML_xmhd_rep%current_level
 !---
-CALL ML_oft_lagrange%set_level(level)
-IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,ML_oft_lagrange%current_level))CALL oft_abort("Invalid lagrange FE object","xmhd_set_level",__FILE__)
+CALL xmhd_ML_lagrange%set_level(level)
+IF(.NOT.oft_3D_lagrange_cast(oft_lagrange,xmhd_ML_lagrange%current_level))CALL oft_abort("Invalid lagrange FE object","xmhd_set_level",__FILE__)
 IF(j2_ind>0)THEN
-  CALL ML_oft_hcurl%set_level(level)
-  IF(.NOT.oft_3D_hcurl_cast(oft_hcurl,ML_oft_hcurl%current_level))CALL oft_abort("Invalid HCurl FE object","xmhd_set_level",__FILE__)
+  CALL xmhd_ML_hcurl%set_level(level)
+  IF(.NOT.oft_3D_hcurl_cast(oft_hcurl,xmhd_ML_hcurl%current_level))CALL oft_abort("Invalid HCurl FE object","xmhd_set_level",__FILE__)
 END IF
 xmhd_level=level
 ! xmhd_lev=oft_lagrange_lev
@@ -4047,7 +4047,7 @@ do i=levelin,minlev,-1
     if(ASSOCIATED(fullcctmp))DEALLOCATE(fullcctmp)
     allocate(fullcctmp(26,mesh%nc))
     !---Transfer from distributed to local grid
-    if(ML_oft_lagrange%level==ML_oft_lagrange%blevel)then
+    if(xmhd_ML_lagrange%level==xmhd_ML_lagrange%blevel)then
       call multigrid_base_pushcc(mg_mesh,fullcc,fullcctmp,26)
     !---Average values to over child cells
     else
@@ -4518,7 +4518,7 @@ IF(oft_env%head_proc)THEN
   WRITE(*,'(A)')'============================'
   WRITE(*,'(2X,A)')'Starting xMHD post-processing'
 END IF
-mg_mesh=>ML_oft_lagrange%ml_mesh
+mg_mesh=>xmhd_ML_lagrange%ml_mesh
 mesh=>oft_lagrange%mesh
 file_list="none"
 open(NEWUNIT=io_unit,FILE=oft_env%ifile)
@@ -4581,7 +4581,7 @@ nsteps=rst_end
 !---Build composite representation if necessary
 IF(ML_xmhd_rep%nlevels==0)THEN
   CALL xmhd_setup_rep
-  ALLOCATE(oft_xmhd_ops_ML(ML_oft_lagrange%nlevels))
+  ALLOCATE(oft_xmhd_ops_ML(xmhd_ML_lagrange%nlevels))
 END IF
 !---------------------------------------------------------------------------
 ! Create solver fields
@@ -4593,23 +4593,23 @@ call oft_xmhd_create(up)
 ! Create plotting fields
 !---------------------------------------------------------------------------
 NULLIFY(hcvals)
-call ML_oft_lagrange%vec_create(x)
-call ML_oft_vlagrange%vec_create(ap)
-call ML_oft_vlagrange%vec_create(bp)
+call xmhd_ML_lagrange%vec_create(x)
+call xmhd_ML_vlagrange%vec_create(ap)
+call xmhd_ML_vlagrange%vec_create(bp)
 allocate(bvout(3,x%n))
 !---Allocate sub-fields
-call ML_oft_vlagrange%vec_create(sub_fields%B)
-call ML_oft_vlagrange%vec_create(sub_fields%V)
-call ML_oft_lagrange%vec_create(sub_fields%Ne)
-call ML_oft_lagrange%vec_create(sub_fields%Ti)
-IF(xmhd_two_temp)call ML_oft_lagrange%vec_create(sub_fields%Te)
-IF(n2_ind>0)call ML_oft_lagrange%vec_create(sub_fields%N2)
-IF(j2_ind>0)call ML_oft_hcurl%vec_create(sub_fields%J2)
+call xmhd_ML_vlagrange%vec_create(sub_fields%B)
+call xmhd_ML_vlagrange%vec_create(sub_fields%V)
+call xmhd_ML_lagrange%vec_create(sub_fields%Ne)
+call xmhd_ML_lagrange%vec_create(sub_fields%Ti)
+IF(xmhd_two_temp)call xmhd_ML_lagrange%vec_create(sub_fields%Te)
+IF(n2_ind>0)call xmhd_ML_lagrange%vec_create(sub_fields%N2)
+IF(j2_ind>0)call xmhd_ML_hcurl%vec_create(sub_fields%J2)
 !---------------------------------------------------------------------------
 ! Setup Lagrange mass solver
 !---------------------------------------------------------------------------
 NULLIFY(lmop)
-CALL oft_lag_vgetmop(ML_oft_vlagrange%current_level,lmop,'none')
+CALL oft_lag_vgetmop(xmhd_ML_vlagrange%current_level,lmop,'none')
 CALL create_cg_solver(lminv)
 lminv%A=>lmop
 lminv%its=-2

--- a/src/python/OpenFUSIONToolkit/Marklin/_core.py
+++ b/src/python/OpenFUSIONToolkit/Marklin/_core.py
@@ -4,6 +4,7 @@
 @date September 2023
 @ingroup doxy_oft_python
 '''
+import warnings
 import numpy
 from ._interface import *
 from ..io import build_XDMF
@@ -150,14 +151,18 @@ class Marklin():
         '''
         return build_XDMF(path=self._io_basepath,repeat_static=repeat_static,pretty=pretty)
 
-    def compute(self,nmodes=1,cache_file=None):
+    def compute(self,nmodes=1,cache_file=None,save_rst=False):
         r'''! Compute force-free eigenmodes
 
         @param nmodes Number of eigenmodes to compute
-        @param save_rst Save restart files? 
+        @param cache_file Path to cache file to store/load modes
+        @param save_rst Save restart files? (deprecated)
         '''
         if self._nm != -1:
             raise ValueError('Eigenstates already computed')
+        if save_rst:
+            warnings.warn("Argument `save_rst` is deprecated, use `cache_file` instead", DeprecationWarning)
+            cache_file = 'oft_Marklin.rst'
         if cache_file is None:
             cache_string = self._oft_env.path2c("")
         else:

--- a/src/python/OpenFUSIONToolkit/Marklin/_core.py
+++ b/src/python/OpenFUSIONToolkit/Marklin/_core.py
@@ -150,7 +150,7 @@ class Marklin():
         '''
         return build_XDMF(path=self._io_basepath,repeat_static=repeat_static,pretty=pretty)
 
-    def compute(self,nmodes=1,save_rst=True):
+    def compute(self,nmodes=1,cache_file=None):
         r'''! Compute force-free eigenmodes
 
         @param nmodes Number of eigenmodes to compute
@@ -158,10 +158,14 @@ class Marklin():
         '''
         if self._nm != -1:
             raise ValueError('Eigenstates already computed')
+        if cache_file is None:
+            cache_string = self._oft_env.path2c("")
+        else:
+            cache_string = self._oft_env.path2c(cache_file)
         #
         eig_vals = numpy.zeros((nmodes,),dtype=numpy.float64)
         error_string = self._oft_env.get_c_errorbuff()
-        marklin_compute(self._marklin_ptr,nmodes,save_rst,eig_vals,error_string)
+        marklin_compute(self._marklin_ptr,nmodes,eig_vals,cache_string,error_string)
         if error_string.value != b'':
             raise Exception(error_string.value)
         self._nm = nmodes

--- a/src/python/OpenFUSIONToolkit/Marklin/_interface.py
+++ b/src/python/OpenFUSIONToolkit/Marklin/_interface.py
@@ -12,9 +12,9 @@ from .._interface import *
 marklin_setup = ctypes_subroutine(oftpy_lib.marklin_setup,
     [c_void_ptr_ptr, c_void_p, c_int, c_int, c_char_p])
 
-# marklin_compute(marklin_ptr,nmodes,save_rst,eig_vals,error_str)
+# marklin_compute(marklin_ptr,nmodes,eig_vals,cache_file,error_str)
 marklin_compute = ctypes_subroutine(oftpy_lib.marklin_compute,
-    [c_void_p, c_int, c_bool, ctypes_numpy_array(numpy.float64,1), c_char_p])
+    [c_void_p, c_int, ctypes_numpy_array(numpy.float64,1), c_char_p, c_char_p])
 
 # (basepath,error_str
 marklin_setup_io = ctypes_subroutine(oftpy_lib.marklin_setup_io,

--- a/src/python/wrappers/marklin_f.F90
+++ b/src/python/wrappers/marklin_f.F90
@@ -41,9 +41,7 @@ USE oft_hcurl_operators, ONLY: oft_hcurl_cinterp, hcurl_setup_interp, &
 USE oft_hcurl_grad_operators, ONLY: oft_hcurl_grad_divout, oft_hcurl_grad_zeroi, hcurl_grad_mc, oft_hcurl_grad_czerob, &
   hcurl_grad_setup_interp, oft_hcurl_grad_rinterp
 !---Taylor state
-USE taylor, ONLY: taylor_minlev, taylor_hmodes, taylor_hffa, taylor_nm, &
-  taylor_rst, taylor_hlam, ML_oft_hcurl, ML_oft_h1, &
-  ML_hcurl_grad, ML_h1grad, ML_oft_lagrange, ML_oft_vlagrange
+USE taylor, ONLY: oft_taylor_eigs, oft_taylor_inhomo, taylor_hmodes, taylor_vacuum
 USE mhd_utils, ONLY: mu0
 !---Wrappers
 USE oft_base_f, ONLY: copy_string, copy_string_rev
@@ -55,14 +53,16 @@ TYPE :: marklin_obj
   INTEGER(i4), POINTER, DIMENSION(:) :: reg_plot => NULL() !< Needs docs
   INTEGER(i4), POINTER, DIMENSION(:,:) :: lc_plot => NULL() !< Needs docs
   REAL(r8), POINTER, DIMENSION(:,:) :: r_plot => NULL() !< Needs docs
+  TYPE(oft_taylor_eigs) :: eig_obj
+  TYPE(oft_taylor_eigs) :: ff_obj
   TYPE(xdmf_plot_file) :: xdmf_plot
   TYPE(multigrid_mesh), POINTER :: ml_mesh => NULL()
-  ! TYPE(oft_ml_fem_type), POINTER :: ML_oft_lagrange => NULL()
-  ! TYPE(oft_ml_fem_type), POINTER :: ML_oft_h1 => NULL()
-  ! TYPE(oft_ml_fem_type), POINTER :: ML_oft_hgrad => NULL()
-  ! TYPE(oft_ml_fem_type), POINTER :: ML_oft_hcurl => NULL()
-  ! TYPE(oft_ml_fem_comp_type), POINTER :: ML_oft_h1 => NULL()
-  ! TYPE(oft_ml_fem_comp_type), POINTER :: ML_oft_vlagrange => NULL()
+  TYPE(oft_ml_fem_type), POINTER :: ML_lagrange => NULL()
+  TYPE(oft_ml_fem_type), POINTER :: ML_h1 => NULL()
+  TYPE(oft_ml_fem_type), POINTER :: ML_h1grad => NULL()
+  TYPE(oft_ml_fem_type), POINTER :: ML_hcurl => NULL()
+  TYPE(oft_ml_fem_comp_type), POINTER :: ML_hcurl_grad => NULL()
+  TYPE(oft_ml_fem_comp_type), POINTER :: ML_vlagrange => NULL()
 END TYPE marklin_obj
 CONTAINS
 !------------------------------------------------------------------------------
@@ -106,21 +106,22 @@ self%order=order
 self%minlev=minlev
 CALL c_f_pointer(mesh_ptr,self%ml_mesh)
 !---Lagrange
-CALL oft_lag_setup(self%ml_mesh,self%order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange,minlev=self%minlev)
+ALLOCATE(self%ML_lagrange,self%ML_vlagrange)
+CALL oft_lag_setup(self%ml_mesh,self%order,self%ML_lagrange,ML_vlag_obj=self%ML_vlagrange,minlev=self%minlev)
 !---H(Curl) subspace
-CALL oft_hcurl_setup(self%ml_mesh,self%order,ML_oft_hcurl,minlev=self%minlev)
+ALLOCATE(self%ML_hcurl)
+CALL oft_hcurl_setup(self%ml_mesh,self%order,self%ML_hcurl,minlev=self%minlev)
 !---Compute modes
 IF(self%minlev<0)THEN
-  taylor_minlev=ML_oft_hcurl%level
+  self%minlev=self%ML_hcurl%level
 ELSE
-  taylor_minlev=self%minlev
-  IF(oft_env%nprocs>1)taylor_minlev=MAX(oft_env%nbase+1,self%minlev)
+  IF(oft_env%nprocs>1)self%minlev=MAX(oft_env%nbase+1,self%minlev)
 END IF
-IF(taylor_minlev<ML_oft_hcurl%level)THEN
-  CALL lag_setup_interp(ML_oft_lagrange)
+IF(self%minlev<self%ML_hcurl%level)THEN
+  CALL lag_setup_interp(self%ML_lagrange)
   CALL lag_mloptions
-  CALL hcurl_setup_interp(ML_oft_hcurl)
-  CALL hcurl_mloptions(ML_oft_hcurl)
+  CALL hcurl_setup_interp(self%ML_hcurl)
+  CALL hcurl_mloptions(self%ML_hcurl)
 END IF
 !
 marklin_ptr=C_LOC(self)
@@ -146,15 +147,19 @@ TYPE(oft_hcurl_cinterp) :: Bfield
 TYPE(marklin_obj), POINTER :: self
 CHARACTER(LEN=3) :: pltnum
 IF(.NOT.marklin_ccast(marklin_ptr,self,error_str))RETURN
-IF(taylor_nm>0)THEN
+IF(self%eig_obj%nm>0)THEN
   CALL copy_string('Eigenstates already computed',error_str)
   RETURN
 END IF
 oft_env%pm=.TRUE.
-taylor_rst=save_rst
-CALL taylor_hmodes(nmodes)
+CALL self%eig_obj%setup(self%ML_hcurl,self%ML_lagrange,self%minlev)
+IF(save_rst)THEN
+  CALL taylor_hmodes(self%eig_obj,nmodes,'marklin_hmodes.rst')
+ELSE
+  CALL taylor_hmodes(self%eig_obj,nmodes)
+END IF
 CALL c_f_pointer(eig_vals, vals_tmp, [nmodes])
-vals_tmp=taylor_hlam(:,ML_oft_hcurl%level)
+vals_tmp=self%eig_obj%hlam(:,self%ML_hcurl%level)
 END SUBROUTINE marklin_compute
 !------------------------------------------------------------------------------
 !> Needs docs
@@ -170,10 +175,10 @@ CALL copy_string_rev(basepath,pathprefix)
 !---Setup I/0
 IF(TRIM(pathprefix)/='')THEN
   CALL self%xdmf_plot%setup('Marklin',pathprefix)
-  CALL self%ml_mesh%mesh%setup_io(self%xdmf_plot,ML_oft_hcurl%current_level%order)
+  CALL self%ml_mesh%mesh%setup_io(self%xdmf_plot,self%ML_hcurl%current_level%order)
 ELSE
   CALL self%xdmf_plot%setup('Marklin')
-  CALL self%ml_mesh%mesh%setup_io(self%xdmf_plot,ML_oft_hcurl%current_level%order)
+  CALL self%ml_mesh%mesh%setup_io(self%xdmf_plot,self%ML_hcurl%current_level%order)
 END IF
 END SUBROUTINE marklin_setup_io
 !------------------------------------------------------------------------------
@@ -201,24 +206,24 @@ IF(.NOT.marklin_ccast(marklin_ptr,self,error_str))RETURN
 CALL copy_string_rev(key,name_tmp)
 !---Construct operator
 NULLIFY(lmop)
-CALL oft_lag_vgetmop(ML_oft_vlagrange%current_level,lmop,'none')
+CALL oft_lag_vgetmop(self%ML_vlagrange%current_level,lmop,'none')
 !---Setup solver
 CALL create_cg_solver(lminv)
 CALL create_diag_pre(lminv%pre)
 lminv%A=>lmop
 lminv%its=-2
 !---Create solver fields
-CALL ML_oft_vlagrange%vec_create(u)
-CALL ML_oft_vlagrange%vec_create(v)
+CALL self%ML_vlagrange%vec_create(u)
+CALL self%ML_vlagrange%vec_create(v)
 ALLOCATE(bvout(3,u%n/3))
 !---Project field onto plotting mesh
 SELECT CASE(int_type)
 CASE(1)
   CALL c_f_pointer(int_obj, ainterp_obj)
-  CALL oft_lag_vproject(ML_oft_lagrange%current_level,ainterp_obj,v)
+  CALL oft_lag_vproject(self%ML_lagrange%current_level,ainterp_obj,v)
 CASE(2)
   CALL c_f_pointer(int_obj, binterp_obj)
-  CALL oft_lag_vproject(ML_oft_lagrange%current_level,binterp_obj,v)
+  CALL oft_lag_vproject(self%ML_lagrange%current_level,binterp_obj,v)
 END SELECT
 CALL u%set(0.d0)
 CALL lminv%apply(u,v)
@@ -257,47 +262,47 @@ REAL(r8), POINTER, DIMENSION(:) :: tmp => NULL()
 TYPE(oft_h1_zerogrnd), TARGET :: h1_zerogrnd
 TYPE(oft_h1_zerob), TARGET :: h1_zerob
 IF(.NOT.marklin_ccast(marklin_ptr,self,error_str))RETURN
-IF(ML_hcurl_grad%nlevels==0)THEN
+IF(self%ML_hcurl_grad%nlevels==0)THEN
   !---Grad(H^1) subspace
-  CALL oft_h1_setup(self%ml_mesh,ML_oft_hcurl%current_level%order+1,ML_oft_h1,minlev=ML_oft_hcurl%minlev+1)
-  CALL h1_setup_interp(ML_oft_h1)
+  CALL oft_h1_setup(self%ml_mesh,self%ML_hcurl%current_level%order+1,self%ML_h1,minlev=self%ML_hcurl%minlev+1)
+  CALL h1_setup_interp(self%ML_h1)
   !---Full H(Curl) + Grad(H^1) space
-  CALL oft_hcurl_grad_setup(ML_oft_hcurl,ML_oft_h1,ML_hcurl_grad,ML_h1grad,ML_oft_hcurl%minlev)
-  CALL hcurl_grad_setup_interp(ML_hcurl_grad,ML_oft_h1)
+  CALL oft_hcurl_grad_setup(self%ML_hcurl,self%ML_h1,self%ML_hcurl_grad,self%ML_h1grad,self%ML_hcurl%minlev)
+  CALL hcurl_grad_setup_interp(self%ML_hcurl_grad,self%ML_h1)
 END IF
 !---------------------------------------------------------------------------
 ! Create divergence cleaner
 !---------------------------------------------------------------------------
 NULLIFY(lop,tmp)
 IF(zero_norm)THEN
-  CALL oft_h1_getlop(ML_oft_h1%current_level,lop,"grnd")
+  CALL oft_h1_getlop(self%ML_h1%current_level,lop,"grnd")
 ELSE
-  CALL oft_h1_getlop(ML_oft_h1%current_level,lop,"zerob")
+  CALL oft_h1_getlop(self%ML_h1%current_level,lop,"zerob")
 END IF
 CALL create_cg_solver(linv)
 linv%A=>lop
 linv%its=-2
 CALL create_diag_pre(linv%pre) ! Setup Preconditioner
-CALL divout%setup(ML_hcurl_grad,'none',solver=linv)
+CALL divout%setup(self%ML_hcurl_grad,'none',solver=linv)
 IF(zero_norm)THEN
-  h1_zerogrnd%ML_H1_rep=>ML_h1grad
+  h1_zerogrnd%ML_H1_rep=>self%ML_h1grad
   divout%bc=>h1_zerogrnd
   divout%keep_boundary=.TRUE.
 ELSE
-  h1_zerob%ML_H1_rep=>ML_h1grad
+  h1_zerob%ML_H1_rep=>self%ML_h1grad
   divout%bc=>h1_zerob
 END IF
 !---------------------------------------------------------------------------
 ! Setup initial conditions
 !---------------------------------------------------------------------------
 ALLOCATE(interp_obj)
-CALL ML_hcurl_grad%vec_create(interp_obj%u)
-CALL taylor_hffa(1,ML_oft_hcurl%level)%f%get_local(tmp)
+CALL self%ML_hcurl_grad%vec_create(interp_obj%u)
+CALL self%eig_obj%hffa(1,self%ML_hcurl%level)%f%get_local(tmp)
 CALL interp_obj%u%restore_local(tmp,1)
 IF(zero_norm)WRITE(*,*)'Setting gauge'
 divout%pm=.TRUE.
 CALL divout%apply(interp_obj%u)
-CALL interp_obj%setup(ML_oft_hcurl%current_level,ML_oft_h1%current_level)
+CALL interp_obj%setup(self%ML_hcurl%current_level,self%ML_h1%current_level)
 int_obj=C_LOC(interp_obj)
 !---Cleanup
 CALL lop%delete()
@@ -322,8 +327,8 @@ TYPE(marklin_obj), POINTER :: self
 TYPE(oft_hcurl_cinterp), POINTER :: interp_obj
 IF(.NOT.marklin_ccast(marklin_ptr,self,error_str))RETURN
 ALLOCATE(interp_obj)
-interp_obj%u=>taylor_hffa(imode,ML_oft_hcurl%level)%f
-CALL interp_obj%setup(ML_oft_hcurl%current_level)
+interp_obj%u=>self%eig_obj%hffa(imode,self%ML_hcurl%level)%f
+CALL interp_obj%setup(self%ML_hcurl%current_level)
 int_obj=C_LOC(interp_obj)
 END SUBROUTINE marklin_get_bint
 !------------------------------------------------------------------------------

--- a/src/python/wrappers/marklin_f.F90
+++ b/src/python/wrappers/marklin_f.F90
@@ -155,9 +155,9 @@ oft_env%pm=.TRUE.
 CALL self%eig_obj%setup(self%ML_hcurl,self%ML_lagrange,self%minlev)
 CALL copy_string_rev(cache_file,rst_filename)
 IF(TRIM(rst_filename)=='')THEN
-  CALL taylor_hmodes(self%eig_obj,nmodes,rst_filename)
-ELSE
   CALL taylor_hmodes(self%eig_obj,nmodes)
+ELSE
+  CALL taylor_hmodes(self%eig_obj,nmodes,rst_filename)
 END IF
 CALL c_f_pointer(eig_vals, vals_tmp, [nmodes])
 vals_tmp=self%eig_obj%hlam(:,self%ML_hcurl%level)

--- a/src/python/wrappers/marklin_f.F90
+++ b/src/python/wrappers/marklin_f.F90
@@ -41,7 +41,7 @@ USE oft_hcurl_operators, ONLY: oft_hcurl_cinterp, hcurl_setup_interp, &
 USE oft_hcurl_grad_operators, ONLY: oft_hcurl_grad_divout, oft_hcurl_grad_zeroi, hcurl_grad_mc, oft_hcurl_grad_czerob, &
   hcurl_grad_setup_interp, oft_hcurl_grad_rinterp
 !---Taylor state
-USE taylor, ONLY: oft_taylor_eigs, oft_taylor_inhomo, taylor_hmodes, taylor_vacuum
+USE taylor, ONLY: oft_taylor_eigs, oft_taylor_inhomo, taylor_hmodes
 USE mhd_utils, ONLY: mu0
 !---Wrappers
 USE oft_base_f, ONLY: copy_string, copy_string_rev

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 # Add sub-directories and copy testing script
 configure_file( oft_testing.py ${CMAKE_CURRENT_BINARY_DIR} COPYONLY )
 configure_file( conftest.py ${CMAKE_CURRENT_BINARY_DIR} COPYONLY )
+add_subdirectory( base )
 add_subdirectory( grid )
 add_subdirectory( lin_alg )
 add_subdirectory( fem )
@@ -48,7 +49,7 @@ add_custom_target(test)
 add_custom_command(
     TARGET  test
     POST_BUILD
-    COMMAND PATH=${OFT_TEST_PATH} OFT_HAVE_MPI=${OFT_MPI_TEST} OFT_DEBUG_TEST=${OFT_DEBUG_TEST} ${OFT_PYTEST_EXE} --junitxml=OFT.junit.xml -m \"not slow\" grid lin_alg fem physics
+    COMMAND PATH=${OFT_TEST_PATH} OFT_HAVE_MPI=${OFT_MPI_TEST} OFT_DEBUG_TEST=${OFT_DEBUG_TEST} ${OFT_PYTEST_EXE} --junitxml=OFT.junit.xml -m \"not slow\" base grid lin_alg fem physics
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests
     POST_BUILD
 )
@@ -57,7 +58,7 @@ add_custom_target(test_full)
 add_custom_command(
     TARGET  test_full
     POST_BUILD
-    COMMAND PATH=${OFT_TEST_PATH} OFT_HAVE_MPI=${OFT_MPI_TEST} OFT_DEBUG_TEST=${OFT_DEBUG_TEST} ${OFT_PYTEST_EXE} --junitxml=OFT.junit.xml grid lin_alg fem physics
+    COMMAND PATH=${OFT_TEST_PATH} OFT_HAVE_MPI=${OFT_MPI_TEST} OFT_DEBUG_TEST=${OFT_DEBUG_TEST} ${OFT_PYTEST_EXE} --junitxml=OFT.junit.xml base grid lin_alg fem physics
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests
     POST_BUILD
 )
@@ -68,7 +69,7 @@ if( OFT_COVERAGE )
   add_custom_command(
       TARGET  test_cov
       POST_BUILD
-      COMMAND PATH=${OFT_TEST_PATH} COVERAGE_PROCESS_START=.coveragerc OFT_HAVE_MPI=${OFT_MPI_TEST} OFT_DEBUG_TEST=1 coverage run -m pytest -m \"coverage\" grid lin_alg fem physics
+      COMMAND PATH=${OFT_TEST_PATH} COVERAGE_PROCESS_START=.coveragerc OFT_HAVE_MPI=${OFT_MPI_TEST} OFT_DEBUG_TEST=1 coverage run -m pytest -m \"coverage\" base grid lin_alg fem physics
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests
       POST_BUILD
   )

--- a/src/tests/base/CMakeLists.txt
+++ b/src/tests/base/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Add test executables
+if( OFT_BUILD_TESTS )
+  oft_add_test( test_io.F90 )
+  configure_file( test_io.py ${CMAKE_CURRENT_BINARY_DIR} COPYONLY )
+endif()

--- a/src/tests/base/test_io.F90
+++ b/src/tests/base/test_io.F90
@@ -1,0 +1,149 @@
+!------------------------------------------------------------------------------
+! Flexible Unstructured Simulation Infrastructure with Open Numerics (Open FUSION Toolkit)
+!------------------------------------------------------------------------------
+!> @file test_io.F90
+!
+!> Regression tests for some HDF5 I/O
+!!
+!! @authors Chris Hansen
+!! @date March 2025
+!! @ingroup testing
+!-----------------------------------------------------------------------------
+PROGRAM test_io
+USE oft_base
+USE oft_io, ONLY: hdf5_write, hdf5_read, hdf5_create_file
+!--Grid
+USE oft_mesh_cube, ONLY: mesh_cube_id
+USE multigrid, ONLY: multigrid_mesh
+USE multigrid_build, ONLY: multigrid_construct
+!---Linear Algebra
+USE oft_la_base, ONLY: oft_vector
+!---Lagrange FE space
+USE fem_base, ONLY: oft_ml_fem_type
+USE oft_lag_basis, ONLY: oft_lag_setup
+IMPLICIT NONE
+LOGICAL :: success
+INTEGER(i4) :: iounit,ierr
+INTEGER(i4), PARAMETER :: ival=10,iarray(3)=[100,101,102],imat(2,2)=RESHAPE([100,101,102,103],[2,2])
+INTEGER(i4) :: ival_chk,iarray_chk(3),imat_chk(2,2)
+REAL(r8), PARAMETER :: rval=1.d-1,rarray(3)=[1.0d-2,1.1d-2,1.2d-2],rmat(2,2)=RESHAPE([1.0d-2,1.1d-2,1.2d-2,1.3d-2],[2,2])
+REAL(r8) :: rval_chk,rarray_chk(3),rmat_chk(2,2),norm,norm_chk
+TYPE(multigrid_mesh) :: mg_mesh
+TYPE(oft_ml_fem_type), TARGET :: ML_oft_lagrange
+CLASS(oft_vector), POINTER :: vec_tmp,vec_chk
+INTEGER(i4) :: test_id=1
+NAMELIST/test_io_options/test_id
+!---------------------------------------------------------------------------
+! Initialize enviroment
+!---------------------------------------------------------------------------
+CALL oft_init
+!---Read in options
+OPEN(NEWUNIT=iounit,FILE=oft_env%ifile)
+READ(iounit,test_io_options,IOSTAT=ierr)
+CLOSE(iounit)
+!---Setup grid
+CALL multigrid_construct(mg_mesh)
+IF(mg_mesh%mesh%cad_type/=mesh_cube_id)CALL oft_abort('Wrong mesh type, test for CUBE only.','main',__FILE__)
+!---------------------------------------------------------------------------
+! Run tests
+!---------------------------------------------------------------------------
+oft_env%pm=.FALSE.
+SELECT CASE(test_id)
+  CASE(1) !< Test saving/reading 1D
+    IF(oft_env%head_proc)THEN
+      CALL hdf5_create_file("oft_test.rst")
+      CALL hdf5_write(ival,"oft_test.rst","ival")
+      CALL hdf5_write(iarray,"oft_test.rst","iarray")
+      CALL hdf5_write(rval,"oft_test.rst","rval")
+      CALL hdf5_write(rarray,"oft_test.rst","rarray")
+      !
+      CALL hdf5_read(ival_chk,"oft_test.rst","ival")
+      IF(ival/=ival_chk)CALL oft_abort("Integer values do not match","test_io",__FILE__)
+      CALL hdf5_read(iarray_chk,"oft_test.rst","iarray")
+      IF(ANY(iarray/=iarray_chk))CALL oft_abort("Integer arrays do not match","test_io",__FILE__)
+      CALL hdf5_read(rval_chk,"oft_test.rst","rval")
+      IF(rval/=rval_chk)CALL oft_abort("Real values do not match","test_io",__FILE__)
+      CALL hdf5_read(rarray_chk,"oft_test.rst","rarray")
+      IF(ANY(rarray/=rarray_chk))CALL oft_abort("Real arrays do not match","test_io",__FILE__)
+    END IF
+  CASE(2) !< Test saving/reading 2D
+    IF(oft_env%head_proc)THEN
+      CALL hdf5_create_file("oft_test.rst")
+      CALL hdf5_write(imat,"oft_test.rst","iarray")
+      CALL hdf5_write(rmat,"oft_test.rst","rarray")
+      !
+      CALL hdf5_read(imat_chk,"oft_test.rst","iarray")
+      IF(ANY(imat(:,1)/=imat_chk(:,1)))CALL oft_abort("Integer matrices do not match","test_io",__FILE__)
+      IF(ANY(imat(:,2)/=imat_chk(:,2)))CALL oft_abort("Integer matrices do not match","test_io",__FILE__)
+      CALL hdf5_read(rmat_chk,"oft_test.rst","rarray")
+      IF(ANY(rmat(:,1)/=rmat_chk(:,1)))CALL oft_abort("Real matrices do not match","test_io",__FILE__)
+      IF(ANY(rmat(:,2)/=rmat_chk(:,2)))CALL oft_abort("Real matrices do not match","test_io",__FILE__)
+    END IF
+  CASE(3) !< Test saving/reading vectors
+    CALL oft_lag_setup(mg_mesh,2,ML_oft_lagrange,minlev=-1)
+    CALL ML_oft_lagrange%vec_create(vec_tmp)
+    CALL vec_tmp%set(0.d0,random=.TRUE.)
+    norm = vec_tmp%dot(vec_tmp)
+    CALL ML_oft_lagrange%vec_create(vec_chk)
+    !
+    IF(oft_env%head_proc)CALL hdf5_create_file("oft_test.rst")
+    CALL oft_mpi_barrier(ierr)
+    CALL ML_oft_lagrange%current_level%vec_save(vec_tmp,"oft_test.rst","vec",append=.TRUE.)
+    !
+    CALL ML_oft_lagrange%current_level%vec_load(vec_chk,"oft_test.rst","vec")
+    CALL vec_chk%add(1.d0,-1.d0,vec_tmp)
+    norm_chk = vec_chk%dot(vec_chk)
+    IF(ABS(norm_chk/norm)>1.d-14)CALL oft_abort("Integer matrices do not match","test_io",__FILE__)
+    !
+    CALL vec_tmp%delete()
+    CALL vec_chk%delete()
+    DEALLOCATE(vec_tmp,vec_chk)
+  CASE(4) !< Test read missing fields
+    CALL oft_lag_setup(mg_mesh,2,ML_oft_lagrange,minlev=-1)
+    CALL ML_oft_lagrange%vec_create(vec_tmp)
+    !
+    IF(oft_env%head_proc)THEN
+      CALL hdf5_create_file("oft_test.rst")
+      CALL hdf5_write(ival,"oft_test.rst","field")
+      CALL hdf5_read(ival_chk,"oft_test.rst","empty",success=success)
+      IF(success)CALL oft_abort("Success reported for integer read of missing field","test_io",__FILE__)
+      CALL hdf5_read(iarray_chk,"oft_test.rst","empty",success=success)
+      IF(success)CALL oft_abort("Success reported for integer array read of missing field","test_io",__FILE__)
+      CALL hdf5_read(imat_chk,"oft_test.rst","empty",success=success)
+      IF(success)CALL oft_abort("Success reported for integer matrix read of missing field","test_io",__FILE__)
+      CALL hdf5_read(rval_chk,"oft_test.rst","empty",success=success)
+      IF(success)CALL oft_abort("Success reported for real read of missing field","test_io",__FILE__)
+      CALL hdf5_read(rarray_chk,"oft_test.rst","empty",success=success)
+      IF(success)CALL oft_abort("Success reported for real array read of missing field","test_io",__FILE__)
+      CALL hdf5_read(rmat_chk,"oft_test.rst","empty",success=success)
+      IF(success)CALL oft_abort("Success reported for real matrix read of missing field","test_io",__FILE__)
+    END IF
+    CALL oft_mpi_barrier(ierr)
+    CALL ML_oft_lagrange%current_level%vec_load(vec_tmp,"oft_test.rst","empty",err_flag=ierr)
+    IF(ierr==0)CALL oft_abort("Success reported for vector read of missing field","test_io",__FILE__)
+    !
+    CALL vec_tmp%delete()
+    DEALLOCATE(vec_tmp)
+  CASE(5) !< Test overwritting fields
+    CALL oft_lag_setup(mg_mesh,2,ML_oft_lagrange,minlev=-1)
+    CALL ML_oft_lagrange%vec_create(vec_tmp)
+    !
+    IF(oft_env%head_proc)THEN
+      CALL hdf5_create_file("oft_test.rst")
+      CALL hdf5_write(ival,"oft_test.rst","field")
+      CALL hdf5_write(ival,"oft_test.rst","field")
+      CALL hdf5_write(iarray,"oft_test.rst","field")
+      CALL hdf5_write(imat,"oft_test.rst","iarray")
+      CALL hdf5_write(rval,"oft_test.rst","field")
+      CALL hdf5_write(rarray,"oft_test.rst","field")
+      CALL hdf5_write(rmat,"oft_test.rst","rarray")
+    END IF
+    CALL oft_mpi_barrier(ierr)
+    CALL ML_oft_lagrange%current_level%vec_save(vec_tmp,"oft_test.rst","field",append=.TRUE.)
+    !
+    CALL vec_tmp%delete()
+    DEALLOCATE(vec_tmp)
+END SELECT
+!---Finalize enviroment
+CALL oft_finalize
+END PROGRAM test_io

--- a/src/tests/base/test_io.py
+++ b/src/tests/base/test_io.py
@@ -1,0 +1,54 @@
+from __future__ import print_function
+import os
+import sys
+import pytest
+test_dir = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(os.path.abspath(os.path.join(test_dir, '..')))
+from oft_testing import run_OFT
+
+# Basic template for input file
+oft_in_template = """
+&runtime_options
+ ppn=1
+ debug=0
+ test_run=T
+/
+
+&mesh_options
+ meshname='cube'
+ cad_type=92
+ nlevels={0}
+ nbase={1}
+ grid_order=1
+/
+
+&cube_options
+ mesh_type=1
+/
+
+&test_io_options
+ test_id={2}
+/
+"""
+
+# Common setup function and process handling
+def io_setup(test_id, parallel = False):
+    nbase = 3
+    if parallel:
+        nlevels = 4
+        nproc = 2
+    else:
+        nlevels = 3
+        nproc = 1
+    #
+    os.chdir(test_dir)
+    with open('oft.in','w+') as fid:
+        fid.write(oft_in_template.format(nlevels,nbase,test_id))
+    return run_OFT("./test_io", nproc, 60)
+
+# Test runner for base test case
+@pytest.mark.coverage
+@pytest.mark.parametrize("test_id", (1,2,3,4,5))
+@pytest.mark.parametrize("parallel", (False,True))
+def test_base(test_id,parallel):
+    assert io_setup(test_id,parallel)

--- a/src/tests/oft_testing.py
+++ b/src/tests/oft_testing.py
@@ -3,8 +3,8 @@ import time
 import os
 import pytest
 
-def run_command(command):
-    pid = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def run_command(command, cwd=None):
+    pid = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
     outs, errs = pid.communicate()
     errcode = pid.poll()
     return outs, errs, errcode

--- a/src/tests/physics/test_Marklin.py
+++ b/src/tests/physics/test_Marklin.py
@@ -58,7 +58,7 @@ def run_marklin(meshfile,nmodes,order,grid_order,meshfile2,mp_q):
             taylor_solver = Marklin(myOFT)
             taylor_solver.setup_mesh(mesh_file=meshfile2,grid_order=grid_order)
             taylor_solver.setup(order,minlev=1)
-            taylor_solver.compute(nmodes,cache_file='Marklin_{0}.rst'.format(meshfile.split(".")[0]))
+            taylor_solver.compute(nmodes,cache_file='Marklin_{0}.rst'.format(meshfile2.split(".")[0]))
             result = True
         except BaseException as e:
             print(e)

--- a/src/tests/physics/test_Marklin.py
+++ b/src/tests/physics/test_Marklin.py
@@ -39,7 +39,7 @@ def mp_run(target,args,timeout=180):
     return test_result
 
 
-def run_marklin(meshfile,nmodes,order,grid_order,mp_q):
+def run_marklin(meshfile,nmodes,order,grid_order,meshfile2,mp_q):
     try:
         from OpenFUSIONToolkit import OFT_env
         from OpenFUSIONToolkit.Marklin import Marklin
@@ -47,11 +47,22 @@ def run_marklin(meshfile,nmodes,order,grid_order,mp_q):
         taylor_solver = Marklin(myOFT)
         taylor_solver.setup_mesh(mesh_file=meshfile,grid_order=grid_order)
         taylor_solver.setup(order,minlev=1)
-        taylor_solver.compute(nmodes)
+        taylor_solver.compute(nmodes,cache_file='Marklin_{0}.rst'.format(meshfile.split(".")[0]))
         result = True
     except BaseException as e:
         print(e)
         result = False
+    if (meshfile2 is not None) and result:
+        try:
+            taylor_solver_old = taylor_solver
+            taylor_solver = Marklin(myOFT)
+            taylor_solver.setup_mesh(mesh_file=meshfile2,grid_order=grid_order)
+            taylor_solver.setup(order,minlev=1)
+            taylor_solver.compute(nmodes,cache_file='Marklin_{0}.rst'.format(meshfile.split(".")[0]))
+            result = True
+        except BaseException as e:
+            print(e)
+            result = False
     oftpy_dump_cov()
     if result:
         mp_q.put(taylor_solver.eig_vals)
@@ -65,7 +76,7 @@ def validate_eigs(results,eigs):
         return False
     test_result = True
     if abs((results[0]-eigs)/eigs) > 1.E-4:
-        print("FAILED: psi error too high!")
+        print("FAILED: Eigenvalue error too high!")
         print("  Expected = {0}".format(eigs))
         print("  Actual =   {0}".format(results[0]))
         test_result = False
@@ -75,8 +86,8 @@ def validate_eigs(results,eigs):
 def marklin_lin_cell(order):
     eigs = [5.029946,4.958005,4.957746,4.957744]
     if order == 1:
-        run_command("rm -f *.rst")
-    results = mp_run(run_marklin,('cyl_Marklin.h5',1,order,1))
+        run_command("rm -f *.rst", cwd=test_dir)
+    results = mp_run(run_marklin,('cyl_Marklin.h5',1,order,1,None))
     assert validate_eigs(results,eigs[order-1])
 
 @pytest.mark.coverage
@@ -97,8 +108,8 @@ def test_marklin_g1_p4():
 def marklin_quad_cell(order):
     eigs = [5.027066,4.955207,4.954955,4.954955]
     if order == 1:
-        run_command("rm -f *.rst")
-    results = mp_run(run_marklin,('cyl_Marklin.h5',1,order,2))
+        run_command("rm -f *.rst", cwd=test_dir)
+    results = mp_run(run_marklin,('cyl_Marklin.h5',1,order,2,None))
     assert validate_eigs(results,eigs[order-1])
 
 @pytest.mark.coverage
@@ -115,8 +126,18 @@ def test_marklin_g2_p3():
 def test_marklin_g2_p4():
     marklin_quad_cell(4)
 
-# Example of how to run single test without pytest
+# Test runner for multiple concurrent Marklin instances
+def test_marklin_multiple():
+    cyl_eig = 4.955207
+    tor_eig = 6.317001
+    results = mp_run(run_marklin,('cyl_Marklin.h5',1,2,2,'torus_test.h5'))
+    assert validate_eigs(results,tor_eig)
+    results = mp_run(run_marklin,('torus_test.h5',1,2,2,'cyl_Marklin.h5'))
+    assert validate_eigs(results,cyl_eig)
+
+# # Example of how to run single test without pytest
 # if __name__ == '__main__':
 #     multiprocessing.freeze_support()
 #     mp_q = multiprocessing.Queue()
-#     run_marklin('cyl_Marklin.h5',1,order,1,mp_q)
+#     run_command("rm -f *.rst")
+#     run_marklin('cyl_Marklin.h5',1,2,2,'torus_test.h5',mp_q)

--- a/src/tests/physics/test_alfven.F90
+++ b/src/tests/physics/test_alfven.F90
@@ -37,8 +37,8 @@ USE oft_vector_inits, ONLY: uniform_field
 USE diagnostic, ONLY: vec_energy
 USE mhd_utils, ONLY: mu0, proton_mass
 USE xmhd, ONLY: xmhd_run, xmhd_plot, xmhd_minlev, xmhd_taxis, xmhd_lin_run, &
-  xmhd_sub_fields, ML_oft_hcurl, ML_oft_h1, &
-  ML_hcurl_grad, ML_h1grad, ML_oft_lagrange, ML_oft_vlagrange
+  xmhd_sub_fields, xmhd_ML_hcurl, xmhd_ML_H1, &
+  xmhd_ML_hcurl_grad, xmhd_ML_H1grad, xmhd_ML_lagrange, xmhd_ML_vlagrange
 USE test_phys_helpers, ONLY: alfven_eig
 IMPLICIT NONE
 !---Full H(Curl) space mass matrix solver
@@ -84,40 +84,40 @@ CALL multigrid_construct(mg_mesh)
 ! Build FE structures
 !---------------------------------------------------------------------------
 !--- Lagrange
-CALL oft_lag_setup(mg_mesh,order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange,minlev=minlev)
-CALL lag_setup_interp(ML_oft_lagrange)
+CALL oft_lag_setup(mg_mesh,order,xmhd_ML_lagrange,ML_vlag_obj=xmhd_ML_vlagrange,minlev=minlev)
+CALL lag_setup_interp(xmhd_ML_lagrange)
 !--- Grad(H^1) subspace
-CALL oft_h1_setup(mg_mesh,order+1,ML_oft_h1,minlev=minlev)
-CALL h1_setup_interp(ML_oft_h1)
+CALL oft_h1_setup(mg_mesh,order+1,xmhd_ML_H1,minlev=minlev)
+CALL h1_setup_interp(xmhd_ML_H1)
 !--- H(Curl) subspace
-CALL oft_hcurl_setup(mg_mesh,order,ML_oft_hcurl,minlev=minlev)
-CALL hcurl_setup_interp(ML_oft_hcurl)
+CALL oft_hcurl_setup(mg_mesh,order,xmhd_ML_hcurl,minlev=minlev)
+CALL hcurl_setup_interp(xmhd_ML_hcurl)
 !--- Full H(Curl) space
-CALL oft_hcurl_grad_setup(ML_oft_hcurl,ML_oft_h1,ML_hcurl_grad,ML_h1grad,minlev)
-CALL hcurl_grad_setup_interp(ML_hcurl_grad,ML_oft_h1)
-hcurl_grad_gzerop%ML_hcurl_grad_rep=>ML_hcurl_grad
+CALL oft_hcurl_grad_setup(xmhd_ML_hcurl,xmhd_ML_H1,xmhd_ML_hcurl_grad,xmhd_ML_H1grad,minlev)
+CALL hcurl_grad_setup_interp(xmhd_ML_hcurl_grad,xmhd_ML_H1)
+hcurl_grad_gzerop%ML_hcurl_grad_rep=>xmhd_ML_hcurl_grad
 !---------------------------------------------------------------------------
 ! Create Full H(Curl) space mass matrix solver
 !---------------------------------------------------------------------------
 NULLIFY(mop)
-CALL hcurl_grad_getmop(ML_hcurl_grad%current_level,mop,"none")
+CALL hcurl_grad_getmop(xmhd_ML_hcurl_grad%current_level,mop,"none")
 CALL create_cg_solver(minv)
 minv%A=>mop
 minv%its=-3
 minv%atol=1.d-10
 CALL create_diag_pre(minv%pre)
 !---
-CALL ML_hcurl_grad%vec_create(u)
-CALL ML_hcurl_grad%vec_create(v)
-CALL ML_hcurl_grad%vec_create(b)
-CALL ML_hcurl_grad%vec_create(db)
-CALL ML_hcurl_grad%vec_create(be)
-CALL ML_hcurl_grad%vec_create(bi)
+CALL xmhd_ML_hcurl_grad%vec_create(u)
+CALL xmhd_ML_hcurl_grad%vec_create(v)
+CALL xmhd_ML_hcurl_grad%vec_create(b)
+CALL xmhd_ML_hcurl_grad%vec_create(db)
+CALL xmhd_ML_hcurl_grad%vec_create(be)
+CALL xmhd_ML_hcurl_grad%vec_create(bi)
 !---------------------------------------------------------------------------
 ! Set uniform B0 = zhat
 !---------------------------------------------------------------------------
 z_field%val=(/0.d0,0.d0,1.d0/)
-CALL oft_hcurl_grad_project(ML_hcurl_grad%current_level,z_field,v)
+CALL oft_hcurl_grad_project(xmhd_ML_hcurl_grad%current_level,z_field,v)
 CALL hcurl_grad_gzerop%apply(v)
 CALL u%set(0.d0)
 CALL minv%apply(u,v)
@@ -127,7 +127,7 @@ CALL be%add(0.d0,1.d0,u)
 ! Set dB from alfven wave init
 !---------------------------------------------------------------------------
 alf_field%mesh=>mg_mesh%mesh
-CALL oft_hcurl_grad_project(ML_hcurl_grad%current_level,alf_field,v)
+CALL oft_hcurl_grad_project(xmhd_ML_hcurl_grad%current_level,alf_field,v)
 CALL hcurl_grad_gzerop%apply(v)
 CALL u%set(0.d0)
 CALL minv%apply(u,v)
@@ -138,22 +138,22 @@ CALL bi%add(0.d0,1.d0,u)
 ! Create Lagrange metric solver
 !---------------------------------------------------------------------------
 NULLIFY(lag_mop)
-CALL oft_lag_vgetmop(ML_oft_vlagrange%current_level,lag_mop,"none")
+CALL oft_lag_vgetmop(xmhd_ML_vlagrange%current_level,lag_mop,"none")
 CALL create_cg_solver(lag_minv)
 lag_minv%A=>lag_mop
 lag_minv%its=-3
 lag_minv%atol=1.d-10
 CALL create_diag_pre(lag_minv%pre)
 !---
-CALL ML_oft_vlagrange%vec_create(lag_u)
-CALL ML_oft_vlagrange%vec_create(lag_v)
-CALL ML_oft_vlagrange%vec_create(vel)
-CALL ML_oft_vlagrange%vec_create(dvel)
-CALL ML_oft_vlagrange%vec_create(vi)
+CALL xmhd_ML_vlagrange%vec_create(lag_u)
+CALL xmhd_ML_vlagrange%vec_create(lag_v)
+CALL xmhd_ML_vlagrange%vec_create(vel)
+CALL xmhd_ML_vlagrange%vec_create(dvel)
+CALL xmhd_ML_vlagrange%vec_create(vi)
 !---------------------------------------------------------------------------
 ! Set dB from alfven wave init
 !---------------------------------------------------------------------------
-CALL oft_lag_vproject(ML_oft_lagrange%current_level,alf_field,lag_v)
+CALL oft_lag_vproject(xmhd_ML_lagrange%current_level,alf_field,lag_v)
 CALL lag_u%set(0.d0)
 CALL lag_minv%apply(lag_u,lag_v)
 CALL dvel%add(0.d0,delta,lag_u)
@@ -169,10 +169,10 @@ IF(linear)THEN
   CALL db%scale(B0)
   CALL dvel%scale(v_alf)
   !
-  CALL ML_oft_lagrange%vec_create(den)
-  CALL ML_oft_lagrange%vec_create(temp)
-  CALL ML_oft_lagrange%vec_create(dden)
-  CALL ML_oft_lagrange%vec_create(dtemp)
+  CALL xmhd_ML_lagrange%vec_create(den)
+  CALL xmhd_ML_lagrange%vec_create(temp)
+  CALL xmhd_ML_lagrange%vec_create(dden)
+  CALL xmhd_ML_lagrange%vec_create(dtemp)
   CALL den%set(1.d19)
   CALL temp%set(1.d1)
   equil_fields%B=>b
@@ -197,8 +197,8 @@ ELSE
   CALL vel%add(0.d0,1.d0,dvel)
   CALL vel%scale(v_alf)
   !
-  CALL ML_oft_lagrange%vec_create(den)
-  CALL ML_oft_lagrange%vec_create(temp)
+  CALL xmhd_ML_lagrange%vec_create(den)
+  CALL xmhd_ML_lagrange%vec_create(temp)
   CALL den%set(1.d19)
   CALL temp%set(1.d1)
   equil_fields%B=>b
@@ -219,7 +219,7 @@ CALL b%scale(1.d0/B0)
 CALL b%add(-1.d0,1.d0,be)
 CALL b%scale(1.d0/delta)
 bfield%u=>b
-CALL bfield%setup(ML_hcurl_grad%current_level)
+CALL bfield%setup(xmhd_ML_hcurl_grad%current_level)
 berr=vec_energy(mg_mesh%mesh,err_field,order*2)
 !---Check velocity field waveform
 vierr=vec_energy(mg_mesh%mesh,alf_field,order*2)
@@ -228,7 +228,7 @@ err_field%a=>alf_field
 err_field%b=>vfield
 CALL vel%scale(-1.d0/(delta*v_alf))
 vfield%u=>vel
-CALL vfield%setup(ML_oft_lagrange%current_level)
+CALL vfield%setup(xmhd_ML_lagrange%current_level)
 verr=vec_energy(mg_mesh%mesh,err_field,order*2)
 !---Output wave comparisons
 IF(oft_env%head_proc)THEN

--- a/src/tests/physics/test_alfven.F90
+++ b/src/tests/physics/test_alfven.F90
@@ -84,15 +84,19 @@ CALL multigrid_construct(mg_mesh)
 ! Build FE structures
 !---------------------------------------------------------------------------
 !--- Lagrange
+ALLOCATE(xmhd_ML_lagrange,xmhd_ML_vlagrange)
 CALL oft_lag_setup(mg_mesh,order,xmhd_ML_lagrange,ML_vlag_obj=xmhd_ML_vlagrange,minlev=minlev)
 CALL lag_setup_interp(xmhd_ML_lagrange)
 !--- Grad(H^1) subspace
+ALLOCATE(xmhd_ML_H1)
 CALL oft_h1_setup(mg_mesh,order+1,xmhd_ML_H1,minlev=minlev)
 CALL h1_setup_interp(xmhd_ML_H1)
 !--- H(Curl) subspace
+ALLOCATE(xmhd_ML_hcurl)
 CALL oft_hcurl_setup(mg_mesh,order,xmhd_ML_hcurl,minlev=minlev)
 CALL hcurl_setup_interp(xmhd_ML_hcurl)
 !--- Full H(Curl) space
+ALLOCATE(xmhd_ML_hcurl_grad,xmhd_ML_H1grad)
 CALL oft_hcurl_grad_setup(xmhd_ML_hcurl,xmhd_ML_H1,xmhd_ML_hcurl_grad,xmhd_ML_H1grad,minlev)
 CALL hcurl_grad_setup_interp(xmhd_ML_hcurl_grad,xmhd_ML_H1)
 hcurl_grad_gzerop%ML_hcurl_grad_rep=>xmhd_ML_hcurl_grad

--- a/src/tests/physics/test_alfven_lag.F90
+++ b/src/tests/physics/test_alfven_lag.F90
@@ -69,6 +69,7 @@ CALL multigrid_construct(mg_mesh)
 !---------------------------------------------------------------------------
 ! Build FE structures
 !---------------------------------------------------------------------------
+ALLOCATE(xmhd_ML_lagrange,xmhd_ML_vlagrange)
 !---Lagrange
 CALL oft_lag_setup(mg_mesh,order,xmhd_ML_lagrange,ML_vlag_obj=xmhd_ML_vlagrange,minlev=minlev)
 CALL lag_setup_interp(xmhd_ML_lagrange)

--- a/src/tests/physics/test_alfven_lag.F90
+++ b/src/tests/physics/test_alfven_lag.F90
@@ -29,7 +29,7 @@ USE oft_vector_inits, ONLY: uniform_field
 USE diagnostic, ONLY: vec_energy
 USE mhd_utils, ONLY: mu0, proton_mass
 USE xmhd_lag, ONLY: xmhd_run, xmhd_plot, xmhd_minlev, xmhd_taxis, xmhd_lin_run, &
-  xmhd_sub_fields, ML_oft_lagrange, ML_oft_vlagrange
+  xmhd_sub_fields, xmhd_ML_lagrange, xmhd_ML_vlagrange
 USE test_phys_helpers, ONLY: alfven_eig
 IMPLICIT NONE
 !---Lagrange mass matrix solver
@@ -70,33 +70,33 @@ CALL multigrid_construct(mg_mesh)
 ! Build FE structures
 !---------------------------------------------------------------------------
 !---Lagrange
-CALL oft_lag_setup(mg_mesh,order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange,minlev=minlev)
-CALL lag_setup_interp(ML_oft_lagrange)
+CALL oft_lag_setup(mg_mesh,order,xmhd_ML_lagrange,ML_vlag_obj=xmhd_ML_vlagrange,minlev=minlev)
+CALL lag_setup_interp(xmhd_ML_lagrange)
 !---------------------------------------------------------------------------
 ! Create Lagrange metric solver
 !---------------------------------------------------------------------------
 NULLIFY(mop)
-CALL oft_lag_vgetmop(ML_oft_vlagrange%current_level,mop,"none")
+CALL oft_lag_vgetmop(xmhd_ML_vlagrange%current_level,mop,"none")
 CALL create_cg_solver(minv)
 minv%A=>mop
 minv%its=-3
 minv%atol=1.d-10
 CALL create_diag_pre(minv%pre)
 !---
-CALL ML_oft_vlagrange%vec_create(u)
-CALL ML_oft_vlagrange%vec_create(v)
-CALL ML_oft_vlagrange%vec_create(b)
-CALL ML_oft_vlagrange%vec_create(db)
-CALL ML_oft_vlagrange%vec_create(be)
-CALL ML_oft_vlagrange%vec_create(bi)
-CALL ML_oft_vlagrange%vec_create(vel)
-CALL ML_oft_vlagrange%vec_create(dvel)
-CALL ML_oft_vlagrange%vec_create(vi)
+CALL xmhd_ML_vlagrange%vec_create(u)
+CALL xmhd_ML_vlagrange%vec_create(v)
+CALL xmhd_ML_vlagrange%vec_create(b)
+CALL xmhd_ML_vlagrange%vec_create(db)
+CALL xmhd_ML_vlagrange%vec_create(be)
+CALL xmhd_ML_vlagrange%vec_create(bi)
+CALL xmhd_ML_vlagrange%vec_create(vel)
+CALL xmhd_ML_vlagrange%vec_create(dvel)
+CALL xmhd_ML_vlagrange%vec_create(vi)
 !---------------------------------------------------------------------------
 ! Set uniform B0 = zhat
 !---------------------------------------------------------------------------
 z_field%val=(/0.d0,0.d0,1.d0/)
-CALL oft_lag_vproject(ML_oft_lagrange%current_level,z_field,v)
+CALL oft_lag_vproject(xmhd_ML_lagrange%current_level,z_field,v)
 CALL u%set(0.d0)
 CALL minv%apply(u,v)
 CALL b%add(0.d0,1.d0,u)
@@ -105,7 +105,7 @@ CALL be%add(0.d0,1.d0,u)
 ! Set dB from alfven wave init
 !---------------------------------------------------------------------------
 alf_field%mesh=>mg_mesh%mesh
-CALL oft_lag_vproject(ML_oft_lagrange%current_level,alf_field,v)
+CALL oft_lag_vproject(xmhd_ML_lagrange%current_level,alf_field,v)
 CALL u%set(0.d0)
 CALL minv%apply(u,v)
 CALL db%add(0.d0,delta,u)
@@ -114,7 +114,7 @@ CALL bi%add(0.d0,1.d0,u)
 !---------------------------------------------------------------------------
 ! Set dV from alfven wave init
 !---------------------------------------------------------------------------
-CALL oft_lag_vproject(ML_oft_lagrange%current_level,alf_field,v)
+CALL oft_lag_vproject(xmhd_ML_lagrange%current_level,alf_field,v)
 CALL u%set(0.d0)
 CALL minv%apply(u,v)
 CALL dvel%add(0.d0,delta,u)
@@ -129,10 +129,10 @@ IF(linear)THEN
   CALL b%scale(B0)
   CALL db%scale(B0)
   CALL dvel%scale(v_alf)
-  CALL ML_oft_lagrange%vec_create(den)
-  CALL ML_oft_lagrange%vec_create(temp)
-  CALL ML_oft_lagrange%vec_create(dden)
-  CALL ML_oft_lagrange%vec_create(dtemp)
+  CALL xmhd_ML_lagrange%vec_create(den)
+  CALL xmhd_ML_lagrange%vec_create(temp)
+  CALL xmhd_ML_lagrange%vec_create(dden)
+  CALL xmhd_ML_lagrange%vec_create(dtemp)
   CALL den%set(1.d19)
   CALL temp%set(1.d1)
   equil_fields%B=>b
@@ -156,8 +156,8 @@ ELSE
   CALL b%scale(B0)
   CALL vel%add(0.d0,1.d0,dvel)
   CALL vel%scale(v_alf)
-  CALL ML_oft_lagrange%vec_create(den)
-  CALL ML_oft_lagrange%vec_create(temp)
+  CALL xmhd_ML_lagrange%vec_create(den)
+  CALL xmhd_ML_lagrange%vec_create(temp)
   CALL den%set(1.d19)
   CALL temp%set(1.d1)
   equil_fields%B=>b
@@ -178,7 +178,7 @@ CALL b%scale(1.d0/B0)
 CALL b%add(-1.d0,1.d0,be)
 CALL b%scale(1.d0/delta)
 bfield%u=>b
-CALL bfield%setup(ML_oft_lagrange%current_level)
+CALL bfield%setup(xmhd_ML_lagrange%current_level)
 berr=vec_energy(mg_mesh%mesh,err_field,order*2)
 !---Check velocity field waveform
 vierr=vec_energy(mg_mesh%mesh,alf_field,order*2)
@@ -187,7 +187,7 @@ err_field%a=>alf_field
 err_field%b=>vfield
 CALL vel%scale(-1.d0/(delta*v_alf))
 vfield%u=>vel
-CALL vfield%setup(ML_oft_lagrange%current_level)
+CALL vfield%setup(xmhd_ML_lagrange%current_level)
 verr=vec_energy(mg_mesh%mesh,err_field,order*2)
 !---Output wave comparisons
 IF(oft_env%head_proc)THEN

--- a/src/tests/physics/test_sound.F90
+++ b/src/tests/physics/test_sound.F90
@@ -81,15 +81,19 @@ CALL multigrid_construct(mg_mesh)
 ! Build FE structures
 !---------------------------------------------------------------------------
 !--- Lagrange
+ALLOCATE(xmhd_ML_lagrange,xmhd_ML_vlagrange)
 CALL oft_lag_setup(mg_mesh,order,xmhd_ML_lagrange,ML_vlag_obj=xmhd_ML_vlagrange,minlev=minlev)
 CALL lag_setup_interp(xmhd_ML_lagrange)
 !--- Grad(H^1) subspace
+ALLOCATE(xmhd_ML_H1)
 CALL oft_h1_setup(mg_mesh,order+1,xmhd_ML_H1,minlev=minlev)
 CALL h1_setup_interp(xmhd_ML_H1)
 !--- H(Curl) subspace
+ALLOCATE(xmhd_ML_hcurl)
 CALL oft_hcurl_setup(mg_mesh,order,xmhd_ML_hcurl,minlev=minlev)
 CALL hcurl_setup_interp(xmhd_ML_hcurl)
 !--- Full H(Curl) space
+ALLOCATE(xmhd_ML_hcurl_grad,xmhd_ML_H1grad)
 CALL oft_hcurl_grad_setup(xmhd_ML_hcurl,xmhd_ML_H1,xmhd_ML_hcurl_grad,xmhd_ML_H1grad,minlev)
 CALL hcurl_grad_setup_interp(xmhd_ML_hcurl_grad,xmhd_ML_H1)
 !---------------------------------------------------------------------------

--- a/src/tests/physics/test_sound.F90
+++ b/src/tests/physics/test_sound.F90
@@ -35,8 +35,8 @@ USE oft_hcurl_grad_operators, ONLY: hcurl_grad_setup_interp, hcurl_grad_getmop, 
 USE diagnostic, ONLY: scal_energy, vec_energy
 USE mhd_utils, ONLY: elec_charge, proton_mass
 USE xmhd, ONLY: xmhd_run, xmhd_plot, xmhd_minlev, xmhd_taxis, temp_floor, &
-  xmhd_lin_run, xmhd_adv_b, xmhd_sub_fields, ML_oft_hcurl, ML_oft_h1, &
-  ML_hcurl_grad, ML_h1grad, ML_oft_lagrange, ML_oft_vlagrange
+  xmhd_lin_run, xmhd_adv_b, xmhd_sub_fields, xmhd_ML_hcurl, xmhd_ML_H1, &
+  xmhd_ML_hcurl_grad, xmhd_ML_H1grad, xmhd_ML_lagrange, xmhd_ML_vlagrange
 USE test_phys_helpers, ONLY: sound_eig
 IMPLICIT NONE
 !---Lagrange Metric solver
@@ -81,43 +81,43 @@ CALL multigrid_construct(mg_mesh)
 ! Build FE structures
 !---------------------------------------------------------------------------
 !--- Lagrange
-CALL oft_lag_setup(mg_mesh,order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange,minlev=minlev)
-CALL lag_setup_interp(ML_oft_lagrange)
+CALL oft_lag_setup(mg_mesh,order,xmhd_ML_lagrange,ML_vlag_obj=xmhd_ML_vlagrange,minlev=minlev)
+CALL lag_setup_interp(xmhd_ML_lagrange)
 !--- Grad(H^1) subspace
-CALL oft_h1_setup(mg_mesh,order+1,ML_oft_h1,minlev=minlev)
-CALL h1_setup_interp(ML_oft_h1)
+CALL oft_h1_setup(mg_mesh,order+1,xmhd_ML_H1,minlev=minlev)
+CALL h1_setup_interp(xmhd_ML_H1)
 !--- H(Curl) subspace
-CALL oft_hcurl_setup(mg_mesh,order,ML_oft_hcurl,minlev=minlev)
-CALL hcurl_setup_interp(ML_oft_hcurl)
+CALL oft_hcurl_setup(mg_mesh,order,xmhd_ML_hcurl,minlev=minlev)
+CALL hcurl_setup_interp(xmhd_ML_hcurl)
 !--- Full H(Curl) space
-CALL oft_hcurl_grad_setup(ML_oft_hcurl,ML_oft_h1,ML_hcurl_grad,ML_h1grad,minlev)
-CALL hcurl_grad_setup_interp(ML_hcurl_grad,ML_oft_h1)
+CALL oft_hcurl_grad_setup(xmhd_ML_hcurl,xmhd_ML_H1,xmhd_ML_hcurl_grad,xmhd_ML_H1grad,minlev)
+CALL hcurl_grad_setup_interp(xmhd_ML_hcurl_grad,xmhd_ML_H1)
 !---------------------------------------------------------------------------
 ! Create Lagrange metric solver
 !---------------------------------------------------------------------------
 NULLIFY(mop)
-CALL oft_lag_getmop(ML_oft_lagrange%current_level,mop,"none")
+CALL oft_lag_getmop(xmhd_ML_lagrange%current_level,mop,"none")
 CALL create_cg_solver(minv)
 minv%A=>mop
 minv%its=-3
 minv%atol=1.d-10
 CALL create_diag_pre(minv%pre)
 !---
-CALL ML_oft_lagrange%vec_create(u)
-CALL ML_oft_lagrange%vec_create(v)
-CALL ML_oft_lagrange%vec_create(n)
-CALL ML_oft_lagrange%vec_create(dn)
-CALL ML_oft_lagrange%vec_create(ni)
-CALL ML_oft_lagrange%vec_create(temp)
-CALL ML_oft_lagrange%vec_create(dtemp)
-CALL ML_oft_lagrange%vec_create(ti)
+CALL xmhd_ML_lagrange%vec_create(u)
+CALL xmhd_ML_lagrange%vec_create(v)
+CALL xmhd_ML_lagrange%vec_create(n)
+CALL xmhd_ML_lagrange%vec_create(dn)
+CALL xmhd_ML_lagrange%vec_create(ni)
+CALL xmhd_ML_lagrange%vec_create(temp)
+CALL xmhd_ML_lagrange%vec_create(dtemp)
+CALL xmhd_ML_lagrange%vec_create(ti)
 !---------------------------------------------------------------------------
 ! Set dn from sound wave init
 !---------------------------------------------------------------------------
 sound_field%mesh=>mg_mesh%mesh
 sound_field%delta=delta
 sound_field%field='n'
-CALL oft_lag_project(ML_oft_lagrange%current_level,sound_field,v)
+CALL oft_lag_project(xmhd_ML_lagrange%current_level,sound_field,v)
 CALL u%set(0.d0)
 CALL minv%apply(u,v)
 CALL n%set(1.d0)
@@ -127,7 +127,7 @@ CALL ni%add(0.d0,1.d0,dn)
 ! Set dt from sound wave init
 !---------------------------------------------------------------------------
 sound_field%field='t'
-CALL oft_lag_project(ML_oft_lagrange%current_level,sound_field,v)
+CALL oft_lag_project(xmhd_ML_lagrange%current_level,sound_field,v)
 CALL u%set(0.d0)
 CALL minv%apply(u,v)
 CALL temp%set(1.d0)
@@ -145,22 +145,22 @@ CALL minv%delete
 ! Create Lagrange vector metric solver
 !---------------------------------------------------------------------------
 NULLIFY(mop)
-CALL oft_lag_vgetmop(ML_oft_vlagrange%current_level,mop,"none")
+CALL oft_lag_vgetmop(xmhd_ML_vlagrange%current_level,mop,"none")
 minv%A=>mop
 minv%its=-3
 minv%atol=1.d-10
 CALL create_diag_pre(minv%pre)
 !---
-CALL ML_oft_vlagrange%vec_create(u)
-CALL ML_oft_vlagrange%vec_create(v)
-CALL ML_oft_vlagrange%vec_create(vel)
-CALL ML_oft_vlagrange%vec_create(dvel)
-CALL ML_oft_vlagrange%vec_create(vi)
+CALL xmhd_ML_vlagrange%vec_create(u)
+CALL xmhd_ML_vlagrange%vec_create(v)
+CALL xmhd_ML_vlagrange%vec_create(vel)
+CALL xmhd_ML_vlagrange%vec_create(dvel)
+CALL xmhd_ML_vlagrange%vec_create(vi)
 !---------------------------------------------------------------------------
 ! Set dV from sound wave init
 !---------------------------------------------------------------------------
 sound_field%field='v'
-CALL oft_lag_vproject(ML_oft_lagrange%current_level,sound_field,v)
+CALL oft_lag_vproject(xmhd_ML_lagrange%current_level,sound_field,v)
 CALL u%set(0.d0)
 CALL minv%apply(u,v)
 v_delta=T0*elec_charge/(proton_mass*v_sound)
@@ -174,8 +174,8 @@ DEALLOCATE(u,v,mop)
 !---------------------------------------------------------------------------
 ! Run simulation and test result
 !---------------------------------------------------------------------------
-CALL ML_hcurl_grad%vec_create(b)
-CALL ML_hcurl_grad%vec_create(db)
+CALL xmhd_ML_hcurl_grad%vec_create(b)
+CALL xmhd_ML_hcurl_grad%vec_create(db)
 xmhd_minlev=minlev
 xmhd_taxis=2
 xmhd_adv_b=.FALSE.
@@ -187,9 +187,9 @@ IF(linear)THEN
   CALL temp%scale(T0)
   CALL dtemp%scale(T0)
   IF(two_temp)THEN
-    CALL ML_oft_lagrange%vec_create(tempe)
+    CALL xmhd_ML_lagrange%vec_create(tempe)
     CALL tempe%add(0.d0,1.d0,temp)
-    CALL ML_oft_lagrange%vec_create(dtempe)
+    CALL xmhd_ML_lagrange%vec_create(dtempe)
     CALL dtempe%add(0.d0,1.d0,dtemp)
     equil_fields%Te=>tempe
     pert_fields%Te=>dtempe
@@ -216,7 +216,7 @@ ELSE
   CALL temp%add(1.d0,1.d0,dtemp)
   CALL temp%scale(T0)
   IF(two_temp)THEN
-    CALL ML_oft_lagrange%vec_create(tempe)
+    CALL xmhd_ML_lagrange%vec_create(tempe)
     CALL tempe%add(0.d0,1.d0,temp)
     equil_fields%Te=>tempe
   END IF
@@ -226,7 +226,7 @@ ELSE
   equil_fields%Ti=>temp
   CALL xmhd_run(equil_fields)
 END IF
-CALL ML_oft_lagrange%vec_create(u)
+CALL xmhd_ML_lagrange%vec_create(u)
 CALL u%set(1.d0)
 !---Compare density waveform
 sound_field%field='n'
@@ -238,7 +238,7 @@ err_field%b=>sfield
 CALL n%scale(1.d0/N0)
 CALL n%add(1.d0,-1.d0,u)
 sfield%u=>n
-CALL sfield%setup(ML_oft_lagrange%current_level)
+CALL sfield%setup(xmhd_ML_lagrange%current_level)
 nerr=scal_energy(mg_mesh%mesh,err_field,order*2)
 !---Compare temperature waveform
 sound_field%field='t'
@@ -255,7 +255,7 @@ IF(two_temp)THEN
   CALL temp%add(5.d-1,5.d-1,tempe)
 END IF
 sfield%u=>temp
-CALL sfield%setup(ML_oft_lagrange%current_level)
+CALL sfield%setup(xmhd_ML_lagrange%current_level)
 terr=scal_energy(mg_mesh%mesh,err_field,order*2)
 !---Compare velocity waveform
 sound_field%field='v'
@@ -266,7 +266,7 @@ err_field%a=>sound_field
 err_field%b=>vfield
 CALL vel%scale(1.d0/v_delta)
 vfield%u=>vel
-CALL vfield%setup(ML_oft_lagrange%current_level)
+CALL vfield%setup(xmhd_ML_lagrange%current_level)
 verr=vec_energy(mg_mesh%mesh,err_field,order*2)
 !---Output wave comparisons
 IF(oft_env%head_proc)THEN

--- a/src/tests/physics/test_sound_lag.F90
+++ b/src/tests/physics/test_sound_lag.F90
@@ -28,7 +28,7 @@ USE oft_lag_operators, ONLY: lag_setup_interp, oft_lag_vproject, oft_lag_vgetmop
 USE diagnostic, ONLY: scal_energy, vec_energy
 USE mhd_utils, ONLY: elec_charge, proton_mass
 USE xmhd_lag, ONLY: xmhd_run, xmhd_plot, xmhd_minlev, xmhd_taxis, temp_floor, &
-  xmhd_lin_run, xmhd_adv_b, xmhd_sub_fields, ML_oft_lagrange, ML_oft_vlagrange
+  xmhd_lin_run, xmhd_adv_b, xmhd_sub_fields, xmhd_ML_lagrange, xmhd_ML_vlagrange
 USE test_phys_helpers, ONLY: sound_eig
 IMPLICIT NONE
 !---Lagrange Metric solver
@@ -73,34 +73,34 @@ CALL multigrid_construct(mg_mesh)
 ! Build FE structures
 !---------------------------------------------------------------------------
 !---Lagrange
-CALL oft_lag_setup(mg_mesh,order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange,minlev=minlev)
-CALL lag_setup_interp(ML_oft_lagrange)
+CALL oft_lag_setup(mg_mesh,order,xmhd_ML_lagrange,ML_vlag_obj=xmhd_ML_vlagrange,minlev=minlev)
+CALL lag_setup_interp(xmhd_ML_lagrange)
 !---------------------------------------------------------------------------
 ! Create Lagrange metric solver
 !---------------------------------------------------------------------------
 NULLIFY(mop)
-CALL oft_lag_getmop(ML_oft_lagrange%current_level,mop,"none")
+CALL oft_lag_getmop(xmhd_ML_lagrange%current_level,mop,"none")
 CALL create_cg_solver(minv)
 minv%A=>mop
 minv%its=-3
 minv%atol=1.d-10
 CALL create_diag_pre(minv%pre)
 !---
-CALL ML_oft_lagrange%vec_create(u)
-CALL ML_oft_lagrange%vec_create(v)
-CALL ML_oft_lagrange%vec_create(n)
-CALL ML_oft_lagrange%vec_create(dn)
-CALL ML_oft_lagrange%vec_create(ni)
-CALL ML_oft_lagrange%vec_create(temp)
-CALL ML_oft_lagrange%vec_create(dtemp)
-CALL ML_oft_lagrange%vec_create(ti)
+CALL xmhd_ML_lagrange%vec_create(u)
+CALL xmhd_ML_lagrange%vec_create(v)
+CALL xmhd_ML_lagrange%vec_create(n)
+CALL xmhd_ML_lagrange%vec_create(dn)
+CALL xmhd_ML_lagrange%vec_create(ni)
+CALL xmhd_ML_lagrange%vec_create(temp)
+CALL xmhd_ML_lagrange%vec_create(dtemp)
+CALL xmhd_ML_lagrange%vec_create(ti)
 !---------------------------------------------------------------------------
 ! Set dn from sound wave init
 !---------------------------------------------------------------------------
 sound_field%mesh=>mg_mesh%mesh
 sound_field%delta=delta
 sound_field%field='n'
-CALL oft_lag_project(ML_oft_lagrange%current_level,sound_field,v)
+CALL oft_lag_project(xmhd_ML_lagrange%current_level,sound_field,v)
 CALL u%set(0.d0)
 CALL minv%apply(u,v)
 CALL n%set(1.d0)
@@ -110,7 +110,7 @@ CALL ni%add(0.d0,1.d0,dn)
 ! Set dt from sound wave init
 !---------------------------------------------------------------------------
 sound_field%field='t'
-CALL oft_lag_project(ML_oft_lagrange%current_level,sound_field,v)
+CALL oft_lag_project(xmhd_ML_lagrange%current_level,sound_field,v)
 CALL u%set(0.d0)
 CALL minv%apply(u,v)
 CALL temp%set(1.d0)
@@ -128,22 +128,22 @@ CALL minv%delete
 ! Create Lagrange vector metric solver
 !---------------------------------------------------------------------------
 NULLIFY(mop)
-CALL oft_lag_vgetmop(ML_oft_vlagrange%current_level,mop,"none")
+CALL oft_lag_vgetmop(xmhd_ML_vlagrange%current_level,mop,"none")
 minv%A=>mop
 minv%its=-3
 minv%atol=1.d-10
 CALL create_diag_pre(minv%pre)
 !---
-CALL ML_oft_vlagrange%vec_create(u)
-CALL ML_oft_vlagrange%vec_create(v)
-CALL ML_oft_vlagrange%vec_create(vel)
-CALL ML_oft_vlagrange%vec_create(dvel)
-CALL ML_oft_vlagrange%vec_create(vi)
+CALL xmhd_ML_vlagrange%vec_create(u)
+CALL xmhd_ML_vlagrange%vec_create(v)
+CALL xmhd_ML_vlagrange%vec_create(vel)
+CALL xmhd_ML_vlagrange%vec_create(dvel)
+CALL xmhd_ML_vlagrange%vec_create(vi)
 !---------------------------------------------------------------------------
 ! Set dV from sound wave init
 !---------------------------------------------------------------------------
 sound_field%field='v'
-CALL oft_lag_vproject(ML_oft_lagrange%current_level,sound_field,v)
+CALL oft_lag_vproject(xmhd_ML_lagrange%current_level,sound_field,v)
 CALL u%set(0.d0)
 CALL minv%apply(u,v)
 v_delta=T0*elec_charge/(proton_mass*v_sound)
@@ -157,8 +157,8 @@ DEALLOCATE(u,v,mop)
 !---------------------------------------------------------------------------
 ! Run simulation and test result
 !---------------------------------------------------------------------------
-CALL ML_oft_vlagrange%vec_create(b)
-CALL ML_oft_vlagrange%vec_create(db)
+CALL xmhd_ML_vlagrange%vec_create(b)
+CALL xmhd_ML_vlagrange%vec_create(db)
 xmhd_minlev=minlev
 xmhd_taxis=2
 xmhd_adv_b=.FALSE.
@@ -170,9 +170,9 @@ IF(linear)THEN
   CALL temp%scale(T0)
   CALL dtemp%scale(T0)
   IF(two_temp)THEN
-    CALL ML_oft_lagrange%vec_create(tempe)
+    CALL xmhd_ML_lagrange%vec_create(tempe)
     CALL tempe%add(0.d0,1.d0,temp)
-    CALL ML_oft_lagrange%vec_create(dtempe)
+    CALL xmhd_ML_lagrange%vec_create(dtempe)
     CALL dtempe%add(0.d0,1.d0,dtemp)
     equil_fields%Te=>tempe
     pert_fields%Te=>dtempe
@@ -199,7 +199,7 @@ ELSE
   CALL temp%add(1.d0,1.d0,dtemp)
   CALL temp%scale(T0)
   IF(two_temp)THEN
-    CALL ML_oft_lagrange%vec_create(tempe)
+    CALL xmhd_ML_lagrange%vec_create(tempe)
     CALL tempe%add(0.d0,1.d0,temp)
     equil_fields%Te=>tempe
   END IF
@@ -209,7 +209,7 @@ ELSE
   equil_fields%Ti=>temp
   CALL xmhd_run(equil_fields)
 END IF
-CALL ML_oft_lagrange%vec_create(u)
+CALL xmhd_ML_lagrange%vec_create(u)
 CALL u%set(1.d0)
 !---Compare density waveform
 sound_field%field='n'
@@ -221,7 +221,7 @@ err_field%b=>sfield
 CALL n%scale(1.d0/N0)
 CALL n%add(1.d0,-1.d0,u)
 sfield%u=>n
-CALL sfield%setup(ML_oft_lagrange%current_level)
+CALL sfield%setup(xmhd_ML_lagrange%current_level)
 nerr=scal_energy(mg_mesh%mesh,err_field,order*2)
 !---Compare temperature waveform
 sound_field%field='t'
@@ -238,7 +238,7 @@ IF(two_temp)THEN
   CALL temp%add(5.d-1,5.d-1,tempe)
 END IF
 sfield%u=>temp
-CALL sfield%setup(ML_oft_lagrange%current_level)
+CALL sfield%setup(xmhd_ML_lagrange%current_level)
 terr=scal_energy(mg_mesh%mesh,err_field,order*2)
 !---Compare velocity waveform
 sound_field%field='v'
@@ -249,7 +249,7 @@ err_field%a=>sound_field
 err_field%b=>vfield
 CALL vel%scale(1.d0/v_delta)
 vfield%u=>vel
-CALL vfield%setup(ML_oft_lagrange%current_level)
+CALL vfield%setup(xmhd_ML_lagrange%current_level)
 verr=vec_energy(mg_mesh%mesh,err_field,order*2)
 !---Output wave comparisons
 IF(oft_env%head_proc)THEN

--- a/src/tests/physics/test_sound_lag.F90
+++ b/src/tests/physics/test_sound_lag.F90
@@ -72,6 +72,7 @@ CALL multigrid_construct(mg_mesh)
 !---------------------------------------------------------------------------
 ! Build FE structures
 !---------------------------------------------------------------------------
+ALLOCATE(xmhd_ML_lagrange,xmhd_ML_vlagrange)
 !---Lagrange
 CALL oft_lag_setup(mg_mesh,order,xmhd_ML_lagrange,ML_vlag_obj=xmhd_ML_vlagrange,minlev=minlev)
 CALL lag_setup_interp(xmhd_ML_lagrange)

--- a/src/tests/physics/test_taylor.F90
+++ b/src/tests/physics/test_taylor.F90
@@ -20,11 +20,11 @@ USE oft_lag_basis, ONLY: oft_lag_setup
 USE oft_lag_operators, ONLY: lag_setup_interp, lag_mloptions
 USE oft_hcurl_basis, ONLY: oft_hcurl_setup
 USE oft_hcurl_operators, ONLY: hcurl_setup_interp, hcurl_mloptions
-USE taylor, ONLY: taylor_hmodes, oft_taylor_eigs
+USE taylor, ONLY: taylor_hmodes, oft_taylor_hmodes
 implicit none
 INTEGER(i4) :: order=1,nm=1,ierr,io_unit
 TYPE(multigrid_mesh) :: mg_mesh
-TYPE(oft_taylor_eigs) :: taylor_states
+TYPE(oft_taylor_hmodes) :: taylor_states
 LOGICAL :: mg_test=.FALSE.
 NAMELIST/test_taylor_options/order,nm,mg_test
 !---Initialize enviroment

--- a/src/tests/physics/test_taylor.F90
+++ b/src/tests/physics/test_taylor.F90
@@ -20,11 +20,11 @@ USE oft_lag_basis, ONLY: oft_lag_setup
 USE oft_lag_operators, ONLY: lag_setup_interp, lag_mloptions
 USE oft_hcurl_basis, ONLY: oft_hcurl_setup
 USE oft_hcurl_operators, ONLY: hcurl_setup_interp, hcurl_mloptions
-USE taylor, ONLY: taylor_minlev, taylor_hmodes, taylor_hlam, &
-  taylor_htor, ML_oft_hcurl, ML_oft_lagrange, ML_oft_vlagrange
+USE taylor, ONLY: taylor_hmodes, oft_taylor_eigs
 implicit none
 INTEGER(i4) :: order=1,nm=1,ierr,io_unit
 TYPE(multigrid_mesh) :: mg_mesh
+TYPE(oft_taylor_eigs) :: taylor_states
 LOGICAL :: mg_test=.FALSE.
 NAMELIST/test_taylor_options/order,nm,mg_test
 !---Initialize enviroment
@@ -37,31 +37,32 @@ CLOSE(io_unit)
 CALL multigrid_construct(mg_mesh)
 IF(mg_mesh%mesh%cad_type/=mesh_sphere_id)CALL oft_abort('Wrong mesh type, test for SPHERE only.','main',__FILE__)
 IF(mg_test)THEN
-  taylor_minlev=2
-  IF(oft_env%nprocs>1)taylor_minlev=mg_mesh%nbase+1
-  IF(mg_mesh%mesh%type==3)taylor_minlev=mg_mesh%mgmax
+  taylor_states%minlev=2
+  IF(oft_env%nprocs>1)taylor_states%minlev=mg_mesh%nbase+1
+  IF(mg_mesh%mesh%type==3)taylor_states%minlev=mg_mesh%mgmax
 ELSE
-  taylor_minlev=mg_mesh%mgmax+order-1
+  taylor_states%minlev=mg_mesh%mgmax+order-1
+END IF
+ALLOCATE(taylor_states%ML_hcurl,taylor_states%ML_lagrange)
+!---
+CALL oft_hcurl_setup(mg_mesh,order,taylor_states%ML_hcurl,minlev=taylor_states%minlev)
+IF(mg_test)THEN
+  CALL hcurl_setup_interp(taylor_states%ML_hcurl)
+  CALL hcurl_mloptions(taylor_states%ML_hcurl)
 END IF
 !---
-CALL oft_hcurl_setup(mg_mesh,order,ML_oft_hcurl,minlev=taylor_minlev)
+CALL oft_lag_setup(mg_mesh,order,taylor_states%ML_lagrange,minlev=taylor_states%minlev)
 IF(mg_test)THEN
-  CALL hcurl_setup_interp(ML_oft_hcurl)
-  CALL hcurl_mloptions(ML_oft_hcurl)
-END IF
-!---
-CALL oft_lag_setup(mg_mesh,order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange,minlev=taylor_minlev)
-IF(mg_test)THEN
-  CALL lag_setup_interp(ML_oft_lagrange)
+  CALL lag_setup_interp(taylor_states%ML_lagrange)
   CALL lag_mloptions
 END IF
 !---Run tests
 oft_env%pm=.FALSE.
-CALL taylor_hmodes(nm)
+CALL taylor_hmodes(taylor_states,nm,rst_filename='oft_taylor.rst')
 IF(oft_env%head_proc)THEN
   OPEN(NEWUNIT=io_unit,FILE='taylor.results')
-  WRITE(io_unit,*)taylor_hlam(:,ML_oft_hcurl%nlevels)
-  WRITE(io_unit,*)taylor_htor(:,ML_oft_hcurl%nlevels)
+  WRITE(io_unit,*)taylor_states%hlam(:,taylor_states%ML_hcurl%nlevels)
+  WRITE(io_unit,*)taylor_states%htor(:,taylor_states%ML_hcurl%nlevels)
   CLOSE(io_unit)
 END IF
 !---Finalize enviroment

--- a/src/tests/physics/test_taylor_inj.F90
+++ b/src/tests/physics/test_taylor_inj.F90
@@ -28,7 +28,7 @@ USE oft_hcurl_operators, ONLY: hcurl_setup_interp, hcurl_mloptions
 USE oft_h1_basis, ONLY: oft_h1_setup
 USE oft_h1_operators, ONLY: h1_mloptions, h1_setup_interp
 USE taylor, ONLY: taylor_vacuum, taylor_injectors, taylor_injector_single, &
-  oft_taylor_rinterp, oft_taylor_eigs, oft_taylor_inhomo, taylor_tag_size
+  oft_taylor_rinterp, oft_taylor_hmodes, oft_taylor_ifield, taylor_tag_size
 implicit none
 INTEGER(i4) :: ierr,io_unit
 REAL(r8) :: comps(3),diff_err
@@ -39,8 +39,8 @@ CHARACTER(LEN=taylor_tag_size) :: htags(nh)
 TYPE(xdmf_plot_file) :: plot_file
 TYPE(multigrid_mesh) :: mg_mesh
 TYPE(oft_ml_fem_comp_type) :: ML_vlagrange
-TYPE(oft_taylor_eigs) :: hmodes
-TYPE(oft_taylor_inhomo) :: ff_obj
+TYPE(oft_taylor_hmodes) :: hmodes
+TYPE(oft_taylor_ifield) :: ff_obj
 INTEGER(i4) :: order=1
 LOGICAL :: mg_test=.FALSE.
 NAMELIST/test_taylor_options/order,mg_test

--- a/src/tests/physics/test_taylor_inj.F90
+++ b/src/tests/physics/test_taylor_inj.F90
@@ -80,17 +80,18 @@ END IF
 hcpc(:,1)=(/1.d0, 0.d0, 0.d0/)
 hcpv(:,1)=(/0.d0, 1.d0, 0.d0/)*1.5d0
 htags(1)='Tinj'
+CALL ff_obj%setup(nh,hcpc,hcpv,htags)
 !---Run tests
 ff_obj%jtol=1.d-4
 oft_env%pm=.FALSE.
-CALL taylor_vacuum(ff_obj,nh,hcpc,hcpv,htags,energy=energy,hmodes=hmodes,rst_filename='oft_taylor.rst')
+CALL taylor_vacuum(ff_obj,energy=energy,hmodes=hmodes,rst_filename='oft_taylor.rst')
 CALL taylor_injectors(ff_obj,hmodes,5.d0,rst_filename='oft_taylor.rst')
-comps(1) = ff_obj%hvac(1,ff_obj%ML_hcurl_grad%level)%f%dot(ff_obj%hvac(1,ff_obj%ML_hcurl_grad%level)%f)
-comps(2) = ff_obj%hcur(1,ff_obj%ML_hcurl_grad%level)%f%dot(ff_obj%hcur(1,ff_obj%ML_hcurl_grad%level)%f)
-comps(3) = ff_obj%gffa(1,ff_obj%ML_hcurl_grad%level)%f%dot(ff_obj%gffa(1,ff_obj%ML_hcurl_grad%level)%f)
-CALL ff_obj%gffa(1,ff_obj%ML_hcurl_grad%level)%f%new(gffa)
+comps(1) = ff_obj%hvac(1)%f%dot(ff_obj%hvac(1)%f)
+comps(2) = ff_obj%hcur(1)%f%dot(ff_obj%hcur(1)%f)
+comps(3) = ff_obj%gffa(1)%f%dot(ff_obj%gffa(1)%f)
+CALL ff_obj%gffa(1)%f%new(gffa)
 CALL taylor_injector_single(ff_obj,hmodes,5.d0,(/1.d0/),gffa)
-CALL gffa%add(1.d0,-1.d0,ff_obj%gffa(1,ff_obj%ML_hcurl_grad%level)%f)
+CALL gffa%add(1.d0,-1.d0,ff_obj%gffa(1)%f)
 diff_err = gffa%dot(gffa)
 IF(oft_env%head_proc)THEN
   OPEN(NEWUNIT=io_unit,FILE='taylor.results')
@@ -121,8 +122,8 @@ lminv%its=-2
 CALL ML_vlagrange%current_level%vec_create(u)
 CALL ML_vlagrange%current_level%vec_create(v)
 !---Plot solution
-Bfield%uvac=>ff_obj%hvac(1,ff_obj%ML_hcurl_grad%level)%f
-Bfield%ua=>ff_obj%gffa(1,ff_obj%ML_hcurl_grad%level)%f
+Bfield%uvac=>ff_obj%hvac(1)%f
+Bfield%ua=>ff_obj%gffa(1)%f
 CALL Bfield%setup(ff_obj%ML_hcurl%current_level,ff_obj%ML_h1%current_level)
 !---Project field
 CALL oft_lag_vproject(ff_obj%ML_lagrange%current_level,Bfield,v)

--- a/src/tests/physics/test_taylor_inj.F90
+++ b/src/tests/physics/test_taylor_inj.F90
@@ -19,6 +19,7 @@ USE multigrid_build, ONLY: multigrid_construct
 USE oft_la_base, ONLY: oft_vector, oft_matrix
 USE oft_solver_base, ONLY: oft_solver
 USE oft_solver_utils, ONLY: create_cg_solver, create_diag_pre
+USE fem_composite, ONLY: oft_ml_fem_comp_type
 USE oft_lag_basis, ONLY: oft_lag_setup
 USE oft_lag_operators, ONLY: lag_setup_interp, lag_mloptions, oft_lag_vgetmop, &
   oft_lag_vproject
@@ -27,9 +28,7 @@ USE oft_hcurl_operators, ONLY: hcurl_setup_interp, hcurl_mloptions
 USE oft_h1_basis, ONLY: oft_h1_setup
 USE oft_h1_operators, ONLY: h1_mloptions, h1_setup_interp
 USE taylor, ONLY: taylor_vacuum, taylor_injectors, taylor_injector_single, &
-  taylor_minlev, taylor_jtol, taylor_tag_size, taylor_hvac, taylor_hcur, &
-  taylor_gffa, oft_taylor_rinterp, ML_oft_hcurl, ML_oft_h1, &
-  ML_hcurl_grad, ML_h1grad, ML_oft_lagrange, ML_oft_vlagrange
+  oft_taylor_rinterp, oft_taylor_eigs, oft_taylor_inhomo, taylor_tag_size
 implicit none
 INTEGER(i4) :: ierr,io_unit
 REAL(r8) :: comps(3),diff_err
@@ -39,6 +38,9 @@ REAL(r8) :: fluxes(nh),hcpc(3,nh),hcpv(3,nh),energy(nh)
 CHARACTER(LEN=taylor_tag_size) :: htags(nh)
 TYPE(xdmf_plot_file) :: plot_file
 TYPE(multigrid_mesh) :: mg_mesh
+TYPE(oft_ml_fem_comp_type) :: ML_vlagrange
+TYPE(oft_taylor_eigs) :: hmodes
+TYPE(oft_taylor_inhomo) :: ff_obj
 INTEGER(i4) :: order=1
 LOGICAL :: mg_test=.FALSE.
 NAMELIST/test_taylor_options/order,mg_test
@@ -53,21 +55,25 @@ CALL multigrid_construct(mg_mesh)
 CALL plot_file%setup("Test")
 CALL mg_mesh%mesh%setup_io(plot_file,order)
 IF(mg_test)THEN
-  taylor_minlev=2
+  ff_obj%minlev=2
 ELSE
-  taylor_minlev=mg_mesh%mgmax+order-1
+  ff_obj%minlev=mg_mesh%mgmax+order-1
 END IF
+hmodes%minlev=ff_obj%minlev
 !---
-CALL oft_lag_setup(mg_mesh,order,ML_oft_lagrange,ML_vlag_obj=ML_oft_vlagrange,minlev=taylor_minlev)
-CALL oft_hcurl_setup(mg_mesh,order,ML_oft_hcurl,minlev=taylor_minlev)
-CALL oft_h1_setup(mg_mesh,order+1,ML_oft_h1,minlev=taylor_minlev)
-CALL oft_hcurl_grad_setup(ML_oft_hcurl,ML_oft_h1,ML_hcurl_grad,ML_h1grad,taylor_minlev)
+ALLOCATE(ff_obj%ML_hcurl,ff_obj%ML_h1,ff_obj%ML_hcurl_grad,ff_obj%ML_h1grad,ff_obj%ML_lagrange)
+hmodes%ML_hcurl=>ff_obj%ML_hcurl
+hmodes%ML_lagrange=>ff_obj%ML_lagrange
+CALL oft_lag_setup(mg_mesh,order,ff_obj%ML_lagrange,ML_vlag_obj=ML_vlagrange,minlev=ff_obj%minlev)
+CALL oft_hcurl_setup(mg_mesh,order,ff_obj%ML_hcurl,minlev=ff_obj%minlev)
+CALL oft_h1_setup(mg_mesh,order+1,ff_obj%ML_h1,minlev=ff_obj%minlev)
+CALL oft_hcurl_grad_setup(ff_obj%ML_hcurl,ff_obj%ML_h1,ff_obj%ML_hcurl_grad,ff_obj%ML_h1grad,ff_obj%minlev)
 IF(mg_test)THEN
-  CALL lag_setup_interp(ML_oft_lagrange)
+  CALL lag_setup_interp(ff_obj%ML_lagrange)
   CALL lag_mloptions
-  CALL hcurl_setup_interp(ML_oft_hcurl)
-  CALL hcurl_mloptions(ML_oft_hcurl)
-  CALL h1_setup_interp(ML_oft_h1)
+  CALL hcurl_setup_interp(ff_obj%ML_hcurl)
+  CALL hcurl_mloptions(ff_obj%ML_hcurl)
+  CALL h1_setup_interp(ff_obj%ML_h1)
   CALL h1_mloptions
 END IF
 !---Define jumps
@@ -75,16 +81,16 @@ hcpc(:,1)=(/1.d0, 0.d0, 0.d0/)
 hcpv(:,1)=(/0.d0, 1.d0, 0.d0/)*1.5d0
 htags(1)='Tinj'
 !---Run tests
-taylor_jtol=1.d-4
+ff_obj%jtol=1.d-4
 oft_env%pm=.FALSE.
-CALL taylor_vacuum(nh,hcpc,hcpv,htags,energy)
-CALL taylor_injectors(5.d0)
-comps(1) = taylor_hvac(1,ML_hcurl_grad%level)%f%dot(taylor_hvac(1,ML_hcurl_grad%level)%f)
-comps(2) = taylor_hcur(1,ML_hcurl_grad%level)%f%dot(taylor_hcur(1,ML_hcurl_grad%level)%f)
-comps(3) = taylor_gffa(1,ML_hcurl_grad%level)%f%dot(taylor_gffa(1,ML_hcurl_grad%level)%f)
-CALL taylor_gffa(1,ML_hcurl_grad%level)%f%new(gffa)
-CALL taylor_injector_single(5.d0,(/1.d0/),gffa)
-CALL gffa%add(1.d0,-1.d0,taylor_gffa(1,ML_hcurl_grad%level)%f)
+CALL taylor_vacuum(ff_obj,nh,hcpc,hcpv,htags,energy=energy,hmodes=hmodes,rst_filename='oft_taylor.rst')
+CALL taylor_injectors(ff_obj,hmodes,5.d0,rst_filename='oft_taylor.rst')
+comps(1) = ff_obj%hvac(1,ff_obj%ML_hcurl_grad%level)%f%dot(ff_obj%hvac(1,ff_obj%ML_hcurl_grad%level)%f)
+comps(2) = ff_obj%hcur(1,ff_obj%ML_hcurl_grad%level)%f%dot(ff_obj%hcur(1,ff_obj%ML_hcurl_grad%level)%f)
+comps(3) = ff_obj%gffa(1,ff_obj%ML_hcurl_grad%level)%f%dot(ff_obj%gffa(1,ff_obj%ML_hcurl_grad%level)%f)
+CALL ff_obj%gffa(1,ff_obj%ML_hcurl_grad%level)%f%new(gffa)
+CALL taylor_injector_single(ff_obj,hmodes,5.d0,(/1.d0/),gffa)
+CALL gffa%add(1.d0,-1.d0,ff_obj%gffa(1,ff_obj%ML_hcurl_grad%level)%f)
 diff_err = gffa%dot(gffa)
 IF(oft_env%head_proc)THEN
   OPEN(NEWUNIT=io_unit,FILE='taylor.results')
@@ -105,21 +111,21 @@ CLASS(oft_solver), POINTER :: lminv => NULL()
 TYPE(oft_taylor_rinterp), TARGET :: Bfield
 !---Construct operator
 NULLIFY(lmop)
-CALL oft_lag_vgetmop(ML_oft_vlagrange%current_level,lmop,'none')
+CALL oft_lag_vgetmop(ML_vlagrange%current_level,lmop,'none')
 !---Setup solver
 CALL create_cg_solver(lminv)
 CALL create_diag_pre(lminv%pre)
 lminv%A=>lmop
 lminv%its=-2
 !---Create solver fields
-CALL ML_oft_vlagrange%current_level%vec_create(u)
-CALL ML_oft_vlagrange%current_level%vec_create(v)
+CALL ML_vlagrange%current_level%vec_create(u)
+CALL ML_vlagrange%current_level%vec_create(v)
 !---Plot solution
-Bfield%uvac=>taylor_hvac(1,ML_hcurl_grad%level)%f
-Bfield%ua=>taylor_gffa(1,ML_hcurl_grad%level)%f
-CALL Bfield%setup(ML_oft_hcurl%current_level,ML_oft_h1%current_level)
+Bfield%uvac=>ff_obj%hvac(1,ff_obj%ML_hcurl_grad%level)%f
+Bfield%ua=>ff_obj%gffa(1,ff_obj%ML_hcurl_grad%level)%f
+CALL Bfield%setup(ff_obj%ML_hcurl%current_level,ff_obj%ML_h1%current_level)
 !---Project field
-CALL oft_lag_vproject(ML_oft_lagrange%current_level,Bfield,v)
+CALL oft_lag_vproject(ff_obj%ML_lagrange%current_level,Bfield,v)
 CALL u%set(0.d0)
 CALL lminv%apply(u,v)
 !---Retrieve local values and save


### PR DESCRIPTION
This pull request removes the restriction of having only a single Marklin instance by encapsulating all required data/objects in the compiled code, including:

- The `save_rst` argument to `Marklin.compute()` is now deprecated in favor of a new `cache_file` argument, which enables specifying a specific file path for caching.
- Add regression test for concurrent Marklin instances

Additionally, the following changes were made to the core code:

- `hdf5_write` will now overwrite fields and issue a warning to avoid crashes with rewriting to files in a single Python script
- Improve error handling in FE `%vec_load()` implementations when fields are not present
- Add regression tests for HDF5 I/O operations

This pull request **does not** introduce breaking changes for any existing python APIs or input files. This pull request **does** extensively modify the internal Fortran API for Marklin.