### PR TITLE
Add support for spatial packing in 2D square meshes

### DIFF
--- a/src/grid/mesh_cube.F90
+++ b/src/grid/mesh_cube.F90
@@ -124,10 +124,16 @@ IF(mesh_type==1)THEN
     mesh%lc(:,12)=(/7,6,5,9/)
     !---
     DO i=1,3
-      IF(ref_per(i))THEN
+      IF(ref_per(i))ni(i)=MAX(2,ni(i))
+      xtmp=LOG(REAL(ni(i),8))/LOG(2.d0)
+      IF(ABS(INT(xtmp)-xtmp)>1.d-8)CALL oft_abort('For Tet meshes values of "ni" must be a power of 2',"mesh_cube_load",__FILE__)
+      ni(i)=INT(xtmp)
+    END DO
+    DO i=1,3
+      DO j=1,ni(i)
         CALL reflect_tet(i)
         mesh%r(i,:)=(mesh%r(i,:)+1.d0)/2.d0
-      END IF
+      END DO
     END DO
     !---
     mesh%r(1,:)=mesh%r(1,:)*rscale(1)+shift(1)
@@ -384,16 +390,17 @@ subroutine smesh_square_load(mg_mesh)
 type(multigrid_mesh), intent(inout) :: mg_mesh
 INTEGER(i4) :: i,j,k,ierr,io_unit,nptmp,nctmp,mesh_type,ni(3)
 INTEGER(i4), ALLOCATABLE :: pmap(:,:),lctmp(:,:)
-REAL(r8) :: rscale(3),shift(3)
+REAL(r8) :: rscale(3),shift(3),packing(3),alpha,beta,xtmp,ytmp
 REAL(r8), ALLOCATABLE :: rtmp(:,:)
 class(oft_bmesh), pointer :: smesh
-namelist/cube_options/mesh_type,ni,rscale,shift,ref_per
+namelist/cube_options/mesh_type,ni,rscale,shift,ref_per,packing
 DEBUG_STACK_PUSH
 mesh_type=1
 ni=1
 rscale=1.d0
 shift=0.d0
 ref_per=.FALSE.
+packing=1.d0
 IF(oft_env%head_proc)THEN
   OPEN(NEWUNIT=io_unit,FILE=oft_env%ifile)
   READ(io_unit,cube_options,IOSTAT=ierr)
@@ -407,6 +414,7 @@ IF(oft_env%head_proc)THEN
   WRITE(*,'(2A,2I4)')oft_indent,    'nx, ny      = ',ni(1:2)
   WRITE(*,'(2A,2ES11.3)')oft_indent,'Scale facs  = ',rscale(1:2)
   WRITE(*,'(2A,2L2)')oft_indent,    'Periodicity = ',ref_per(1:2)
+  WRITE(*,'(2A,3ES11.3)')oft_indent,'Packing     = ',packing
 END IF
 !---Broadcast input information
 #ifdef HAVE_MPI
@@ -439,12 +447,23 @@ IF(oft_env%rank==0)THEN
   ALLOCATE(pmap(ni(1)+1,ni(2)+1))
   pmap=-1
   nptmp=0
+  ! Adjust scales for packing
+  beta = 2.0*(packing(1)-1.0); alpha = -2.0*beta/3.0
+  rscale(1) = rscale(1)/(alpha + beta + 1.d0)
+  beta = 2.0*(packing(2)-1.0); alpha = -2.0*beta/3.0
+  rscale(2) = rscale(2)/(alpha + beta + 1.d0)
   DO i=1,ni(1)+1
+    beta = 2.0*(packing(1)-1.0); alpha = -2.0*beta/3.0
+    xtmp = (i-1)/REAL(ni(1),8)
+    xtmp = rscale(1)*(alpha*(xtmp**3) + beta*(xtmp**2) + xtmp)
     DO j=1,ni(2)+1
+      beta = 2.0*(packing(2)-1.0); alpha = -2.0*beta/3.0
+      ytmp = (j-1)/REAL(ni(2),8)
+      ytmp = rscale(2)*(alpha*(ytmp**3) + beta*(ytmp**2) + ytmp)
+      !
       nptmp=nptmp+1
       pmap(i,j)=nptmp
-      rtmp(:,nptmp)=[(i-1)*rscale(1)/REAL(ni(1),8), &
-        (j-1)*rscale(2)/REAL(ni(2),8)]+shift(1:2)
+      rtmp(:,nptmp)=[xtmp,ytmp]+shift(1:2)
     END DO
   END DO
   !---Setup cells

--- a/src/grid/multigrid.F90
+++ b/src/grid/multigrid.F90
@@ -1353,8 +1353,8 @@ enddo
 do i=1,self%ne ! Loop over edges to set child edge global index
   fmesh%global%lp(self%np+i)=self%global%np &
     + ABS(self%global%le(i))
-    lecors=self%le(:,i)
-    IF(self%global%le(i)<0)lecors((/2,1/))=lecors((/1,2/))
+  lecors=self%le(:,i)
+  IF(self%global%le(i)<0)lecors((/2,1/))=lecors((/1,2/))
   do j=1,2
     k=mesh_local_findedge(fmesh,(/lecors(j), self%np+i/))
     fmesh%global%le(ABS(k))=j+2*(ABS(self%global%le(i))-1)
@@ -1368,7 +1368,7 @@ do i=1,self%nc ! Loop over faces to set child edge and face global index
     k=mesh_local_findedge(fmesh,(/ABS(self%lce(j,i))+self%np, &
       ABS(self%lce(l,i))+self%np/))
     IF(k==0)CALL oft_abort("Bad edge link", "tetmesh_mg_globals", __FILE__)
-    fmesh%global%le(ABS(k)) = (j+2*self%ne+3*(self%global%lc(i)-1))
+    fmesh%global%le(ABS(k)) = (j+2*self%global%ne+3*(self%global%lc(i)-1))
   enddo
   do j=1,4
     fmesh%global%lc((i-1)*4+j) = (j+4*(self%global%lc(i)-1))

--- a/src/lin_alg/native_la.F90
+++ b/src/lin_alg/native_la.F90
@@ -2549,6 +2549,7 @@ IF(.NOT.uv%stitch_info%full)THEN
       ELSE
         last=letmp(1,mm)
       END IF
+      IF(m>neout)EXIT
       do while(leout(1,m)<=letmp(1,mm))
         IF(leout(1,m)<letmp(1,mm))jp=m+1
         IF(leout(1,m)==letmp(1,mm))THEN
@@ -2589,6 +2590,7 @@ IF(jn>0)THEN
     ELSE
       last=leout(1,mm)
     END IF
+    IF(m>neout)EXIT
     do while(leout(1,m)<=leout(1,mm))
       IF(leout(1,m)<leout(1,mm))jp=m+1
       IF((leout(1,m)==leout(1,mm)).AND.(m/=mm))THEN

--- a/src/physics/oft_vector_inits.F90
+++ b/src/physics/oft_vector_inits.F90
@@ -173,19 +173,6 @@ real(r8) :: pt(3),i,ar,az,s,c
 pt=self%mesh%log2phys(cell,f)
 CALL cyl_taylor_eval(self,pt,val)
 val=val*self%scale
-! !---
-! ar=self%akr*SQRT(SUM(pt(self%rplane)**2))
-! az=self%akz*(pt(self%zaxis)-self%zmin)
-! if(ar==0)then
-!   i=.5d0
-! else
-!   i=dbesj1(ar)/ar
-! end if
-! s=SIN(az); c=COS(az)
-! !---
-! val(self%rplane(2))=(self%alm*pt(self%rplane(1))*s-self%akz*pt(self%rplane(2))*c)*i
-! val(self%rplane(1))=-(self%alm*pt(self%rplane(2))*s+self%akz*pt(self%rplane(1))*c)*i
-! val(self%zaxis)=dbesj0(ar)*s
 end subroutine cyl_taylor_interp
 !------------------------------------------------------------------------------
 !> Evalute analytic Taylor state fields for a cylindrical geometry

--- a/src/tests/fem/test_lag.py
+++ b/src/tests/fem/test_lag.py
@@ -59,9 +59,10 @@ def lagrange_setup(nbase, nlevels, order, grid_type, mg=False, df='', nu='', pet
     nproc = 1
     if nbase != nlevels:
         nproc = 2
-    ni_line = ' ni=2,2,2'
-    if not (xperiodic or yperiodic or zperiodic):
-        ni_line = '!' + ni_line
+    if (grid_type == 2) and (xperiodic or yperiodic or zperiodic):
+        ni_line = ' ni=2,2,2'
+    else:
+        ni_line = '! ni=2,2,2'
     #
     os.chdir(test_dir)
     with open('oft.in', 'w+') as fid:

--- a/src/tests/physics/test_alfven.py
+++ b/src/tests/physics/test_alfven.py
@@ -18,21 +18,14 @@ oft_in_template = """
 
 &mesh_options
  meshname='cube'
- cad_type={11}
+ cad_type=92
  nlevels={1}
  nbase={0}
  grid_order=1
 /
 
-&t3d_options
- filename='cube.t3d'
- inpname='cube.inp'
- reflect='xyz'
- ref_per=T,T,T
-/
-
 &cube_options
- mesh_type=2
+ mesh_type={11}
  ni=1,2,4
  rscale=1.,1.,2.
  shift=-0.5,-0.5,-1.
@@ -82,7 +75,7 @@ def alfven_setup(nbase,nlevels,order,minlev,nu_mhd='-1',linear=False,
                  mf=False,petsc=False,hex_mesh=False):
     mesh_type=1
     if hex_mesh:
-        mesh_type=92
+        mesh_type=2
     dt='4.E-7'
     its='250'
     tol='1.E-12'
@@ -150,7 +143,7 @@ def validate_result(berr_exp,verr_exp,steps_exp=11,linear=False):
 #============================================================================
 # Non-Linear test runners for NP=2
 def test_nl_r1_p2(petsc_flag=False):
-    berr_exp = 3.6337154826251369E-002
+    berr_exp = 4.2660712289547556E-002
     verr_exp = 3.2114524936411738E-002
     assert alfven_setup(1,1,2,2,petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp)
@@ -161,7 +154,7 @@ def test_nl_r1_p2(petsc_flag=False):
 def test_nl_r1_p2_mpi(mf,petsc_flag):
     if mf and petsc_flag:
         pytest.skip()
-    berr_exp = 3.6337154826251369E-002
+    berr_exp = 4.2660712289547556E-002
     verr_exp = 3.2114524936411738E-002
     assert alfven_setup(1,2,2,3,mf=mf,petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp)
@@ -170,8 +163,8 @@ def test_nl_r1_p2_mpi(mf,petsc_flag):
 # Non-Linear test runners for NP=3
 @pytest.mark.slow
 def test_nl_r1_p3(petsc_flag=False):
-    berr_exp = 3.1344661129302444E-003
-    verr_exp = 1.8333585622266604E-003
+    berr_exp = 6.387170216933607E-003
+    verr_exp = 2.3404150169503545E-003
     assert alfven_setup(1,1,3,2,'0,2,2',petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp)
 @pytest.mark.slow
@@ -181,8 +174,8 @@ def test_nl_r1_p3(petsc_flag=False):
 def test_nl_r1_p3_mpi(mf,petsc_flag):
     if mf and petsc_flag:
         pytest.skip()
-    berr_exp = 3.1344661129302444E-003
-    verr_exp = 1.8333585622266604E-003
+    berr_exp = 6.387170216933607E-003
+    verr_exp = 2.3404150169503545E-003
     assert alfven_setup(1,2,3,3,'0,0,2,2',mf=mf,petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp)
 
@@ -190,7 +183,7 @@ def test_nl_r1_p3_mpi(mf,petsc_flag):
 # Non-Linear test runners for NP=4
 @pytest.mark.slow
 def test_nl_r1_p4(petsc_flag=False):
-    berr_exp = 3.4446909270430422E-004
+    berr_exp = 3.8236858815081484E-004
     verr_exp = 2.5485805438810947E-004
     assert alfven_setup(1,1,4,2,'0,10,4,2',petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp)
@@ -201,7 +194,7 @@ def test_nl_r1_p4(petsc_flag=False):
 def test_nl_r1_p4_mpi(mf,petsc_flag):
     if mf and petsc_flag:
         pytest.skip()
-    berr_exp = 3.4446909270430422E-004
+    berr_exp = 3.8236858815081484E-004
     verr_exp = 2.5485805438810947E-004
     assert alfven_setup(1,2,4,3,'0,0,10,4,2',mf=mf,petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp)
@@ -210,7 +203,7 @@ def test_nl_r1_p4_mpi(mf,petsc_flag):
 # Linear test runners for NP=2
 @pytest.mark.linear
 def test_lin_r1_p2(petsc_flag=False):
-    berr_exp = 3.6339799347819605E-002
+    berr_exp = 4.2680204579902244E-002
     verr_exp = 3.2104584635227973E-002
     assert alfven_setup(1,1,2,2,linear=True,petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp,linear=True)
@@ -219,7 +212,7 @@ def test_lin_r1_p2(petsc_flag=False):
 @pytest.mark.coverage
 @pytest.mark.parametrize("petsc_flag", (True, False))
 def test_lin_r1_p2_mpi(petsc_flag):
-    berr_exp = 3.6339799347819605E-002
+    berr_exp = 4.2680204579902244E-002
     verr_exp = 3.2104584635227973E-002
     assert alfven_setup(1,2,2,3,linear=True,petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp,linear=True)
@@ -229,8 +222,8 @@ def test_lin_r1_p2_mpi(petsc_flag):
 @pytest.mark.linear
 @pytest.mark.slow
 def test_lin_r1_p3(petsc_flag=False):
-    berr_exp = 3.1424512164583028E-003
-    verr_exp = 1.8563760659227942E-003
+    berr_exp = 6.3953902414141325E-003
+    verr_exp = 2.3594097996094206E-003
     assert alfven_setup(1,1,3,2,'0,2,2',linear=True,petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp,linear=True)
 @pytest.mark.linear
@@ -238,8 +231,8 @@ def test_lin_r1_p3(petsc_flag=False):
 @pytest.mark.mpi
 @pytest.mark.parametrize("petsc_flag", (True, False))
 def test_lin_r1_p3_mpi(petsc_flag):
-    berr_exp = 3.1424512164583028E-003
-    verr_exp = 1.8563760659227942E-003
+    berr_exp = 6.3953902414141325E-003
+    verr_exp = 2.3594097996094206E-003
     assert alfven_setup(1,2,3,3,'0,0,2,2',linear=True,petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp,linear=True)
 
@@ -248,7 +241,7 @@ def test_lin_r1_p3_mpi(petsc_flag):
 @pytest.mark.linear
 @pytest.mark.slow
 def test_lin_r1_p4(petsc_flag=False):
-    berr_exp = 6.5622744829070675E-004
+    berr_exp = 8.595609282107447E-004
     verr_exp = 3.8358125487992524E-004
     assert alfven_setup(1,1,4,2,'0,2,2,2',linear=True,petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp,linear=True)
@@ -257,7 +250,7 @@ def test_lin_r1_p4(petsc_flag=False):
 @pytest.mark.mpi
 @pytest.mark.parametrize("petsc_flag", (True, False))
 def test_lin_r1_p4_mpi(petsc_flag):
-    berr_exp = 6.5622744829070675E-004
+    berr_exp = 8.595609282107447E-004
     verr_exp = 3.8358125487992524E-004
     assert alfven_setup(1,2,4,3,'0,0,2,2,2',linear=True,petsc=petsc_flag)
     assert validate_result(berr_exp,verr_exp,linear=True)

--- a/src/tests/physics/test_alfven_lag.py
+++ b/src/tests/physics/test_alfven_lag.py
@@ -18,21 +18,14 @@ oft_in_template = """
 
 &mesh_options
  meshname='cube'
- cad_type={11}
+ cad_type=92
  nlevels={1}
  nbase={0}
  grid_order=1
 /
 
-&t3d_options
- filename='cube.t3d'
- inpname='cube.inp'
- reflect='xyz'
- ref_per=T,T,T
-/
-
 &cube_options
- mesh_type=2
+ mesh_type={11}
  ni=1,2,4
  rscale=1.,1.,2.
  shift=-0.5,-0.5,-1.
@@ -82,7 +75,7 @@ def alfven_setup(nbase,nlevels,order,minlev,nu_mhd='-1',linear=False,
     os.chdir(test_dir)
     mesh_type=1
     if hex_mesh:
-        mesh_type=92
+        mesh_type=2
     dt='4.E-7'
     its='250'
     tol='1.E-12'

--- a/src/tests/physics/test_sound.py
+++ b/src/tests/physics/test_sound.py
@@ -18,21 +18,14 @@ oft_in_template = """
 
 &mesh_options
  meshname='cube'
- cad_type={11}
+ cad_type=92
  nlevels={1}
  nbase={0}
  grid_order=1
 /
 
-&t3d_options
- filename='cube.t3d'
- inpname='cube.inp'
- reflect='xyz'
- ref_per=T,T,T
-/
-
 &cube_options
- mesh_type=2
+ mesh_type={11}
  ni=1,1,4
  rscale=1.,1.,2.
  shift=-0.5,-0.5,-1.
@@ -86,7 +79,7 @@ def sound_setup(nbase,nlevels,order,minlev,nu_mhd='-1',linear=False,mf=False,pet
     os.chdir(test_dir)
     mesh_type=1
     if hex_mesh:
-        mesh_type=92
+        mesh_type=2
     dt='1.e-6'
     its='100'
     tol='1.E-12'

--- a/src/tests/physics/test_sound_lag.py
+++ b/src/tests/physics/test_sound_lag.py
@@ -18,21 +18,14 @@ oft_in_template = """
 
 &mesh_options
  meshname='cube'
- cad_type={11}
+ cad_type=92
  nlevels={1}
  nbase={0}
  grid_order=1
 /
 
-&t3d_options
- filename='cube.t3d'
- inpname='cube.inp'
- reflect='xyz'
- ref_per=T,T,T
-/
-
 &cube_options
- mesh_type=2
+ mesh_type={11}
  ni=1,1,4
  rscale=1.,1.,2.
  shift=-0.5,-0.5,-1.
@@ -86,7 +79,7 @@ def sound_setup(nbase,nlevels,order,minlev,nu_mhd='-1',linear=False,mf=False,pet
     os.chdir(test_dir)
     mesh_type=1
     if hex_mesh:
-        mesh_type=92
+        mesh_type=2
     dt='1.e-6'
     its='100'
     tol='1.E-12'


### PR DESCRIPTION
This pull request adds support for spatial packing for 2D square/rectangular meshes using the internal "cube" mesh construction functionality, including:

 - Add support cell count specification for tetrahedra cube meshes (must be power of 2)
 - Fix global indexing bug with multi-level periodic surface meshes
 - Fix out of bounds bug in native sub-matrix setup
 - Update MHD tests to use internal cube mesh

This pull request **does not** introduce changes for any existing APIs. This pull request **does** change the behavior of input files as the `ni` field in `cube_options` is now used for Tet meshes.
