### PR TITLE
TokaMaker: Remove legacy code and deprecate command line drivers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ option(OFT_DOCS_ONLY "Build documentation only?" OFF)
 option(OFT_PACKAGE_BUILD "Perform a destributable package?" OFF)
 option(OFT_PACKAGE_NIGHTLY "Perform a nightly build and include git hash in package filename?" ON)
 option(OFT_COVERAGE "Build with code coverage information?" OFF)
+option(OFT_TOKAMAKER_LEGACY "Build legacy TokaMaker executables?" OFF)
 set(OFT_MPI_PLEN "4" CACHE STRING "Size of strings for MPI processor index")
 set(OFT_PATH_SLEN "200" CACHE STRING "Size of path strings")
 set(OFT_ERROR_SLEN "200" CACHE STRING "Size of error strings")
@@ -294,6 +295,10 @@ endif()
 ########################
 # Setup component libraries
 ########################
+# Setup component flags
+if( OFT_TOKAMAKER_LEGACY )
+  add_definitions( -DOFT_TOKAMAKER_LEGACY )
+endif()
 # Include files
 add_subdirectory( include )
 include_directories( ${CMAKE_BINARY_DIR}/include )

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -22,7 +22,10 @@ set( THINCURR_EXES
   thincurr_coupling.F90
 )
 
-set( BIN_SRCS ${OFT_EXES} ${MARKLIN_EXES} ${TOKAMAKER_EXES} ${THINCURR_EXES} )
+set( BIN_SRCS ${OFT_EXES} ${MARKLIN_EXES} ${THINCURR_EXES} )
+if( OFT_TOKAMAKER_LEGACY )
+  set( BIN_SRCS ${BIN_SRCS} ${TOKAMAKER_EXES} )
+endif()
 
 foreach( file ${BIN_SRCS} )
   oft_add_exe( ${file} )

--- a/src/bin/tokamaker_fit.F90
+++ b/src/bin/tokamaker_fit.F90
@@ -67,7 +67,6 @@ LOGICAL :: free_boundary = .FALSE.
 LOGICAL :: has_plasma = .TRUE.
 LOGICAL :: save_mug = .FALSE.
 LOGICAL :: fast_boundary = .TRUE.
-LOGICAL :: limited_only = .FALSE.
 CHARACTER(LEN=OFT_PATH_SLEN) :: coil_file = 'none'
 CHARACTER(LEN=OFT_PATH_SLEN) :: limiter_file = 'none'
 CHARACTER(LEN=OFT_PATH_SLEN) :: eqdsk_filename = 'gTokaMaker'
@@ -86,7 +85,7 @@ LOGICAL :: fixed_p = .FALSE.
 LOGICAL :: fixed_center = .FALSE.
 NAMELIST/tokamaker_options/order,pm,mode,maxits,ninner,urf,nl_tol,itor_target,pnorm, &
 alam,beta_mr,free_boundary,coil_file,limiter_file,f_offset,has_plasma,rmin,R0_target, &
-V0_target,save_mug,fast_boundary,limited_only,eqdsk_filename,eqdsk_nr,eqdsk_nz,eqdsk_rbounds, &
+V0_target,save_mug,fast_boundary,eqdsk_filename,eqdsk_nr,eqdsk_nz,eqdsk_rbounds, &
 eqdsk_zbounds,eqdsk_run_info,eqdsk_limiter_file,eqdsk_lcfs_pad,init_r0,init_a,init_kappa, &
 init_delta,lim_zmax,estore_target
 NAMELIST/tokamaker_fit_options/psinorm,adjust_pnorm,adjust_alam,adjust_R0,adjust_V0, &
@@ -190,14 +189,12 @@ mygs%maxits=maxits
 mygs%nl_tol=nl_tol
 mygs%pnorm=pnorm
 mygs%psiscale=psinorm
-mygs%limited_only=limited_only
 mygs%R0_target=R0_target
 mygs%V0_target=V0_target
 mygs%limiter_file=limiter_file
 CALL mygs%load_limiters
 IF(mygs%free)THEN
   mygs%alam=alam
-  mygs%boundary_limiter=.FALSE.
 ELSE
   IF(f_offset/=0.d0)mygs%alam=alam
 END IF

--- a/src/bin/tokamaker_gs.F90
+++ b/src/bin/tokamaker_gs.F90
@@ -73,7 +73,6 @@ LOGICAL :: free_boundary = .FALSE.
 LOGICAL :: has_plasma = .TRUE.
 LOGICAL :: save_mug = .FALSE.
 LOGICAL :: fast_boundary = .TRUE.
-LOGICAL :: limited_only = .FALSE.
 CHARACTER(LEN=OFT_PATH_SLEN) :: coil_file = 'none'
 CHARACTER(LEN=OFT_PATH_SLEN) :: limiter_file = 'none'
 CHARACTER(LEN=OFT_PATH_SLEN) :: eqdsk_filename = 'gTokaMaker'
@@ -81,7 +80,7 @@ CHARACTER(LEN=40) :: eqdsk_run_info = ''
 CHARACTER(LEN=OFT_PATH_SLEN) :: eqdsk_limiter_file = ''
 NAMELIST/tokamaker_options/order,pm,mode,maxits,ninner,urf,nl_tol,itor_target,pnorm, &
 alam,beta_mr,free_boundary,coil_file,limiter_file,f_offset,has_plasma,rmin,R0_target, &
-V0_target,save_mug,fast_boundary,limited_only,eqdsk_filename,eqdsk_nr,eqdsk_nz,eqdsk_rbounds, &
+V0_target,save_mug,fast_boundary,eqdsk_filename,eqdsk_nr,eqdsk_nz,eqdsk_rbounds, &
 eqdsk_zbounds,eqdsk_run_info,eqdsk_limiter_file,eqdsk_lcfs_pad,init_r0,init_a,init_kappa, &
 init_delta,lim_zmax,estore_target
 !------------------------------------------------------------------------------
@@ -206,14 +205,12 @@ mygs%urf=urf
 mygs%maxits=maxits
 mygs%nl_tol=nl_tol
 mygs%pnorm=pnorm
-mygs%limited_only=limited_only
 mygs%R0_target=R0_target
 mygs%V0_target=V0_target
 mygs%limiter_file=limiter_file
 CALL mygs%load_limiters
 IF(mygs%free)THEN
   mygs%alam=alam
-  mygs%boundary_limiter=.FALSE.
 ELSE
   IF(f_offset/=0.d0)mygs%alam=alam
 END IF

--- a/src/bin/tokamaker_wall.F90
+++ b/src/bin/tokamaker_wall.F90
@@ -701,6 +701,51 @@ END IF
 WRITE(*,*)'  Finished'
 DEALLOCATE(eig_vec,etatmp,corr_mat)
 END SUBROUTINE nonax_eigs
+!---------------------------------------------------------------------------------
+!> Needs docs
+!---------------------------------------------------------------------------------
+SUBROUTINE decay_eigenmodes(ncoils,rc,eig_val,eig_vec,eta)
+INTEGER(i4), INTENT(in) :: ncoils
+REAL(r8), INTENT(in) :: rc(2,ncoils)
+REAL(r8), intent(out) :: eig_val(ncoils),eig_vec(ncoils,ncoils)
+REAL(r8), OPTIONAL, INTENT(in) :: eta(ncoils)
+!---
+INTEGER(i4) :: i,j,info,N,LDVL,LDVR,LDA,LWORK
+REAL(r8), ALLOCATABLE, DIMENSION(:) :: WR,WI,WORK
+REAL(r8), ALLOCATABLE, DIMENSION(:,:) :: Amat,VL,VR
+CHARACTER(LEN=1) :: JOBVL,JOBVR
+!--- Create coupling matrix
+ALLOCATE(Amat(ncoils,ncoils))
+!$omp parallel do private(j)
+DO i=1,ncoils
+  DO j=1,ncoils
+    Amat(i,j)=green(rc(1,i),rc(2,i),rc(1,j),rc(2,j))/rc(1,i)
+  END DO
+END DO
+!---Set eta profile
+IF(PRESENT(eta))THEN
+  DO i=1,ncoils
+    Amat(i,:)=Amat(i,:)/eta(i)
+  END DO
+END IF
+!--- Compute eigenvalues
+JOBVL = 'V'
+JOBVR = 'V'
+N = ncoils
+LDA = ncoils
+LDVL = ncoils
+LDVR = ncoils
+ALLOCATE(WR(N),WI(N),VL(LDVL,N),VR(LDVR,N),WORK(1))
+LWORK=-1
+CALL DGEEV(JOBVL, JOBVR, N, Amat, LDA, WR, WI, VL, LDVL, VR, LDVR, WORK, LWORK, INFO )
+LWORK=INT(WORK(1),4)
+DEALLOCATE(WORK)
+ALLOCATE(WORK(LWORK))
+CALL DGEEV(JOBVL, JOBVR, N, Amat, LDA, WR, WI, VL, LDVL, VR, LDVR, WORK, LWORK, INFO )
+eig_val=-1.d0/WR
+eig_vec=REAL(VR,8)
+DEALLOCATE(WI,WR,VL,VR,WORK,Amat)
+END SUBROUTINE decay_eigenmodes
 END MODULE nonax_wall
 !---------------------------------------------------------------------------------
 ! Flexible Unstructured Simulation Infrastructure with Open Numerics (Open FUSION Toolkit)
@@ -726,8 +771,7 @@ USE oft_lag_basis, ONLY: oft_lag_setup_bmesh, oft_scalar_bfem, oft_lag_setup
 USE oft_gs_profiles, ONLY: zero_flux_func
 USE oft_gs, ONLY: gs_eq, gs_setup_walls, gs_cond_source, gs_vacuum_solve
 USE oft_gs_fit, ONLY: fit_load, fit_constraint_ptr, gs_active
-USE axi_green, ONLY: decay_eigenmodes
-USE nonax_wall, ONLY: nonax_rescouple, nonax_indcouple, nonax_eigs
+USE nonax_wall, ONLY: nonax_rescouple, nonax_indcouple, nonax_eigs, decay_eigenmodes
 USE exp_geom, ONLY: exp_setup
 IMPLICIT NONE
 #include "local.h"

--- a/src/bin/tokamaker_wall.F90
+++ b/src/bin/tokamaker_wall.F90
@@ -866,7 +866,6 @@ CALL exp_setup(mygs)
 mygs%free=.TRUE.
 mygs%pnorm=0.d0
 mygs%alam=1.d-7
-mygs%boundary_limiter=.FALSE.
 mygs%has_plasma=.FALSE.
 mygs%compute_chi=.FALSE.
 IF(TRIM(coil_file)/='none')THEN

--- a/src/fem/lagrange_operators.F90
+++ b/src/fem/lagrange_operators.F90
@@ -61,7 +61,7 @@ contains
   procedure :: setup => lag_rinterp_setup
   !> Reconstruct field
   procedure :: interp => lag_rinterp
-  !> Delete reconstruction object
+  !> Destroy interpolation object
   procedure :: delete => lag_rinterp_delete
 end type oft_lag_rinterp
 !------------------------------------------------------------------------------
@@ -86,7 +86,7 @@ contains
   procedure :: setup => lag_vrinterp_setup
   !> Reconstruct field
   procedure :: interp => lag_vrinterp
-  !> Delete reconstruction object
+  !> Destroy interpolation object
   procedure :: delete => lag_vrinterp_delete
 end type oft_lag_vrinterp
 !------------------------------------------------------------------------------
@@ -106,42 +106,49 @@ contains
   procedure :: interp => lag_vdinterp
 end type oft_lag_vdinterp
 !------------------------------------------------------------------------------
-!> Needs docs
+!> Zero Lagrange FE vector at all global boundary nodes
 !------------------------------------------------------------------------------
 type, extends(oft_solver_bc) :: oft_lag_zerob
   class(oft_ml_fem_type), pointer :: ML_lag_rep => NULL() !< FE representation
 contains
+  !> Zero field on boundary nodes
   procedure :: apply => zerob_apply
+  !> Destroy BC object
   procedure :: delete => zerob_delete
 end type oft_lag_zerob
 !------------------------------------------------------------------------------
-!> Needs docs
+!> Zero Lagrange FE vector at all global grounding node(s)
 !------------------------------------------------------------------------------
 type, extends(oft_lag_zerob) :: oft_lag_zerogrnd
 contains
+  !> Zero field at grounding node(s)
   procedure :: apply => zerogrnd_apply
 end type oft_lag_zerogrnd
 !------------------------------------------------------------------------------
-!> Needs docs
+!> Zero all components of vector Lagrange FE vector at all global boundary nodes
 !------------------------------------------------------------------------------
 type, extends(oft_solver_bc) :: oft_vlag_zerob
   class(oft_ml_fem_comp_type), pointer :: ML_vlag_rep => NULL() !< FE representation
 contains
+  !> Zero all components of vector on boundary nodes
   procedure :: apply => vzerob_apply
+  !> Destroy BC object
   procedure :: delete => vzerob_delete
 end type oft_vlag_zerob
 !------------------------------------------------------------------------------
-!> Needs docs
+!> Zero normal component of vector Lagrange FE vector at all global boundary nodes
 !------------------------------------------------------------------------------
 type, extends(oft_vlag_zerob) :: oft_vlag_zeron
 contains
+  !> Zero normal component of vector on boundary nodes
   procedure :: apply => vzeron_apply
 end type oft_vlag_zeron
 !------------------------------------------------------------------------------
-!> Needs docs
+!> Zero tangential component of vector Lagrange FE vector at all global boundary nodes
 !------------------------------------------------------------------------------
 type, extends(oft_vlag_zerob) :: oft_vlag_zerot
 contains
+  !> Zero tangential component of vector on boundary nodes
   procedure :: apply => vzerot_apply
 end type oft_vlag_zerot
 !---Pre options
@@ -213,7 +220,7 @@ ELSE
 END IF
 end subroutine lag_rinterp_setup
 !------------------------------------------------------------------------------
-!> Destroy temporary internal storage
+!> Destroy temporary internal storage and nullify references
 !------------------------------------------------------------------------------
 subroutine lag_rinterp_delete(self)
 class(oft_lag_rinterp), intent(inout) :: self
@@ -352,9 +359,7 @@ ELSE
 END IF
 end subroutine lag_vrinterp_setup
 !------------------------------------------------------------------------------
-!> Setup interpolator for Lagrange vector fields
-!!
-!! Fetches local representation used for interpolation from vector object
+!> Destroy temporary internal storage and nullify references
 !------------------------------------------------------------------------------
 subroutine lag_vrinterp_delete(self)
 class(oft_lag_vrinterp), intent(inout) :: self
@@ -523,9 +528,7 @@ deallocate(vloc)
 DEBUG_STACK_POP
 end subroutine zerob_apply
 !------------------------------------------------------------------------------
-!> Zero a Lagrange scalar field at all boundary nodes
-!!
-!! @param[in,out] a Field to be zeroed
+!> Destroy temporary internal storage and nullify references
 !------------------------------------------------------------------------------
 subroutine zerob_delete(self)
 class(oft_lag_zerob), intent(inout) :: self
@@ -587,9 +590,7 @@ DEALLOCATE(vloc)
 DEBUG_STACK_POP
 end subroutine vzerob_apply
 !------------------------------------------------------------------------------
-!> Zero a Lagrange scalar field at all boundary nodes
-!!
-!! @param[in,out] a Field to be zeroed
+!> Destroy temporary internal storage and nullify references
 !------------------------------------------------------------------------------
 subroutine vzerob_delete(self)
 class(oft_vlag_zerob), intent(inout) :: self

--- a/src/physics/grad_shaf_fit.F90
+++ b/src/physics/grad_shaf_fit.F90
@@ -33,82 +33,80 @@ IMPLICIT NONE
 #include "local.h"
 PRIVATE
 !---------------------------------------------------------------------------------
-!> Needs Docs
+!> Abstract fit constraint
 !---------------------------------------------------------------------------------
 TYPE :: fit_constraint
-  INTEGER(4) :: ncomp = 0 !< Needs docs
-  REAL(8) :: wt = 1.d0 !< Needs docs
-  REAL(8) :: val = 0.d0 !< Needs docs
-  REAL(8), POINTER, DIMENSION(:) :: nax_corr => NULL() !< Needs docs
-  REAL(8), POINTER, DIMENSION(:,:) :: comp_r => NULL() !< Needs docs
-  REAL(8), POINTER, DIMENSION(:,:) :: comp_n => NULL() !< Needs docs
+  INTEGER(4) :: ncomp = 0 !< Number of non-axisymmetric compensations
+  REAL(8) :: wt = 1.d0 !< Constraint weight
+  REAL(8) :: val = 0.d0 !< Constraint value
+  REAL(8), POINTER, DIMENSION(:) :: nax_corr => NULL() !< Non-axisymmetric compensations
+  REAL(8), POINTER, DIMENSION(:,:) :: comp_r => NULL() !< Compensation location
+  REAL(8), POINTER, DIMENSION(:,:) :: comp_n => NULL() !< Compensation unit normal
 CONTAINS
-  !> Needs docs
+  !> Compute error
   PROCEDURE :: error => fit_dummy_error
-  !> Needs docs
+  !> Evaluate constraint value
   PROCEDURE :: eval => fit_dummy_eval
-  !> Needs docs
+  !> Setup 3D error field compensation information
   PROCEDURE :: setup_comp => fit_dummy_setup_comp
-  !> Needs docs
+  !> Get non-axisymmetric correction
   PROCEDURE :: get_nax => fit_dummy_nax_corr
-  !> Needs docs
+  !> Does constraint use parallelism in calculation?
   PROCEDURE :: is_parallel => fit_dummy_parallel
 END TYPE fit_constraint
 !---------------------------------------------------------------------------------
-!> Needs Docs
+!> Coil current constraint
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: coil_constraint
-  INTEGER(4) :: coil = 0 !< Needs docs
+  INTEGER(4) :: coil = 0 !< Coil to constrain
 CONTAINS
-  !> Needs docs
+  !> Compute error
   PROCEDURE :: error => fit_coil_error
-  !> Needs docs
+  !> Evaluate constraint value
   PROCEDURE :: eval => fit_coil_eval
 END TYPE coil_constraint
 !---------------------------------------------------------------------------------
-! TYPE vcont_constraint
-!---------------------------------------------------------------------------------
-!> Needs Docs
+!> Virtual VSC current constraint
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: vcont_constraint
 CONTAINS
-  !> Needs docs
+  !> Compute error
   PROCEDURE :: error => fit_vcont_error
-  !> Needs docs
+  !> Evaluate constraint value
   PROCEDURE :: eval => fit_vcont_eval
 END TYPE vcont_constraint
 !---------------------------------------------------------------------------------
-!> Needs Docs
+!> Local magnetic field constraint
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: field_constraint
-  INTEGER(4) :: cell = 0 !< Needs docs
-  REAL(8) :: phi = 0.d0 !< Needs docs
-  REAL(8) :: f(3) = 0.d0 !< Needs docs
-  REAL(8) :: r(3) = [0.d0,0.d0,0.d0] !< Needs docs
-  REAL(8) :: v(3) = [0.d0,0.d0,0.d0] !< Needs docs
+  INTEGER(4) :: cell = 0 !< Cell containing point
+  REAL(8) :: phi = 0.d0 !< Toroidal location of constraint
+  REAL(8) :: f(3) = 0.d0 !< Logical coordinate of point in cell
+  REAL(8) :: r(3) = [0.d0,0.d0,0.d0] !< Constraint location
+  REAL(8) :: v(3) = [0.d0,0.d0,0.d0] !< Constraint normal direction
 CONTAINS
-  !> Needs docs
+  !> Compute error
   PROCEDURE :: error => fit_field_error
-  !> Needs docs
+  !> Evaluate constraint value
   PROCEDURE :: eval => fit_field_eval
-  !> Needs docs
+  !> Setup 3D error field compensation information
   PROCEDURE :: setup_comp => fit_field_setup_comp
 END TYPE field_constraint
 !---------------------------------------------------------------------------------
-!> Needs Docs
+!> Flux loop constraint
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: flux_constraint
-  INTEGER(4) :: cell = 0 !< Needs docs
-  REAL(8) :: f(3) = 0.d0 !< Needs docs
-  REAL(8) :: r(3) = [0.d0,0.d0,0.d0] !< Needs docs
+  INTEGER(4) :: cell = 0 !< Cell containing point
+  REAL(8) :: f(3) = 0.d0 !< Logical coordinate of point in cell
+  REAL(8) :: r(3) = [0.d0,0.d0,0.d0] !< Constraint location
 CONTAINS
-  !> Needs docs
+  !> Compute error
   PROCEDURE :: error => fit_flux_error
-  !> Needs docs
+  !> Evaluate constraint value
   PROCEDURE :: eval => fit_flux_eval
 END TYPE flux_constraint
 !---------------------------------------------------------------------------------
-!> Needs Docs
+!> Saddle loop constraint
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: saddle_constraint
   INTEGER(4) :: cells(2) = 0 !< Needs docs
@@ -118,67 +116,67 @@ TYPE, EXTENDS(fit_constraint) :: saddle_constraint
   REAL(8) :: r(3,2) = 0.d0 !< Needs docs
   REAL(8) :: width = 0.d0 !< Needs docs
 CONTAINS
-  !> Needs docs
+  !> Compute error
   PROCEDURE :: error => fit_saddle_error
-  !> Needs docs
+  !> Evaluate constraint value
   PROCEDURE :: eval => fit_saddle_eval
-  !> Needs docs
+  !> Setup 3D error field compensation information
   PROCEDURE :: setup_comp => fit_saddle_setup_comp
 END TYPE saddle_constraint
 !---------------------------------------------------------------------------------
-!> Needs Docs
+!> Toroidal current constraint
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: itor_constraint
 CONTAINS
-  !> Needs docs
+  !> Compute error
   PROCEDURE :: error => fit_itor_error
-  !> Needs docs
+  !> Evaluate constraint value
   PROCEDURE :: eval => fit_itor_eval
-  !> Needs docs
+  !> Does constraint use parallelism in calculation?
   PROCEDURE :: is_parallel => fit_itor_parallel
 END TYPE itor_constraint
 !---------------------------------------------------------------------------------
-!> Needs Docs
+!> Diamagnetic flux constraint
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: dflux_constraint
 CONTAINS
-  !> Needs docs
+  !> Compute error
   PROCEDURE :: error => fit_dflux_error
-  !> Needs docs
+  !> Evaluate constraint value
   PROCEDURE :: eval => fit_dflux_eval
 END TYPE dflux_constraint
 !---------------------------------------------------------------------------------
-!> Needs Docs
+!> Plasma pressure constraint
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: press_constraint
-  INTEGER(4) :: cell = 0 !< Needs docs
-  REAL(8) :: f(3) = 0.d0 !< Needs docs
-  REAL(8) :: r(3) = [0.d0,0.d0,0.d0] !< Needs docs
+  INTEGER(4) :: cell = 0 !< Cell containing point
+  REAL(8) :: f(3) = 0.d0 !< Logical coordinate of point in cell
+  REAL(8) :: r(3) = [0.d0,0.d0,0.d0] !< Constraint location
 CONTAINS
-  !> Needs docs
+  !> Compute error
   PROCEDURE :: error => fit_press_error
-  !> Needs docs
+  !> Evaluate constraint value
   PROCEDURE :: eval => fit_press_eval
 END TYPE press_constraint
 !---------------------------------------------------------------------------------
-!> Needs Docs
+!> Safety factor constraint
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: q_constraint
   INTEGER(4) :: type = 1 !< Type of constraint (1 -> min, 2 -> max, 3 -> rel_flux)
   REAL(8) :: loc = 0.d0 !< Location of constraint in normalized flux
 CONTAINS
-  !> Needs docs
+  !> Compute error
   PROCEDURE :: error => fit_q_error
-  !> Needs docs
+  !> Evaluate constraint value
   PROCEDURE :: eval => fit_q_eval
-  !> Needs docs
+  !> Does constraint use parallelism in calculation?
   PROCEDURE :: is_parallel => fit_q_parallel
 END TYPE q_constraint
 !---------------------------------------------------------------------------------
-!> Needs Docs
+!> Reconstruction constraint pointer
 !---------------------------------------------------------------------------------
 TYPE :: fit_constraint_ptr
-  CLASS(fit_constraint), POINTER :: con => NULL() !< Needs docs
+  CLASS(fit_constraint), POINTER :: con => NULL() !< Constraint object
 END TYPE fit_constraint_ptr
 !---
 TYPE(gs_eq), POINTER, PUBLIC :: gs_active => NULL() !< Needs docs
@@ -201,9 +199,9 @@ LOGICAL, PRIVATE :: fit_P = .TRUE. !< Needs docs
 LOGICAL, PRIVATE :: fit_Pnorm = .TRUE. !< Needs docs
 LOGICAL, PRIVATE :: fit_Alam = .FALSE. !< Needs docs
 LOGICAL, PRIVATE :: fit_R0 = .FALSE. !< Needs docs
+LOGICAL, PRIVATE :: fit_V0 = .FALSE. !< Needs docs
 LOGICAL, PRIVATE :: fit_coils = .FALSE. !< Needs docs
 LOGICAL, PRIVATE :: fit_F0 = .FALSE. !< Needs docs
-LOGICAL, PRIVATE :: fit_V0 = .FALSE. !< Needs docs
 LOGICAL, PRIVATE :: fixed_centering = .FALSE. !< Needs docs
 LOGICAL, PRIVATE :: linearized_fit = .FALSE. !< Needs docs
 TYPE(fit_constraint_ptr), POINTER, DIMENSION(:) :: conlist => NULL() !< Needs docs
@@ -215,18 +213,18 @@ CONTAINS
 !> Needs Docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_gs(gs,inpath,outpath,fitI,fitP,fitPnorm,fitAlam,fitR0,fitV0,fitCoils,fitF0,fixedCentering)
-TYPE(gs_eq), TARGET, INTENT(inout) :: gs
-CHARACTER(LEN=*), INTENT(in) :: inpath
-CHARACTER(LEN=*), INTENT(in) :: outpath
-LOGICAL, OPTIONAL, INTENT(in) :: fitI
-LOGICAL, OPTIONAL, INTENT(in) :: fitP
-LOGICAL, OPTIONAL, INTENT(in) :: fitPnorm
-LOGICAL, OPTIONAL, INTENT(in) :: fitAlam
-LOGICAL, OPTIONAL, INTENT(in) :: fitR0
-LOGICAL, OPTIONAL, INTENT(in) :: fitV0
-LOGICAL, OPTIONAL, INTENT(in) :: fitCoils
-LOGICAL, OPTIONAL, INTENT(in) :: fitF0
-LOGICAL, OPTIONAL, INTENT(in) :: fixedCentering
+TYPE(gs_eq), TARGET, INTENT(inout) :: gs !< Needs docs
+CHARACTER(LEN=*), INTENT(in) :: inpath !< Needs docs
+CHARACTER(LEN=*), INTENT(in) :: outpath !< Needs docs
+LOGICAL, OPTIONAL, INTENT(in) :: fitI !< Needs docs
+LOGICAL, OPTIONAL, INTENT(in) :: fitP !< Needs docs
+LOGICAL, OPTIONAL, INTENT(in) :: fitPnorm !< Needs docs
+LOGICAL, OPTIONAL, INTENT(in) :: fitAlam !< Needs docs
+LOGICAL, OPTIONAL, INTENT(in) :: fitR0 !< Needs docs
+LOGICAL, OPTIONAL, INTENT(in) :: fitV0 !< Needs docs
+LOGICAL, OPTIONAL, INTENT(in) :: fitCoils !< Needs docs
+LOGICAL, OPTIONAL, INTENT(in) :: fitF0 !< Needs docs
+LOGICAL, OPTIONAL, INTENT(in) :: fixedCentering !< Needs docs
 !---
 real(8), allocatable :: fjac(:,:),qtf(:),error(:),cofs(:)
 real(8), allocatable :: wa1(:),wa2(:),wa3(:),wa4(:)
@@ -236,14 +234,23 @@ integer(4), allocatable :: ipvt(:)
 logical :: file_exists,comp_var
 NAMELIST/gs_fit_options/ftol,xtol,gtol,maxfev,epsfcn,factor,comp_var,linearized_fit
 !---
+fit_I = .TRUE.
 IF(PRESENT(fitI))fit_I=fitI
+fit_P = .TRUE.
 IF(PRESENT(fitP))fit_P=fitP
+fit_Pnorm = .TRUE.
 IF(PRESENT(fitPnorm))fit_Pnorm=fitPnorm
+fit_Alam = .FALSE.
 IF(PRESENT(fitAlam))fit_alam=fitAlam
+fit_R0 = .FALSE.
 IF(PRESENT(fitR0))fit_R0=fitR0
+fit_V0 = .FALSE.
 IF(PRESENT(fitV0))fit_V0=fitV0
+fit_coils = .FALSE.
 IF(PRESENT(fitCoils))fit_coils=fitCoils
+fit_F0 = .FALSE.
 IF(PRESENT(fitF0))fit_F0=fitF0
+fixed_centering = .FALSE.
 IF(PRESENT(fixedCentering))fixed_centering=fixedCentering
 IF(fitPnorm.AND.fitR0)CALL oft_abort('R0 or Pnorm fitting cannot be used together', &
 'fit_gs',__FILE__)
@@ -388,6 +395,7 @@ epsfcn = 1.d-3
 nprint = 0
 ldfjac = ncons
 comp_var = .FALSE.
+linearized_fit = .FALSE.
 !------------------------------------------------------------------------------
 ! Load settings
 !------------------------------------------------------------------------------
@@ -397,6 +405,9 @@ CLOSE(io_unit)
 IF(ierr>0)CALL oft_abort('Error parsing "gs_fit_options" in input file.','fit_gs',__FILE__)
 !---
 chi_best=1.d99
+alam_best = 1.d99
+pnorm_best = 1.d99
+vcont_best = 1.d99
 ALLOCATE(cofs_best(ncofs))
 cofs_best=cofs
 CALL gs_active%psi%new(psi_best)
@@ -412,6 +423,8 @@ IF(file_exists)THEN
   CLOSE(io_unit)
 ENDIF
 IF(maxfev>0)THEN
+  feval_count=0
+  geval_count=0
   !---Initialize
   CALL fit_error(ncons,ncofs,cofs,error,info)
   ! gs_active%Itor_target=-1.d0
@@ -457,9 +470,9 @@ WRITE(io_unit,*)gs_active%pnorm,gs_active%vcontrol_val
 CLOSE(io_unit)
 !---Cleanup
 CALL psi_best%delete
-DEALLOCATE(cofs_best,psi_best)
-DEALLOCATE(cofs_scale,fjac,qtf,wa1,wa2)
-DEALLOCATE(wa3,wa4,ipvt)
+DEALLOCATE(cofs,cofs_scale,cofs_best,error,psi_best)
+DEALLOCATE(fjac,qtf,wa1,wa2,wa3,wa4,ipvt)
+IF(fit_coils)DEALLOCATE(curr_in)
 CONTAINS
 !------------------------------------------------------------------------------
 !> Decode MINPACK exit flag info
@@ -522,8 +535,9 @@ END SUBROUTINE fit_gs
 !> Estimate confidence in the fit from linearization
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_confidence(m,n,cofs)
-INTEGER(4), INTENT(in) :: m,n
-REAL(8), INTENT(in) :: cofs(n)
+INTEGER(4), INTENT(in) :: m !< Needs docs
+INTEGER(4), INTENT(in) :: n !< Needs docs
+REAL(8), INTENT(in) :: cofs(n) !< Needs docs
 INTEGER(4) :: i,info
 REAL(8) :: sigma
 REAL(8), ALLOCATABLE :: inv_mat(:,:),cof_tmp(:),error(:),err0(:),jac_mat(:,:)
@@ -544,10 +558,11 @@ END SUBROUTINE fit_confidence
 !> Needs docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_error(m,n,cofs,err,iflag)
-integer(4), intent(in) :: m,n
-real(8), intent(in) :: cofs(n)
-real(8), intent(out) :: err(m)
-integer(4), intent(inout) :: iflag
+INTEGER(4), INTENT(in) :: m !< Needs docs
+INTEGER(4), INTENT(in) :: n !< Needs docs
+REAL(8), INTENT(in) :: cofs(n) !< Needs docs
+real(8), intent(out) :: err(m) !< Needs docs
+integer(4), intent(inout) :: iflag !< Needs docs
 REAL(8) :: jac_mat(m,n)
 CALL fit_error_grad(m,n,cofs,err,jac_mat,m,1)
 END SUBROUTINE fit_error
@@ -555,10 +570,13 @@ END SUBROUTINE fit_error
 !> Needs docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_error_grad(m,n,cofs,err,jac_mat,ldjac_mat,iflag)
-integer(4), intent(in) :: m,n,ldjac_mat
-real(8), intent(in) :: cofs(n)
-real(8), intent(out) :: err(m),jac_mat(ldjac_mat,n)
-integer(4), intent(in) :: iflag
+integer(4), intent(in) :: m !< Needs docs
+integer(4), intent(in) :: n !< Needs docs
+integer(4), intent(in) :: ldjac_mat !< Needs docs
+real(8), intent(in) :: cofs(n) !< Needs docs
+real(8), intent(out) :: err(m) !< Needs docs
+real(8), intent(out) :: jac_mat(ldjac_mat,n) !< Needs docs
+integer(4), intent(in) :: iflag !< Needs docs
 logical :: plot_save
 integer(4) :: i,j,js,je,offset,ierr
 real(8) :: rel_err(m),abs_err(m),dx,dxi
@@ -1049,8 +1067,8 @@ END SUBROUTINE run_err
 !> Needs Docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_load(filename,cons)
-CHARACTER(LEN=*), INTENT(in) :: filename
-TYPE(fit_constraint_ptr), POINTER, INTENT(out) :: cons(:)
+CHARACTER(LEN=*), INTENT(in) :: filename !< Needs docs
+TYPE(fit_constraint_ptr), POINTER, INTENT(out) :: cons(:) !< Needs docs
 !---
 TYPE(coil_constraint), POINTER :: coil_con
 TYPE(field_constraint), POINTER :: field_con
@@ -1203,9 +1221,9 @@ END SUBROUTINE fit_load
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_dummy_error(self,gs) RESULT(err)
-CLASS(fit_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: err
+CLASS(fit_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: err !< Needs docs
 CALL oft_abort('No constraint type specified.','fit_dummy_error',__FILE__)
 err=0.d0
 END FUNCTION fit_dummy_error
@@ -1213,9 +1231,9 @@ END FUNCTION fit_dummy_error
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_dummy_eval(self,gs) RESULT(val)
-CLASS(fit_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: val
+CLASS(fit_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: val !< Needs docs
 CALL oft_abort('No constraint type specified.','fit_dummy_eval',__FILE__)
 val=0.d0
 END FUNCTION fit_dummy_eval
@@ -1223,9 +1241,9 @@ END FUNCTION fit_dummy_eval
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_dummy_nax_corr(self,gs) RESULT(val)
-CLASS(fit_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: val
+CLASS(fit_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: val !< Needs docs
 val = 0.d0
 IF(ASSOCIATED(self%nax_corr))val = DOT_PRODUCT(self%nax_corr,gs%cond_weights)
 END FUNCTION fit_dummy_nax_corr
@@ -1233,59 +1251,60 @@ END FUNCTION fit_dummy_nax_corr
 !> Needs Docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_dummy_setup_comp(self)
-CLASS(fit_constraint), INTENT(inout) :: self
+CLASS(fit_constraint), INTENT(inout) :: self !< Needs docs
 END SUBROUTINE fit_dummy_setup_comp
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_dummy_parallel(self) RESULT(is_parallel)
-CLASS(fit_constraint), INTENT(inout) :: self
-LOGICAL :: is_parallel
+CLASS(fit_constraint), INTENT(inout) :: self !< Needs docs
+LOGICAL :: is_parallel !< Needs docs
 is_parallel=.FALSE.
 END FUNCTION fit_dummy_parallel
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_coil_error(self,gs) RESULT(err)
-CLASS(coil_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: err
+CLASS(coil_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: err !< Needs docs
 err = (gs%coil_currs(self%coil)/mu0 - self%val)*self%wt
 END FUNCTION fit_coil_error
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_coil_eval(self,gs) RESULT(val)
-CLASS(coil_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: val
+CLASS(coil_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: val !< Needs docs
 val = gs%coil_currs(self%coil)/mu0
 END FUNCTION fit_coil_eval
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_vcont_error(self,gs) RESULT(err)
-CLASS(vcont_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: err
+CLASS(vcont_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: err !< Needs docs
 err = (gs%vcontrol_val - self%val)*self%wt
 END FUNCTION fit_vcont_error
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_vcont_eval(self,gs) RESULT(val)
-CLASS(vcont_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: val
+CLASS(vcont_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: val !< Needs docs
 val = gs%vcontrol_val
 END FUNCTION fit_vcont_eval
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_q_error(self,gs) RESULT(err)
-CLASS(q_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: err,qval
+CLASS(q_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: err !< Needs docs
+REAL(8) :: qval
 qval = self%eval(gs)
 err = (qval - self%val)*self%wt
 IF(self%type==-1.AND.qval>self%val)err=0.d0
@@ -1294,11 +1313,12 @@ END FUNCTION fit_q_error
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_q_eval(self,gs) RESULT(val)
-CLASS(q_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
+CLASS(q_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: val !< Needs docs
 INTEGER(4) :: j
 INTEGER(4), PARAMETER :: npsi=30
-REAL(8) :: val,qmin,qmax,qprof(npsi),psi_q(npsi),dl,rbounds(2,2),zbounds(2,2),psi0,psi1
+REAL(8) :: qmin,qmax,qprof(npsi),psi_q(npsi),dl,rbounds(2,2),zbounds(2,2),psi0,psi1
 psi0=0.d0; psi1=1.d0
 ! IF(gs%plasma_bounds(1)>-1.d98)THEN
   ! psi0=gs%plasma_bounds(1); psi1=gs%plasma_bounds(2)
@@ -1343,17 +1363,17 @@ END FUNCTION fit_q_eval
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_q_parallel(self) RESULT(is_parallel)
-CLASS(q_constraint), INTENT(inout) :: self
-LOGICAL :: is_parallel
+CLASS(q_constraint), INTENT(inout) :: self !< Needs docs
+LOGICAL :: is_parallel !< Needs docs
 is_parallel=.TRUE.
 END FUNCTION fit_q_parallel
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_field_error(self,gs) RESULT(err)
-CLASS(field_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: err
+CLASS(field_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: err !< Needs docs
 err = self%eval(gs)
 IF(ASSOCIATED(self%nax_corr))err=err+DOT_PRODUCT(self%nax_corr,gs%cond_weights)
 err = (self%val - err)*self%wt
@@ -1362,9 +1382,9 @@ END FUNCTION fit_field_error
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_field_eval(self,gs) RESULT(val)
-CLASS(field_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: val
+CLASS(field_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: val !< Needs docs
 TYPE(oft_lag_brinterp) :: psi_eval
 TYPE(oft_lag_bginterp) :: psi_geval
 REAL(8) :: goptmp(3,3),v,psi(1),gpsi(3),rmin,rdiff,btmp(3)
@@ -1413,7 +1433,7 @@ END FUNCTION fit_field_eval
 !> Needs Docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_field_setup_comp(self)
-CLASS(field_constraint), INTENT(inout) :: self
+CLASS(field_constraint), INTENT(inout) :: self !< Needs docs
 self%ncomp=1
 ALLOCATE(self%comp_r(3,1),self%comp_n(3,1))
 self%comp_r(:,1)=(/self%r(1),self%phi,self%r(2)/)
@@ -1423,9 +1443,10 @@ END SUBROUTINE fit_field_setup_comp
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_flux_error(self,gs) RESULT(err)
-CLASS(flux_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: err,psitmp
+CLASS(flux_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: err !< Needs docs
+REAL(8) :: psitmp
 psitmp = self%eval(gs)
 err = (self%val - psitmp)*self%wt
 END FUNCTION fit_flux_error
@@ -1433,9 +1454,9 @@ END FUNCTION fit_flux_error
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_flux_eval(self,gs) RESULT(val)
-CLASS(flux_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: val
+CLASS(flux_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: val !< Needs docs
 TYPE(oft_lag_brinterp) :: psi_eval
 REAL(8) :: goptmp(3,3),v,psi(1),rmin,rdiff
 INTEGER(4) :: i,ip
@@ -1472,9 +1493,9 @@ END FUNCTION fit_flux_eval
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_saddle_error(self,gs) RESULT(err)
-CLASS(saddle_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: err
+CLASS(saddle_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: err !< Needs docs
 err = self%eval(gs)
 IF(ASSOCIATED(self%nax_corr))err=err+DOT_PRODUCT(self%nax_corr,gs%cond_weights)
 err = (self%val - err)*self%wt
@@ -1483,9 +1504,9 @@ END FUNCTION fit_saddle_error
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_saddle_eval(self,gs) RESULT(val)
-CLASS(saddle_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: val
+CLASS(saddle_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: val !< Needs docs
 TYPE(oft_lag_brinterp) :: psi_eval
 REAL(8) :: goptmp(3,3),psi(1,2)
 INTEGER(4) :: i
@@ -1511,7 +1532,7 @@ END FUNCTION fit_saddle_eval
 !> Needs Docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_saddle_setup_comp(self)
-CLASS(saddle_constraint), INTENT(inout) :: self
+CLASS(saddle_constraint), INTENT(inout) :: self !< Needs docs
 INTEGER(4) :: i,j
 REAL(8) :: r,z,nr,nz,rmag,theta,da,dr,dtheta
 self%ncomp=self%nr*self%nt
@@ -1538,9 +1559,10 @@ END SUBROUTINE fit_saddle_setup_comp
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_itor_error(self,gs) RESULT(err)
-CLASS(itor_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: err,itor
+CLASS(itor_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: err !< Needs docs
+REAL(8) :: itor
 itor = self%eval(gs)
 err = (self%val - itor)*self%wt
 END FUNCTION fit_itor_error
@@ -1548,9 +1570,10 @@ END FUNCTION fit_itor_error
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_itor_eval(self,gs) RESULT(val)
-CLASS(itor_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: val,itor
+CLASS(itor_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: val !< Needs docs
+REAL(8) :: itor
 CALL gs_itor_nl(gs,itor)
 val=itor/mu0
 END FUNCTION fit_itor_eval
@@ -1558,17 +1581,18 @@ END FUNCTION fit_itor_eval
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_itor_parallel(self) RESULT(is_parallel)
-CLASS(itor_constraint), INTENT(inout) :: self
-LOGICAL :: is_parallel
+CLASS(itor_constraint), INTENT(inout) :: self !< Needs docs
+LOGICAL :: is_parallel !< Needs docs
 is_parallel=.TRUE.
 END FUNCTION fit_itor_parallel
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_dflux_error(self,gs) RESULT(err)
-CLASS(dflux_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: err,dflux
+CLASS(dflux_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: err !< Needs docs
+REAL(8) :: dflux
 dflux=self%eval(gs)
 err = (self%val - dflux)*self%wt
 END FUNCTION fit_dflux_error
@@ -1576,18 +1600,19 @@ END FUNCTION fit_dflux_error
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_dflux_eval(self,gs) RESULT(val)
-CLASS(dflux_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: val
+CLASS(dflux_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: val !< Needs docs
 val=gs_dflux(gs)
 END FUNCTION fit_dflux_eval
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_press_error(self,gs) RESULT(err)
-CLASS(press_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: err,press,psi(1),goptmp(3,4)
+CLASS(press_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: err !< Needs docs
+REAL(8) :: press,psi(1),goptmp(3,4)
 TYPE(oft_lag_brinterp) :: psi_eval
 LOGICAL :: in_plasma
 press = self%eval(gs)
@@ -1614,9 +1639,9 @@ END FUNCTION fit_press_error
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_press_eval(self,gs) RESULT(val)
-CLASS(press_constraint), INTENT(inout) :: self
-TYPE(gs_eq), INTENT(inout) :: gs
-REAL(8) :: val
+CLASS(press_constraint), INTENT(inout) :: self !< Needs docs
+TYPE(gs_eq), INTENT(inout) :: gs !< Needs docs
+REAL(8) :: val !< Needs docs
 TYPE(oft_lag_brinterp) :: psi_eval
 REAL(8) :: goptmp(3,3),v,psi(1),rmin,rdiff
 INTEGER(4) :: i,ip

--- a/src/physics/grad_shaf_fit.F90
+++ b/src/physics/grad_shaf_fit.F90
@@ -22,7 +22,7 @@ use oft_lu, only: lapack_matinv
 use oft_lag_basis, only: oft_blag_d2eval, oft_blag_geval
 use oft_blag_operators, only: oft_lag_brinterp, oft_lag_bginterp
 use oft_gs, only: gs_eq, gs_dflux, gs_get_cond_weights, gs_itor_nl, gs_psi2r, &
-  gs_psimax, gs_set_cond_weights, gs_err_reason, gs_test_bounds, gs_get_cond_scales, &
+  gs_set_cond_weights, gs_err_reason, gs_test_bounds, gs_get_cond_scales, &
   gs_get_qprof, gs_epsilon, gsinv_interp, oft_indent, oft_decrease_indent, oft_increase_indent
 use oft_gs_profiles, only: twolam_flux_func
 use tracing_2d, only: active_tracer, tracer, set_tracer

--- a/src/physics/grad_shaf_fit.F90
+++ b/src/physics/grad_shaf_fit.F90
@@ -31,33 +31,36 @@ IMPLICIT NONE
 #include "local.h"
 PRIVATE
 !---------------------------------------------------------------------------------
-! TYPE fit_constraint
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 TYPE :: fit_constraint
-  INTEGER(4) :: ncomp = 0
-  REAL(8) :: wt = 1.d0
-  REAL(8) :: val = 0.d0
-  REAL(8), POINTER, DIMENSION(:) :: nax_corr => NULL()
-  REAL(8), POINTER, DIMENSION(:,:) :: comp_r => NULL()
-  REAL(8), POINTER, DIMENSION(:,:) :: comp_n => NULL()
+  INTEGER(4) :: ncomp = 0 !< Needs docs
+  REAL(8) :: wt = 1.d0 !< Needs docs
+  REAL(8) :: val = 0.d0 !< Needs docs
+  REAL(8), POINTER, DIMENSION(:) :: nax_corr => NULL() !< Needs docs
+  REAL(8), POINTER, DIMENSION(:,:) :: comp_r => NULL() !< Needs docs
+  REAL(8), POINTER, DIMENSION(:,:) :: comp_n => NULL() !< Needs docs
 CONTAINS
+  !> Needs docs
   PROCEDURE :: error => fit_dummy_error
+  !> Needs docs
   PROCEDURE :: eval => fit_dummy_eval
+  !> Needs docs
   PROCEDURE :: setup_comp => fit_dummy_setup_comp
+  !> Needs docs
   PROCEDURE :: get_nax => fit_dummy_nax_corr
+  !> Needs docs
   PROCEDURE :: is_parallel => fit_dummy_parallel
 END TYPE fit_constraint
-!---------------------------------------------------------------------------------
-! TYPE coil_constraint
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: coil_constraint
-  INTEGER(4) :: coil = 0
+  INTEGER(4) :: coil = 0 !< Needs docs
 CONTAINS
+  !> Needs docs
   PROCEDURE :: error => fit_coil_error
+  !> Needs docs
   PROCEDURE :: eval => fit_coil_eval
 END TYPE coil_constraint
 !---------------------------------------------------------------------------------
@@ -66,103 +69,95 @@ END TYPE coil_constraint
 !> Needs Docs
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: vcont_constraint
-  INTEGER(4) :: coil = 0
 CONTAINS
+  !> Needs docs
   PROCEDURE :: error => fit_vcont_error
+  !> Needs docs
   PROCEDURE :: eval => fit_vcont_eval
 END TYPE vcont_constraint
-!---------------------------------------------------------------------------------
-! TYPE field_constraint
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: field_constraint
-  INTEGER(4) :: cell = 0
-  REAL(8) :: phi = 0.d0
-  REAL(8) :: f(3) = 0.d0
-  REAL(8) :: r(3) = [0.d0,0.d0,0.d0]
-  REAL(8) :: v(3) = [0.d0,0.d0,0.d0]
+  INTEGER(4) :: cell = 0 !< Needs docs
+  REAL(8) :: phi = 0.d0 !< Needs docs
+  REAL(8) :: f(3) = 0.d0 !< Needs docs
+  REAL(8) :: r(3) = [0.d0,0.d0,0.d0] !< Needs docs
+  REAL(8) :: v(3) = [0.d0,0.d0,0.d0] !< Needs docs
 CONTAINS
+  !> Needs docs
   PROCEDURE :: error => fit_field_error
+  !> Needs docs
   PROCEDURE :: eval => fit_field_eval
+  !> Needs docs
   PROCEDURE :: setup_comp => fit_field_setup_comp
 END TYPE field_constraint
-!---------------------------------------------------------------------------------
-! TYPE flux_constraint
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: flux_constraint
-  INTEGER(4) :: cell = 0
-  REAL(8) :: f(3) = 0.d0
-  REAL(8) :: r(3) = [0.d0,0.d0,0.d0]
+  INTEGER(4) :: cell = 0 !< Needs docs
+  REAL(8) :: f(3) = 0.d0 !< Needs docs
+  REAL(8) :: r(3) = [0.d0,0.d0,0.d0] !< Needs docs
 CONTAINS
+  !> Needs docs
   PROCEDURE :: error => fit_flux_error
+  !> Needs docs
   PROCEDURE :: eval => fit_flux_eval
 END TYPE flux_constraint
-!---------------------------------------------------------------------------------
-! TYPE saddle_constraint
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: saddle_constraint
-  INTEGER(4) :: cells(2) = 0
-  INTEGER(4) :: nr = 10
-  INTEGER(4) :: nt = 10
-  REAL(8) :: f(3,2) = 0.d0
-  REAL(8) :: r(3,2) = 0.d0
-  REAL(8) :: width = 0.d0
+  INTEGER(4) :: cells(2) = 0 !< Needs docs
+  INTEGER(4) :: nr = 10 !< Needs docs
+  INTEGER(4) :: nt = 10 !< Needs docs
+  REAL(8) :: f(3,2) = 0.d0 !< Needs docs
+  REAL(8) :: r(3,2) = 0.d0 !< Needs docs
+  REAL(8) :: width = 0.d0 !< Needs docs
 CONTAINS
+  !> Needs docs
   PROCEDURE :: error => fit_saddle_error
+  !> Needs docs
   PROCEDURE :: eval => fit_saddle_eval
+  !> Needs docs
   PROCEDURE :: setup_comp => fit_saddle_setup_comp
 END TYPE saddle_constraint
-!---------------------------------------------------------------------------------
-! TYPE itor_constraint
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: itor_constraint
 CONTAINS
+  !> Needs docs
   PROCEDURE :: error => fit_itor_error
+  !> Needs docs
   PROCEDURE :: eval => fit_itor_eval
+  !> Needs docs
   PROCEDURE :: is_parallel => fit_itor_parallel
 END TYPE itor_constraint
-!---------------------------------------------------------------------------------
-! TYPE itor_constraint
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: dflux_constraint
 CONTAINS
+  !> Needs docs
   PROCEDURE :: error => fit_dflux_error
+  !> Needs docs
   PROCEDURE :: eval => fit_dflux_eval
 END TYPE dflux_constraint
-!---------------------------------------------------------------------------------
-! TYPE press_constraint
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 TYPE, EXTENDS(fit_constraint) :: press_constraint
-  INTEGER(4) :: cell = 0
-  REAL(8) :: f(3) = 0.d0
-  REAL(8) :: r(3) = [0.d0,0.d0,0.d0]
+  INTEGER(4) :: cell = 0 !< Needs docs
+  REAL(8) :: f(3) = 0.d0 !< Needs docs
+  REAL(8) :: r(3) = [0.d0,0.d0,0.d0] !< Needs docs
 CONTAINS
+  !> Needs docs
   PROCEDURE :: error => fit_press_error
+  !> Needs docs
   PROCEDURE :: eval => fit_press_eval
 END TYPE press_constraint
-! !---------------------------------------------------------------------------------
-! ! TYPE injlam_constraint
-! !---------------------------------------------------------------------------------
-! !> Needs Docs
-! !---------------------------------------------------------------------------------
-! TYPE, EXTENDS(fit_constraint) :: injlam_constraint
-! CONTAINS
-!   PROCEDURE :: error => fit_injlam_error
-!   PROCEDURE :: eval => fit_injlam_eval
-! END TYPE injlam_constraint
-!---------------------------------------------------------------------------------
-! TYPE qmin_constraint
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -170,51 +165,50 @@ TYPE, EXTENDS(fit_constraint) :: q_constraint
   INTEGER(4) :: type = 1 !< Type of constraint (1 -> min, 2 -> max, 3 -> rel_flux)
   REAL(8) :: loc = 0.d0 !< Location of constraint in normalized flux
 CONTAINS
+  !> Needs docs
   PROCEDURE :: error => fit_q_error
+  !> Needs docs
   PROCEDURE :: eval => fit_q_eval
+  !> Needs docs
   PROCEDURE :: is_parallel => fit_q_parallel
 END TYPE q_constraint
-!---------------------------------------------------------------------------------
-! TYPE fit_constraint_ptr
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 TYPE :: fit_constraint_ptr
-  CLASS(fit_constraint), POINTER :: con => NULL()
+  CLASS(fit_constraint), POINTER :: con => NULL() !< Needs docs
 END TYPE fit_constraint_ptr
 !---
-TYPE(gs_eq), POINTER, PUBLIC :: gs_active => NULL()
-REAL(8), ALLOCATABLE :: cofs_best(:)
-REAL(8) :: chi_best = 1.d99
-REAL(8) :: alam_best = 1.d99
-REAL(8) :: pnorm_best = 1.d99
-REAL(8) :: vcont_best = 1.d99
-CLASS(oft_vector), POINTER :: psi_best => NULL()
-REAL(8), ALLOCATABLE :: cofs_scale(:)
-REAL(8), ALLOCATABLE :: curr_in(:)
-INTEGER(4), PRIVATE :: ncons = 0
-INTEGER(4), PRIVATE :: ncofs = 0
-INTEGER(4), PRIVATE :: ncond_active = 0
-INTEGER(4), PRIVATE :: feval_count = 0
-INTEGER(4), PRIVATE :: geval_count = 0
-LOGICAL :: fit_pm = .FALSE.
-LOGICAL, PRIVATE :: fit_I = .TRUE.
-LOGICAL, PRIVATE :: fit_P = .TRUE.
-LOGICAL, PRIVATE :: fit_Pnorm = .TRUE.
-LOGICAL, PRIVATE :: fit_Alam = .FALSE.
-LOGICAL, PRIVATE :: fit_R0 = .FALSE.
-LOGICAL, PRIVATE :: fit_coils = .FALSE.
-LOGICAL, PRIVATE :: fit_F0 = .FALSE.
-LOGICAL, PRIVATE :: fit_V0 = .FALSE.
-LOGICAL, PRIVATE :: fixed_centering = .FALSE.
-LOGICAL, PRIVATE :: linearized_fit = .FALSE.
-TYPE(fit_constraint_ptr), POINTER, DIMENSION(:) :: conlist => NULL()
+TYPE(gs_eq), POINTER, PUBLIC :: gs_active => NULL() !< Needs docs
+REAL(8), ALLOCATABLE :: cofs_best(:) !< Needs docs
+REAL(8) :: chi_best = 1.d99 !< Needs docs
+REAL(8) :: alam_best = 1.d99 !< Needs docs
+REAL(8) :: pnorm_best = 1.d99 !< Needs docs
+REAL(8) :: vcont_best = 1.d99 !< Needs docs
+CLASS(oft_vector), POINTER :: psi_best => NULL() !< Needs docs
+REAL(8), ALLOCATABLE :: cofs_scale(:) !< Needs docs
+REAL(8), ALLOCATABLE :: curr_in(:) !< Needs docs
+INTEGER(4), PRIVATE :: ncons = 0 !< Needs docs
+INTEGER(4), PRIVATE :: ncofs = 0 !< Needs docs
+INTEGER(4), PRIVATE :: ncond_active = 0 !< Needs docs
+INTEGER(4), PRIVATE :: feval_count = 0 !< Needs docs
+INTEGER(4), PRIVATE :: geval_count = 0 !< Needs docs
+LOGICAL :: fit_pm = .FALSE. !< Needs docs
+LOGICAL, PRIVATE :: fit_I = .TRUE. !< Needs docs
+LOGICAL, PRIVATE :: fit_P = .TRUE. !< Needs docs
+LOGICAL, PRIVATE :: fit_Pnorm = .TRUE. !< Needs docs
+LOGICAL, PRIVATE :: fit_Alam = .FALSE. !< Needs docs
+LOGICAL, PRIVATE :: fit_R0 = .FALSE. !< Needs docs
+LOGICAL, PRIVATE :: fit_coils = .FALSE. !< Needs docs
+LOGICAL, PRIVATE :: fit_F0 = .FALSE. !< Needs docs
+LOGICAL, PRIVATE :: fit_V0 = .FALSE. !< Needs docs
+LOGICAL, PRIVATE :: fixed_centering = .FALSE. !< Needs docs
+LOGICAL, PRIVATE :: linearized_fit = .FALSE. !< Needs docs
+TYPE(fit_constraint_ptr), POINTER, DIMENSION(:) :: conlist => NULL() !< Needs docs
 !---
 PUBLIC fit_constraint, field_constraint, itor_constraint, fit_pm
-PUBLIC fit_constraint_ptr, fit_gs, fit_load!, create_driveinterp
+PUBLIC fit_constraint_ptr, fit_gs, fit_load
 CONTAINS
-!---------------------------------------------------------------------------------
-! SUBROUTINE fit_gs
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -519,8 +513,6 @@ END SELECT
 end function minpack_exit_reason
 END SUBROUTINE fit_gs
 !---------------------------------------------------------------------------------
-! SUBROUTINE fit_confidence
-!---------------------------------------------------------------------------------
 !> Estimate confidence in the fit from linearization
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_confidence(m,n,cofs)
@@ -543,9 +535,7 @@ DO i=1,n
 END DO
 END SUBROUTINE fit_confidence
 !---------------------------------------------------------------------------------
-! SUBROUTINE fit_error
-!---------------------------------------------------------------------------------
-!>
+!> Needs docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_error(m,n,cofs,err,iflag)
 integer(4), intent(in) :: m,n
@@ -556,9 +546,7 @@ REAL(8) :: jac_mat(m,n)
 CALL fit_error_grad(m,n,cofs,err,jac_mat,m,1)
 END SUBROUTINE fit_error
 !---------------------------------------------------------------------------------
-! SUBROUTINE fit_error_grad
-!---------------------------------------------------------------------------------
-!>
+!> Needs docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_error_grad(m,n,cofs,err,jac_mat,ldjac_mat,iflag)
 integer(4), intent(in) :: m,n,ldjac_mat
@@ -996,9 +984,9 @@ ELSE
 END IF
 !---Centering
 CALL reset_eq
-!
 DEALLOCATE(cof_tmp,err_tmp)
 CONTAINS
+!
 SUBROUTINE reset_eq
 gs_active%alam=alam_in
 gs_active%Itor_target=ip_target_in
@@ -1047,8 +1035,6 @@ ELSE
   END DO
 END IF
 END SUBROUTINE run_err
-!---------------------------------------------------------------------------------
-! SUBROUTINE fit_load
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1202,8 +1188,6 @@ RETURN
                    'fit_load',__FILE__)
 END SUBROUTINE fit_load
 !---------------------------------------------------------------------------------
-! FUNCTION fit_dummy_error
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_dummy_error(self,gs) RESULT(err)
@@ -1213,8 +1197,6 @@ REAL(8) :: err
 CALL oft_abort('No constraint type specified.','fit_dummy_error',__FILE__)
 err=0.d0
 END FUNCTION fit_dummy_error
-!---------------------------------------------------------------------------------
-! FUNCTION fit_dummy_eval
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1226,8 +1208,6 @@ CALL oft_abort('No constraint type specified.','fit_dummy_eval',__FILE__)
 val=0.d0
 END FUNCTION fit_dummy_eval
 !---------------------------------------------------------------------------------
-! FUNCTION fit_dummy_nax_corr
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_dummy_nax_corr(self,gs) RESULT(val)
@@ -1238,15 +1218,11 @@ val = 0.d0
 IF(ASSOCIATED(self%nax_corr))val = DOT_PRODUCT(self%nax_corr,gs%cond_weights)
 END FUNCTION fit_dummy_nax_corr
 !---------------------------------------------------------------------------------
-! FUNCTION fit_dummy_setup_comp
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_dummy_setup_comp(self)
 CLASS(fit_constraint), INTENT(inout) :: self
 END SUBROUTINE fit_dummy_setup_comp
-!---------------------------------------------------------------------------------
-! FUNCTION fit_dummy_parallel
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1255,8 +1231,6 @@ CLASS(fit_constraint), INTENT(inout) :: self
 LOGICAL :: is_parallel
 is_parallel=.FALSE.
 END FUNCTION fit_dummy_parallel
-!---------------------------------------------------------------------------------
-! FUNCTION fit_coil_error
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1267,8 +1241,6 @@ REAL(8) :: err
 err = (gs%coil_currs(self%coil)/mu0 - self%val)*self%wt
 END FUNCTION fit_coil_error
 !---------------------------------------------------------------------------------
-! FUNCTION fit_coil_eval
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_coil_eval(self,gs) RESULT(val)
@@ -1277,8 +1249,6 @@ TYPE(gs_eq), INTENT(inout) :: gs
 REAL(8) :: val
 val = gs%coil_currs(self%coil)/mu0
 END FUNCTION fit_coil_eval
-!---------------------------------------------------------------------------------
-! FUNCTION fit_vcont_error
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1289,8 +1259,6 @@ REAL(8) :: err
 err = (gs%vcontrol_val - self%val)*self%wt
 END FUNCTION fit_vcont_error
 !---------------------------------------------------------------------------------
-! FUNCTION fit_vcont_eval
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_vcont_eval(self,gs) RESULT(val)
@@ -1299,8 +1267,6 @@ TYPE(gs_eq), INTENT(inout) :: gs
 REAL(8) :: val
 val = gs%vcontrol_val
 END FUNCTION fit_vcont_eval
-!---------------------------------------------------------------------------------
-! FUNCTION fit_q_error
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1312,8 +1278,6 @@ qval = self%eval(gs)
 err = (qval - self%val)*self%wt
 IF(self%type==-1.AND.qval>self%val)err=0.d0
 END FUNCTION fit_q_error
-!---------------------------------------------------------------------------------
-! FUNCTION fit_q_eval
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1364,8 +1328,6 @@ ELSEIF(self%type==3)THEN
 END IF
 END FUNCTION fit_q_eval
 !---------------------------------------------------------------------------------
-! FUNCTION fit_q_parallel
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_q_parallel(self) RESULT(is_parallel)
@@ -1373,8 +1335,6 @@ CLASS(q_constraint), INTENT(inout) :: self
 LOGICAL :: is_parallel
 is_parallel=.TRUE.
 END FUNCTION fit_q_parallel
-!---------------------------------------------------------------------------------
-! FUNCTION fit_field_error
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1386,8 +1346,6 @@ err = self%eval(gs)
 IF(ASSOCIATED(self%nax_corr))err=err+DOT_PRODUCT(self%nax_corr,gs%cond_weights)
 err = (self%val - err)*self%wt
 END FUNCTION fit_field_error
-!---------------------------------------------------------------------------------
-! FUNCTION fit_field_eval
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1440,8 +1398,6 @@ btmp(3)= gs%psiscale*gpsi(1)/self%r(1)
 val = DOT_PRODUCT(btmp,self%v)
 END FUNCTION fit_field_eval
 !---------------------------------------------------------------------------------
-! FUNCTION fit_field_setup_comp
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_field_setup_comp(self)
@@ -1452,8 +1408,6 @@ self%comp_r(:,1)=(/self%r(1),self%phi,self%r(2)/)
 self%comp_n(:,1)=self%v/magnitude(self%v)
 END SUBROUTINE fit_field_setup_comp
 !---------------------------------------------------------------------------------
-! FUNCTION fit_flux_error
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_flux_error(self,gs) RESULT(err)
@@ -1463,8 +1417,6 @@ REAL(8) :: err,psitmp
 psitmp = self%eval(gs)
 err = (self%val - psitmp)*self%wt
 END FUNCTION fit_flux_error
-!---------------------------------------------------------------------------------
-! FUNCTION fit_flux_eval
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1505,8 +1457,6 @@ CALL psi_eval%delete()
 val = psi(1)*2.d0*pi
 END FUNCTION fit_flux_eval
 !---------------------------------------------------------------------------------
-! FUNCTION fit_saddle_error
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_saddle_error(self,gs) RESULT(err)
@@ -1517,8 +1467,6 @@ err = self%eval(gs)
 IF(ASSOCIATED(self%nax_corr))err=err+DOT_PRODUCT(self%nax_corr,gs%cond_weights)
 err = (self%val - err)*self%wt
 END FUNCTION fit_saddle_error
-!---------------------------------------------------------------------------------
-! FUNCTION fit_saddle_eval
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1548,8 +1496,6 @@ CALL psi_eval%delete
 val = -(psi(1,1)-psi(1,2))*self%width
 END FUNCTION fit_saddle_eval
 !---------------------------------------------------------------------------------
-! FUNCTION fit_saddle_setup_comp
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 SUBROUTINE fit_saddle_setup_comp(self)
@@ -1577,8 +1523,6 @@ DO i=1,self%nr
 END DO
 END SUBROUTINE fit_saddle_setup_comp
 !---------------------------------------------------------------------------------
-! FUNCTION fit_itor_error
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_itor_error(self,gs) RESULT(err)
@@ -1588,8 +1532,6 @@ REAL(8) :: err,itor
 itor = self%eval(gs)
 err = (self%val - itor)*self%wt
 END FUNCTION fit_itor_error
-!---------------------------------------------------------------------------------
-! FUNCTION fit_itor_eval
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1609,8 +1551,6 @@ LOGICAL :: is_parallel
 is_parallel=.TRUE.
 END FUNCTION fit_itor_parallel
 !---------------------------------------------------------------------------------
-! FUNCTION fit_dflux_error
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_dflux_error(self,gs) RESULT(err)
@@ -1621,8 +1561,6 @@ dflux=self%eval(gs)
 err = (self%val - dflux)*self%wt
 END FUNCTION fit_dflux_error
 !---------------------------------------------------------------------------------
-! FUNCTION fit_dflux_eval
-!---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
 FUNCTION fit_dflux_eval(self,gs) RESULT(val)
@@ -1631,8 +1569,6 @@ TYPE(gs_eq), INTENT(inout) :: gs
 REAL(8) :: val
 val=gs_dflux(gs)
 END FUNCTION fit_dflux_eval
-!---------------------------------------------------------------------------------
-! FUNCTION fit_press_error
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1662,8 +1598,6 @@ IF(self%r(1)>0.d0)THEN
 END IF
 err = (self%val - press)*self%wt
 END FUNCTION fit_press_error
-!---------------------------------------------------------------------------------
-! FUNCTION fit_press_eval
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
@@ -1707,29 +1641,4 @@ CALL psi_eval%delete
 !---
 val = gs%psiscale*gs%psiscale*gs%pnorm*gs%P%f(psi(1))/mu0
 END FUNCTION fit_press_eval
-! !---------------------------------------------------------------------------------
-! ! FUNCTION fit_injlam_error
-! !---------------------------------------------------------------------------------
-! !> Needs Docs
-! !---------------------------------------------------------------------------------
-! FUNCTION fit_injlam_error(self,gs) RESULT(err)
-! CLASS(injlam_constraint), INTENT(inout) :: self
-! TYPE(gs_eq), INTENT(inout) :: gs
-! REAL(8) :: err,lam
-! !---
-! lam=gs%I%fp(0.d0)*gs%alam
-! IF(oft_debug_print(1))WRITE(*,*)'IL',lam
-! err = (self%val - lam)*self%wt
-! END FUNCTION fit_injlam_error
-! !---------------------------------------------------------------------------------
-! ! FUNCTION fit_injlam_eval
-! !---------------------------------------------------------------------------------
-! !> Needs Docs
-! !---------------------------------------------------------------------------------
-! FUNCTION fit_injlam_eval(self,gs) RESULT(val)
-! CLASS(injlam_constraint), INTENT(inout) :: self
-! TYPE(gs_eq), INTENT(inout) :: gs
-! REAL(8) :: val
-! val=gs%I%fp(0.d0)*gs%alam
-! END FUNCTION fit_injlam_eval
 END MODULE oft_gs_fit

--- a/src/physics/grad_shaf_mercier.F90
+++ b/src/physics/grad_shaf_mercier.F90
@@ -26,8 +26,6 @@ use spline_mod
 USE mhd_utils, ONLY: mu0
 implicit none
 !------------------------------------------------------------------------------
-! CLASS mercierinv_interp
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 type, extends(gsinv_interp) :: mercierinv_interp
@@ -36,8 +34,6 @@ contains
   !> Reconstruct the gradient of a Lagrange scalar field
   procedure :: interp => minterpinv_apply
 end type mercierinv_interp
-!------------------------------------------------------------------------------
-! INTERFACE mercier_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -49,8 +45,6 @@ contains
     procedure :: update => mercier_update
 end type mercier_flux_func
 contains
-!------------------------------------------------------------------------------
-! SUBROUTINE create_mercier_ff
 !------------------------------------------------------------------------------
 !> Needs Docs
 !------------------------------------------------------------------------------
@@ -71,8 +65,6 @@ select type(self=>func)
     END DO
 end select
 END SUBROUTINE create_mercier_ff
-!------------------------------------------------------------------------------
-! SUBROUTINE mercier_update
 !------------------------------------------------------------------------------
 !> Needs Docs
 !------------------------------------------------------------------------------
@@ -192,8 +184,6 @@ self%xmax=self%funcp%xs(self%npsi)
 IF(oft_debug_print(2))CALL oft_decrease_indent
 end subroutine mercier_update
 ! !------------------------------------------------------------------------------
-! ! SUBROUTINE minterpinv_setup
-! !------------------------------------------------------------------------------
 ! !> Needs Docs
 ! !------------------------------------------------------------------------------
 ! subroutine minterpinv_setup(self,mesh)
@@ -203,8 +193,6 @@ end subroutine mercier_update
 ! CALL self%u%get_local(self%uvals)
 ! self%mesh=>mesh
 ! end subroutine minterpinv_setup
-!------------------------------------------------------------------------------
-! SUBROUTINE minterpinv_apply
 !------------------------------------------------------------------------------
 !> Needs Docs
 !------------------------------------------------------------------------------

--- a/src/physics/grad_shaf_profiles.F90
+++ b/src/physics/grad_shaf_profiles.F90
@@ -18,47 +18,54 @@ USE oft_gs, ONLY: flux_func, gs_eq, oft_indent, oft_increase_indent, &
   oft_decrease_indent
 implicit none
 !------------------------------------------------------------------------------
-! CLASS zero_flux_func
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 type, extends(flux_func) :: zero_flux_func
 contains
-    procedure :: f => zero_f
-    procedure :: fp => zero_fp
-    procedure :: update => zero_update
-    procedure :: set_cofs => zero_cofs_update
-    procedure :: get_cofs => zero_cofs_get
+  !> Needs docs
+  procedure :: f => zero_f
+  !> Needs docs
+  procedure :: fp => zero_fp
+  !> Needs docs
+  procedure :: update => zero_update
+  !> Needs docs
+  procedure :: set_cofs => zero_cofs_update
+  !> Needs docs
+  procedure :: get_cofs => zero_cofs_get
 end type zero_flux_func
-!------------------------------------------------------------------------------
-! CLASS flat_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 type, extends(flux_func) :: flat_flux_func
 contains
-    procedure :: f => flat_f
-    procedure :: fp => flat_fp
-    procedure :: update => flat_update
-    procedure :: set_cofs => flat_cofs_update
-    procedure :: get_cofs => flat_cofs_get
+  !> Needs docs
+  procedure :: f => flat_f
+  !> Needs docs
+  procedure :: fp => flat_fp
+  !> Needs docs
+  procedure :: update => flat_update
+  !> Needs docs
+  procedure :: set_cofs => flat_cofs_update
+  !> Needs docs
+  procedure :: get_cofs => flat_cofs_get
 end type flat_flux_func
-!------------------------------------------------------------------------------
-! CLASS linear_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 type, extends(flux_func) :: linear_flux_func
   real(8) :: alpha = 0.d0 !< Slope parameter
 contains
-    procedure :: f => linear_f
-    procedure :: fp => linear_fp
-    procedure :: update => linear_update
-    procedure :: set_cofs => linear_cofs_update
-    procedure :: get_cofs => linear_cofs_get
+  !> Needs docs
+  procedure :: f => linear_f
+  !> Needs docs
+  procedure :: fp => linear_fp
+  !> Needs docs
+  procedure :: update => linear_update
+  !> Needs docs
+  procedure :: set_cofs => linear_cofs_update
+  !> Needs docs
+  procedure :: get_cofs => linear_cofs_get
 end type linear_flux_func
-!------------------------------------------------------------------------------
-! CLASS poly_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -68,82 +75,100 @@ type, extends(flux_func) :: poly_flux_func
   real(8), pointer, dimension(:) :: cofs => NULL() !< Coefficients [deg]
   logical :: zero_grad = .FALSE. !< Force zero gradient at boundary
 contains
-    procedure :: f => poly_f
-    procedure :: fp => poly_fp
-    procedure :: update => poly_update
-    procedure :: set_cofs => poly_cofs_update
-    procedure :: get_cofs => poly_cofs_get
+  !> Needs docs
+  procedure :: f => poly_f
+  !> Needs docs
+  procedure :: fp => poly_fp
+  !> Needs docs
+  procedure :: update => poly_update
+  !> Needs docs
+  procedure :: set_cofs => poly_cofs_update
+  !> Needs docs
+  procedure :: get_cofs => poly_cofs_get
 end type poly_flux_func
-!------------------------------------------------------------------------------
-! CLASS spline_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 type, extends(flux_func) :: spline_flux_func
-    INTEGER(4) :: npsi = 0
-    REAL(8) :: xmin = 0.d0
-    REAL(8) :: xmax = 0.d0
-    REAL(8) :: f1 = 0.d0
-    REAL(8) :: fn = 0.d0
-    REAL(8) :: yp1 = 0.d0
-    REAL(8) :: ypn = 0.d0
-    TYPE(spline_type) :: func
-    TYPE(spline_type) :: fun_loc(24)
+  INTEGER(4) :: npsi = 0 !< Needs docs
+  REAL(8) :: xmin = 0.d0 !< Needs docs
+  REAL(8) :: xmax = 0.d0 !< Needs docs
+  REAL(8) :: f1 = 0.d0 !< Needs docs
+  REAL(8) :: fn = 0.d0 !< Needs docs
+  REAL(8) :: yp1 = 0.d0 !< Needs docs
+  REAL(8) :: ypn = 0.d0 !< Needs docs
+  TYPE(spline_type) :: func !< Needs docs
+  TYPE(spline_type) :: fun_loc(24) !< Needs docs
 contains
-    procedure :: f => spline_f
-    procedure :: fp => spline_fp
-    procedure :: update => spline_update
-    procedure :: set_cofs => spline_cofs_update
-    procedure :: get_cofs => spline_cofs_get
+  !> Needs docs
+  procedure :: f => spline_f
+  !> Needs docs
+  procedure :: fp => spline_fp
+  !> Needs docs
+  procedure :: update => spline_update
+  !> Needs docs
+  procedure :: set_cofs => spline_cofs_update
+  !> Needs docs
+  procedure :: get_cofs => spline_cofs_get
 end type spline_flux_func
-!------------------------------------------------------------------------------
-! CLASS linterp_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 type, extends(flux_func) :: linterp_flux_func
-    integer(4) :: npsi = 0
-    real(8) :: y0 = 1.d0
-    real(8), pointer, dimension(:) :: x => NULL()
-    real(8), pointer, dimension(:) :: yp => NULL()
-    real(8), pointer, dimension(:) :: y => NULL()
+  integer(4) :: npsi = 0 !< Needs docs
+  real(8) :: y0 = 1.d0 !< Needs docs
+  real(8), pointer, dimension(:) :: x => NULL() !< Needs docs
+  real(8), pointer, dimension(:) :: yp => NULL() !< Needs docs
+  real(8), pointer, dimension(:) :: y => NULL() !< Needs docs
 contains
-    procedure :: f => linterp_f
-    procedure :: fp => linterp_fp
-    procedure :: fpp => linterp_fpp
-    procedure :: update => linterp_update
-    procedure :: set_cofs => linterp_cofs_update
-    procedure :: get_cofs => linterp_cofs_get
+  !> Needs docs
+  procedure :: f => linterp_f
+  !> Needs docs
+  procedure :: fp => linterp_fp
+  !> Needs docs
+  procedure :: fpp => linterp_fpp
+  !> Needs docs
+  procedure :: update => linterp_update
+  !> Needs docs
+  procedure :: set_cofs => linterp_cofs_update
+  !> Needs docs
+  procedure :: get_cofs => linterp_cofs_get
 end type linterp_flux_func
-!------------------------------------------------------------------------------
-! CLASS twolam_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 type, extends(flux_func) :: twolam_flux_func
-    real(8) :: alpha = 0.d0 !< Jump height
-    real(8) :: sep = .5d0 !< Jump location (poloidal flux)
-    real(8) :: width = 200.d0 !< Width factor for TANH
+  real(8) :: alpha = 0.d0 !< Jump height
+  real(8) :: sep = .5d0 !< Jump location (poloidal flux)
+  real(8) :: width = 200.d0 !< Width factor for TANH
 contains
-    procedure :: f => twolam_f
-    procedure :: fp => twolam_fp
-    procedure :: update => twolam_update
-    procedure :: set_cofs => twolam_cofs_update
-    procedure :: get_cofs => twolam_cofs_get
+  !> Needs docs
+  procedure :: f => twolam_f
+  !> Needs docs
+  procedure :: fp => twolam_fp
+  !> Needs docs
+  procedure :: update => twolam_update
+  !> Needs docs
+  procedure :: set_cofs => twolam_cofs_update
+  !> Needs docs
+  procedure :: get_cofs => twolam_cofs_get
 end type twolam_flux_func
-!------------------------------------------------------------------------------
-! CLASS stepslant_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 type, extends(twolam_flux_func) :: stepslant_flux_func
-    real(8) :: beta = 0.d0
+  real(8) :: beta = 0.d0
 contains
-    procedure :: f => stepslant_f
-    procedure :: fp => stepslant_fp
-    procedure :: update => stepslant_update
-    procedure :: set_cofs => stepslant_cofs_update
-    procedure :: get_cofs => stepslant_cofs_get
+  !> Needs docs
+  procedure :: f => stepslant_f
+  !> Needs docs
+  procedure :: fp => stepslant_fp
+  !> Needs docs
+  procedure :: update => stepslant_update
+  !> Needs docs
+  procedure :: set_cofs => stepslant_cofs_update
+  !> Needs docs
+  procedure :: get_cofs => stepslant_cofs_get
 end type stepslant_flux_func
 !------------------------------------------------------------------------------
 ! CLASS wesson_flux_func
@@ -161,8 +186,6 @@ contains
 end type wesson_flux_func
 contains
 !------------------------------------------------------------------------------
-! FUNCTION linear_f
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function zero_f(self,psi) result(b)
@@ -171,8 +194,6 @@ real(8), intent(in) :: psi
 real(8) :: b
 b=0.d0
 end function zero_f
-!------------------------------------------------------------------------------
-! FUNCTION linear_fp
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -183,16 +204,12 @@ real(8) :: b
 b=0.d0
 end function zero_fp
 !------------------------------------------------------------------------------
-! SUBROUTINE zero_update
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine zero_update(self,gseq)
 class(zero_flux_func), intent(inout) :: self
 class(gs_eq), intent(inout) :: gseq
 end subroutine zero_update
-!------------------------------------------------------------------------------
-! FUNCTION zero_cofs_update
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -203,16 +220,12 @@ integer(4) :: ierr
 ierr=0
 end function zero_cofs_update
 !------------------------------------------------------------------------------
-! SUBROUTINE zero_cofs_get
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine zero_cofs_get(self,c)
 class(zero_flux_func), intent(inout) :: self
 real(8), intent(out) :: c(:)
 end subroutine zero_cofs_get
-!------------------------------------------------------------------------------
-! SUBROUTINE create_flat_f
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -224,8 +237,6 @@ select type(self=>func)
     self%ncofs=0
 end select
 END SUBROUTINE create_flat_f
-!------------------------------------------------------------------------------
-! FUNCTION flat_f
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -246,8 +257,6 @@ ELSE
 END IF
 end function flat_f
 !------------------------------------------------------------------------------
-! FUNCTION linear_fp
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function flat_fp(self,psi) result(b)
@@ -267,8 +276,6 @@ ELSE
 END IF
 end function flat_fp
 !------------------------------------------------------------------------------
-! SUBROUTINE flat_update
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine flat_update(self,gseq)
@@ -276,8 +283,6 @@ class(flat_flux_func), intent(inout) :: self
 class(gs_eq), intent(inout) :: gseq
 self%plasma_bounds=gseq%plasma_bounds
 end subroutine flat_update
-!------------------------------------------------------------------------------
-! FUNCTION flat_cofs_update
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -288,8 +293,6 @@ integer(4) :: ierr
 ierr=0
 end function flat_cofs_update
 !------------------------------------------------------------------------------
-! SUBROUTINE flat_cofs_get
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine flat_cofs_get(self,c)
@@ -297,25 +300,18 @@ class(flat_flux_func), intent(inout) :: self
 real(8), intent(out) :: c(:)
 end subroutine flat_cofs_get
 !------------------------------------------------------------------------------
-! SUBROUTINE create_linear_ff
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_linear_ff(func,alpha)
 CLASS(flux_func), POINTER, INTENT(out) :: func
 REAL(8), INTENT(in) :: alpha
-
 ALLOCATE(linear_flux_func::func)
 select type(self=>func)
   type is(linear_flux_func)
-    !---
     self%ncofs=1
     self%alpha=alpha
 end select
-
 END SUBROUTINE create_linear_ff
-!------------------------------------------------------------------------------
-! FUNCTION linear_f
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -337,8 +333,6 @@ ELSE
 END IF
 end function linear_f
 !------------------------------------------------------------------------------
-! FUNCTION linear_fp
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function linear_fp(self,psi) result(b)
@@ -358,8 +352,6 @@ ELSE
 END IF
 end function linear_fp
 !------------------------------------------------------------------------------
-! SUBROUTINE linear_update
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine linear_update(self,gseq)
@@ -367,8 +359,6 @@ class(linear_flux_func), intent(inout) :: self
 class(gs_eq), intent(inout) :: gseq
 self%plasma_bounds=gseq%plasma_bounds
 end subroutine linear_update
-!------------------------------------------------------------------------------
-! FUNCTION linear_cofs_update
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -380,8 +370,6 @@ ierr=0
 self%alpha=c(1)
 end function linear_cofs_update
 !------------------------------------------------------------------------------
-! SUBROUTINE linear_cofs_get
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine linear_cofs_get(self,c)
@@ -389,8 +377,6 @@ class(linear_flux_func), intent(inout) :: self
 real(8), intent(out) :: c(:)
 c(1)=self%alpha
 end subroutine linear_cofs_get
-!------------------------------------------------------------------------------
-! SUBROUTINE create_poly_ff
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -434,8 +420,6 @@ end select
 
 END SUBROUTINE create_poly_ff
 !------------------------------------------------------------------------------
-! FUNCTION poly_f
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function poly_f(self,psi) result(b)
@@ -474,8 +458,6 @@ ELSE
 END IF
 end function poly_f
 !------------------------------------------------------------------------------
-! FUNCTION poly_fp
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function poly_fp(self,psi) result(b)
@@ -513,8 +495,6 @@ ELSE
 END IF
 end function poly_fp
 !------------------------------------------------------------------------------
-! SUBROUTINE poly_update
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine poly_update(self,gseq)
@@ -522,8 +502,6 @@ class(poly_flux_func), intent(inout) :: self
 class(gs_eq), intent(inout) :: gseq
 self%plasma_bounds=gseq%plasma_bounds
 end subroutine poly_update
-!------------------------------------------------------------------------------
-! FUNCTION poly_cofs_update
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -544,8 +522,6 @@ END IF
 ierr=0
 end function poly_cofs_update
 !------------------------------------------------------------------------------
-! SUBROUTINE poly_cofs_get
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine poly_cofs_get(self,c)
@@ -556,8 +532,6 @@ DO i=1,self%ncofs
   c(i)=self%cofs(i)
 END DO
 end subroutine poly_cofs_get
-!------------------------------------------------------------------------------
-! SUBROUTINE create_spline_ff
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -616,8 +590,6 @@ end select
 
 END SUBROUTINE create_spline_ff
 !------------------------------------------------------------------------------
-! FUNCTION linear_f
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function spline_f(self,psi) result(b)
@@ -634,8 +606,6 @@ ELSE
 END IF
 end function spline_f
 !------------------------------------------------------------------------------
-! FUNCTION linear_fp
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function spline_fp(self,psi) result(b)
@@ -651,8 +621,6 @@ ELSE
   b=self%ypn
 END IF
 end function spline_fp
-!------------------------------------------------------------------------------
-! SUBROUTINE spline_update
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -681,8 +649,6 @@ DO i=1,omp_get_max_threads()
   CALL spline_copy(self%func,self%fun_loc(i))
 END DO
 end subroutine spline_update
-!------------------------------------------------------------------------------
-! FUNCTION spline_cofs_update
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -719,8 +685,6 @@ END DO
 ierr=0
 end function spline_cofs_update
 !------------------------------------------------------------------------------
-! SUBROUTINE spline_cofs_get
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine spline_cofs_get(self,c)
@@ -731,8 +695,6 @@ DO i=0,self%npsi-1
   c(i+1)=self%func%fs(i,1)
 END DO
 end subroutine spline_cofs_get
-!------------------------------------------------------------------------------
-! SUBROUTINE create_linterp_ff
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -770,8 +732,6 @@ END SELECT
 
 END SUBROUTINE create_linterp_ff
 !------------------------------------------------------------------------------
-! FUNCTION linear_f
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function linterp_f(self,psi) result(b)
@@ -804,8 +764,6 @@ IF(self%plasma_bounds(1)>-1.d97)THEN
 END IF
 end function linterp_f
 !------------------------------------------------------------------------------
-! FUNCTION linear_fp
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function linterp_fp(self,psi) result(b)
@@ -835,8 +793,6 @@ else
   end do
 end if
 end function linterp_fp
-!------------------------------------------------------------------------------
-! FUNCTION linear_fpp
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -868,8 +824,6 @@ else
 end if
 end function linterp_fpp
 !------------------------------------------------------------------------------
-! SUBROUTINE linterp_update
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine linterp_update(self,gseq)
@@ -877,8 +831,6 @@ class(linterp_flux_func), intent(inout) :: self
 class(gs_eq), intent(inout) :: gseq
 self%plasma_bounds=gseq%plasma_bounds
 end subroutine linterp_update
-!------------------------------------------------------------------------------
-! FUNCTION linterp_cofs_update
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -920,8 +872,6 @@ END IF
 ierr=0
 end function linterp_cofs_update
 !------------------------------------------------------------------------------
-! SUBROUTINE linterp_cofs_get
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine linterp_cofs_get(self,c)
@@ -935,8 +885,6 @@ DO i=1,self%ncofs
   c(i)=self%yp(i+offset)
 END DO
 end subroutine linterp_cofs_get
-!------------------------------------------------------------------------------
-! SUBROUTINE create_twolam_ff
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -956,8 +904,6 @@ end select
 
 END SUBROUTINE create_twolam_ff
 !------------------------------------------------------------------------------
-! FUNCTION twolam_f
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function twolam_f(self,psi) result(b)
@@ -968,8 +914,6 @@ b=(1.d0+self%alpha/2.d0)*psi + self%alpha*LOG(COSH(self%width*(psi-self%sep)))/2
 - self%alpha*LOG(COSH(-self%width*self%sep))/2.d0/self%width
 end function twolam_f
 !------------------------------------------------------------------------------
-! FUNCTION twolam_fp
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function twolam_fp(self,psi) result(b)
@@ -979,8 +923,6 @@ real(8) :: b
 b=1.d0 + self%alpha*(1.d0 + TANH(self%width*(psi-self%sep)))/2.d0
 end function twolam_fp
 !------------------------------------------------------------------------------
-! SUBROUTINE twolam_update
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine twolam_update(self,gseq)
@@ -988,8 +930,6 @@ class(twolam_flux_func), intent(inout) :: self
 class(gs_eq), intent(inout) :: gseq
 self%plasma_bounds=gseq%plasma_bounds
 end subroutine twolam_update
-!------------------------------------------------------------------------------
-! FUNCTION twolam_cofs_update
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -1004,8 +944,6 @@ self%sep=c(1)
 self%alpha=c(2)
 end function twolam_cofs_update
 !------------------------------------------------------------------------------
-! SUBROUTINE twolam_cofs_get
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine twolam_cofs_get(self,c)
@@ -1014,8 +952,6 @@ real(8), intent(out) :: c(:)
 c(1)=self%sep
 c(2)=self%alpha
 end subroutine twolam_cofs_get
-!------------------------------------------------------------------------------
-! SUBROUTINE create_stepslant_ff
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -1037,8 +973,6 @@ end select
 
 END SUBROUTINE create_stepslant_ff
 !------------------------------------------------------------------------------
-! FUNCTION stepslant_f
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function stepslant_f(self,psi) result(b)
@@ -1051,8 +985,6 @@ else
   b=self%sep + (1.d0+self%alpha)*(self%sep-psi)*((self%beta-2)*self%sep-self%beta*psi)/(2*self%sep)
 end if
 end function stepslant_f
-!------------------------------------------------------------------------------
-! FUNCTION stepslant_fp
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -1067,8 +999,6 @@ else
 end if
 end function stepslant_fp
 !------------------------------------------------------------------------------
-! SUBROUTINE twolam_update
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine stepslant_update(self,gseq)
@@ -1076,8 +1006,6 @@ class(stepslant_flux_func), intent(inout) :: self
 class(gs_eq), intent(inout) :: gseq
 self%plasma_bounds=gseq%plasma_bounds
 end subroutine stepslant_update
-!------------------------------------------------------------------------------
-! FUNCTION stepslant_cofs_update
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -1091,8 +1019,6 @@ self%beta=c(3)
 ierr=0
 end function stepslant_cofs_update
 !------------------------------------------------------------------------------
-! SUBROUTINE stepslant_cofs_get
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine stepslant_cofs_get(self,c)
@@ -1102,8 +1028,6 @@ c(1)=self%sep
 c(2)=self%alpha
 c(3)=self%beta
 end subroutine stepslant_cofs_get
-!------------------------------------------------------------------------------
-! SUBROUTINE create_wesson_ff
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -1121,8 +1045,6 @@ select type(self=>func)
 end select
 
 END SUBROUTINE create_wesson_ff
-!------------------------------------------------------------------------------
-! FUNCTION wesson_f
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -1144,8 +1066,6 @@ ELSE
 END IF
 end function wesson_f
 !------------------------------------------------------------------------------
-! FUNCTION wesson_fp
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function wesson_fp(self,psi) result(b)
@@ -1166,8 +1086,6 @@ ELSE
 END IF
 end function wesson_fp
 !------------------------------------------------------------------------------
-! SUBROUTINE wesson_update
-!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 subroutine wesson_update(self,gseq)
@@ -1175,8 +1093,6 @@ class(wesson_flux_func), intent(inout) :: self
 class(gs_eq), intent(inout) :: gseq
 self%plasma_bounds=gseq%plasma_bounds
 end subroutine wesson_update
-!------------------------------------------------------------------------------
-! FUNCTION wesson_cofs_update
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -1187,8 +1103,6 @@ integer(4) :: ierr
 self%gamma=c(1)
 ierr=0
 end function wesson_cofs_update
-!------------------------------------------------------------------------------
-! SUBROUTINE wesson_cofs_get
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------

--- a/src/physics/grad_shaf_td.F90
+++ b/src/physics/grad_shaf_td.F90
@@ -260,7 +260,9 @@ IF(ASSOCIATED(self%rhs))THEN
 END IF
 DEBUG_STACK_POP
 end subroutine delete_gs_td
-!
+!------------------------------------------------------------------------------
+!> Needs docs
+!------------------------------------------------------------------------------
 subroutine step_gs_td(self,time,dt,nl_its,lin_its,nretry)
 class(oft_tmaker_td), target, intent(inout) :: self !< NL operator object
 REAL(8), INTENT(inout) :: time,dt
@@ -328,7 +330,9 @@ END IF
 !     self%mfop%ip_target=-1.d0
 ! END IF
 end subroutine step_gs_td
-!
+!------------------------------------------------------------------------------
+!> Needs docs
+!------------------------------------------------------------------------------
 subroutine eig_gs_td(eq_in,neigs,eigs,eig_vecs,omega,include_bounds,eta_plasma)
 TYPE(gs_eq), TARGET, INTENT(inout) :: eq_in
 INTEGER(4), INTENT(in) :: neigs
@@ -482,125 +486,6 @@ CALL b%restore_local(rhs_vals,add=.TRUE.)
 DEALLOCATE(pol_vals,rhs_vals,reg_source)
 DEBUG_STACK_POP
 end subroutine apply_rhs
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! subroutine picard_step(self,a,b,p_scale,f_scale,ip_target)
-! class(oft_tmaker_td_mfop), intent(inout) :: self !< NL operator object
-! class(oft_vector), target, intent(inout) :: a !< Source field
-! class(oft_vector), intent(inout) :: b !< Result of metric function
-! real(8), intent(in) :: p_scale
-! real(8), intent(inout) :: f_scale
-! real(8), optional, intent(in) :: ip_target
-! integer(i4) :: i,m,jr,jc
-! integer(i4), allocatable :: j(:)
-! real(r8) :: vol,det,goptmp(3,3),elapsed_time,pt(3),eta_tmp,psi_tmp,ip_p,ip_f
-! real(r8) :: dpsi_tmp(2),p_source,f_source,psi_lim,psi_max,eta_source,max_tmp,lim_tmp
-! real(r8), allocatable :: rop(:),gop(:,:),lop(:,:),vals_loc(:,:)
-! real(r8), pointer, dimension(:) :: pol_vals,rhs_vals,pvals
-! class(oft_vector), pointer :: ptmp
-! logical :: curved,in_bounds
-! ! type(oft_timer) :: mytimer
-! DEBUG_STACK_PUSH
-! ! WRITE(*,*)'Hi'
-! ! IF(oft_debug_print(1))THEN
-! !   WRITE(*,'(2X,A)')'Constructing Poloidal flux time-advance operator'
-! !   CALL mytimer%tick()
-! ! END IF
-! !------------------------------------------------------------------------------
-! ! Get local vector values
-! !------------------------------------------------------------------------------
-! NULLIFY(pol_vals,rhs_vals,ptmp,pvals)
-! CALL a%get_local(pol_vals)
-! !---
-! self%gs_eq%psi=>a ! HERE
-! CALL gs_update_bounds(self%gs_eq)
-! ! WRITE(*,*)'Full',self%gs_eq%plasma_bounds
-! self%F%plasma_bounds=self%gs_eq%plasma_bounds
-! self%P%plasma_bounds=self%gs_eq%plasma_bounds
-! CALL b%set(0.d0)
-! CALL b%get_local(rhs_vals)
-! CALL b%new(ptmp)
-! CALL ptmp%get_local(pvals)
-! !------------------------------------------------------------------------------
-! ! Operator integration
-! !------------------------------------------------------------------------------
-! ip_p=0.d0
-! ip_f=0.d0
-! !$omp parallel private(j,vals_loc,rop,gop,det,curved,goptmp,m,vol,jr,jc,pt, &
-! !$omp eta_tmp,psi_tmp,dpsi_tmp,p_source,f_source,eta_source,in_bounds) &
-! !$omp reduction(+:ip_p) reduction(+:ip_f)
-! allocate(j(oft_blagrange%nce),vals_loc(oft_blagrange%nce,2)) ! Local DOF and matrix indices
-! allocate(rop(oft_blagrange%nce),gop(3,oft_blagrange%nce)) ! Reconstructed gradient operator
-! !$omp do schedule(static,1)
-! do i=1,oft_blagrange%mesh%nc
-!     IF(oft_blagrange%mesh%reg(i)/=1)CYCLE
-!     !---Get local to global DOF mapping
-!     call oft_blagrange%ncdofs(i,j)
-!     !---Get local reconstructed operators
-!     vals_loc=0.d0
-!     do m=1,oft_blagrange%quad%np ! Loop over quadrature points
-!     call oft_blagrange%mesh%jacobian(i,oft_blagrange%quad%pts(:,m),goptmp,vol)
-!     det=vol*oft_blagrange%quad%wts(m)
-!     pt=oft_blagrange%mesh%log2phys(i,oft_blagrange%quad%pts(:,m))
-!     psi_tmp=0.d0; dpsi_tmp=0.d0; eta_tmp=0.d0; p_source=0.d0; f_source=0.d0; eta_source=0.d0
-!     do jr=1,oft_blagrange%nce ! Loop over degrees of freedom
-!         call oft_blag_eval(oft_blagrange,i,jr,oft_blagrange%quad%pts(:,m),rop(jr))
-!         psi_tmp = psi_tmp + pol_vals(j(jr))*rop(jr)
-!     end do
-!     !---Compute local matrix contributions
-!     ! IF(oft_blagrange%mesh%reg(i)==1.AND.psi_tmp>psi_lim)THEN
-!     ! IF(self%allow_xpoints)THEN
-!         in_bounds=gs_test_bounds(self%gs_eq,pt).AND.(psi_tmp>self%gs_eq%plasma_bounds(1))
-!     ! ELSE
-!     !     in_bounds=psi_tmp>psi_lim
-!     ! END IF
-!     IF(in_bounds)THEN
-!         ! gs_source=self%dt*self%lam_amp*(psi_tmp-psi_lim)/(psi_max-psi_lim)/(pt(1)+gs_epsilon)
-!         ! p_source=p_scale*pt(1)*self%P%Fp((psi_tmp-psi_lim)/(psi_max-psi_lim))
-!         ! f_source=0.5d0*self%F%fp((psi_tmp-psi_lim)/(psi_max-psi_lim))/(pt(1)+gs_epsilon)
-!         p_source=p_scale*pt(1)*self%P%Fp(psi_tmp)
-!         f_source=0.5d0*self%F%fp(psi_tmp)/(pt(1)+gs_epsilon)
-!         ip_p=ip_p+p_source*det
-!         ip_f=ip_f+f_source*det
-!     END IF
-!     do jr=1,oft_blagrange%nce
-!         vals_loc(jr,1) = vals_loc(jr,1) - rop(jr)*self%dt*p_source*det
-!         vals_loc(jr,2) = vals_loc(jr,2) - rop(jr)*self%dt*f_source*det
-!     end do
-!     end do
-!     do jr=1,oft_blagrange%nce
-!     !$omp atomic
-!     pvals(j(jr)) = pvals(j(jr)) + vals_loc(jr,1)
-!     !$omp atomic
-!     rhs_vals(j(jr)) = rhs_vals(j(jr)) + vals_loc(jr,2)
-!     end do
-! end do
-! deallocate(j,vals_loc,rop,gop)
-! !$omp end parallel
-! DO i=1,oft_blagrange%nbe
-!     rhs_vals(oft_blagrange%lbe(i))=0.d0
-!     pvals(oft_blagrange%lbe(i))=0.d0
-! END DO
-! CALL b%restore_local(rhs_vals,add=.TRUE.)
-! CALL ptmp%restore_local(pvals,add=.TRUE.)
-! IF(PRESENT(ip_target))THEN
-!     f_scale=(ip_target-ip_p)/ip_f
-! !  WRITE(*,*)'Ip',ip_target,ip_p,ip_f,(ip_target-ip_p)/ip_f
-! ELSE
-! !  WRITE(*,*)'Ip',(ip_p+f_scale*ip_f)/mu0
-! END IF
-! CALL b%add(f_scale,1.d0,ptmp)
-! DEALLOCATE(pol_vals,rhs_vals,pvals)
-! CALL ptmp%delete
-! DEALLOCATE(ptmp)
-! !---Report time
-! ! IF(oft_debug_print(1))THEN
-! !   elapsed_time=mytimer%tock()
-! !   WRITE(*,'(4X,A,ES11.4)')'Assembly time = ',elapsed_time
-! ! END IF
-! DEBUG_STACK_POP
-! end subroutine picard_step
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------

--- a/src/physics/grad_shaf_td.F90
+++ b/src/physics/grad_shaf_td.F90
@@ -33,7 +33,7 @@ USE fem_utils, ONLY: bfem_map_flag
 USE oft_lag_basis, ONLY: oft_blag_geval, oft_blag_eval, oft_blag_npos, &
   oft_scalar_bfem
 USE oft_blag_operators, ONLY: oft_lag_brinterp
-USE axi_green, ONLY: green, grad_green
+USE axi_green, ONLY: green
 USE oft_gs, ONLY: gs_epsilon, flux_func, gs_eq, gs_update_bounds, &
     gs_test_bounds, gs_mat_create, compute_bcmat, set_bcmat, build_dels
 USE mhd_utils, ONLY: mu0

--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -25,8 +25,8 @@ USE oft_blag_operators, ONLY: oft_blag_project, oft_lag_brinterp, oft_lag_bginte
 USE tracing_2d, ONLY: active_tracer, tracinginv_fs, set_tracer
 USE mhd_utils, ONLY: mu0
 USE oft_gs, ONLY: gs_eq, flux_func, gs_get_cond_source, gs_get_cond_weights, &
-  gs_set_cond_weights, gs_estored, gs_dflux, gs_tflux, gs_helicity, gs_itor_nl, &
-  gs_psimax, gs_test_bounds, gs_b_interp, oft_indent, gs_get_qprof, gsinv_interp, &
+  gs_set_cond_weights, gs_dflux, gs_itor_nl, &
+  gs_test_bounds, gs_b_interp, oft_indent, gs_get_qprof, gsinv_interp, &
   gs_psi2r, oft_increase_indent, oft_decrease_indent, oft_indent, gs_psi2pt
 USE oft_gs_profiles
 IMPLICIT NONE

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -73,10 +73,6 @@ tokamaker_solve = ctypes_subroutine(oftpy_lib.tokamaker_solve,
 tokamaker_vac_solve = ctypes_subroutine(oftpy_lib.tokamaker_vac_solve, 
     [c_void_p, ctypes_numpy_array(float64,1), c_double_ptr,  c_char_p])
 
-# tokamaker_analyze(tMaker_ptr,error_str)
-tokamaker_analyze = ctypes_subroutine(oftpy_lib.tokamaker_analyze,
-    [c_void_p, c_char_p])
-
 # tokamaker_setup_td(tMaker_ptr,dt,lin_tol,nl_tol,pre_plasma,error_str)
 tokamaker_setup_td = ctypes_subroutine(oftpy_lib.tokamaker_setup_td,
     [c_void_p, c_double, c_double, c_double, c_bool, c_char_p])

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -59,7 +59,7 @@ tokamaker_destroy = ctypes_subroutine(oftpy_lib.tokamaker_destroy,
 
 # tokamaker_load_profiles(tMaker_ptr,f_file,f_offset,p_file,eta_file,f_NI_file,error_str)
 tokamaker_load_profiles = ctypes_subroutine(oftpy_lib.tokamaker_load_profiles,
-    [c_void_p, c_char_p, c_double, c_char_p, c_char_p, c_char_p])
+    [c_void_p, c_char_p, c_double, c_char_p, c_char_p, c_char_p, c_char_p])
 
 # tokamaker_init_psi(tMaker_ptr,r0,z0,a,kappa,delta,rhs_source,error_str)
 tokamaker_init_psi = ctypes_subroutine(oftpy_lib.tokamaker_init_psi,

--- a/src/python/OpenFUSIONToolkit/TokaMaker/reconstruction.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/reconstruction.py
@@ -369,6 +369,18 @@ class reconstruction():
         # Update settings
         self.settings.infile = self._tMaker_obj._oft_env.path2c(self.con_file)
         self.settings.outfile = self._tMaker_obj._oft_env.path2c(self.out_file)
+        # Fit-specific input file settings
+        self._tMaker_obj._oft_env.oft_in_groups['gs_fit_options'] = {
+            'ftol': '1.E-3',
+            'xtol': '1.E-3',
+            'gtol': '1.E-3',
+            'maxfev': '100',
+            'epsfcn': '1.E-3',
+            'factor': '1.0',
+            'comp_var': 'F',
+            'linearized_fit': 'F'
+        }
+        self._tMaker_obj._oft_env.update_oft_in()
     
     def __del__(self):
         '''! Destroy reconstruction object'''
@@ -484,9 +496,27 @@ class reconstruction():
                 else:
                     raise ValueError("Unknown constraint type")
 
-    def reconstruct(self, vacuum=False):
-        '''! Reconstruct G-S equation with specified fitting constraints, profiles, etc.'''
+    def reconstruct(self, vacuum=False, linearized_fit=False, maxits=100, eps=1.E-3, ftol=1.E-3, xtol=1.E-3, gtol=1.E-3):
+        '''! Reconstruct G-S equation with specified fitting constraints, profiles, etc.
+        
+        @param vacuum Perform vacuum reconstruction
+        @param linearized_fit Use linearized solve for suitable terms
+        @param maxits Maximum number of iterations
+        @param eps Epsilong factor for finite difference derivative calculations
+        @param ftol Stopping condition: termination occurs when both the actual and predicted relative reductions in the sum of squares are at most `ftol`
+        @param xtol Stopping condition: termination occurs when the relative error between two consecutive iterates is at most `xtol`
+        @param gtol Stopping condition: termination occurs when the cosine of the angle between fvec and any column of the jacobian is at most `gtol` in absolute value
+        @result Error flag
+        '''
         self.write_fit_in()
+        self._tMaker_obj._oft_env.oft_in_groups['gs_fit_options']['linearized_fit'] = 'T' if linearized_fit else 'F'
+        self._tMaker_obj._oft_env.oft_in_groups['gs_fit_options']['maxfev'] = '{0:d}'.format(maxits)
+        self._tMaker_obj._oft_env.oft_in_groups['gs_fit_options']['epsfcn'] = '{0:.5E}'.format(eps)
+        self._tMaker_obj._oft_env.oft_in_groups['gs_fit_options']['ftol'] = '{0:.5E}'.format(ftol)
+        self._tMaker_obj._oft_env.oft_in_groups['gs_fit_options']['xtol'] = '{0:.5E}'.format(xtol)
+        self._tMaker_obj._oft_env.oft_in_groups['gs_fit_options']['gtol'] = '{0:.5E}'.format(gtol)
+        self._tMaker_obj._oft_env.update_oft_in()
+        #
         error_flag = c_int()
         tokamaker_recon_run(self._tMaker_obj._tMaker_ptr,c_bool(vacuum),self.settings,ctypes.byref(error_flag))
         return error_flag.value

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -26,9 +26,12 @@ USE oft_blag_operators, ONLY: oft_lag_brinterp
 USE mhd_utils, ONLY: mu0
 USE axi_green, ONLY: green
 USE oft_gs, ONLY: gs_eq, gs_save_fields, gs_save_fgrid, gs_setup_walls, build_dels, &
-  gs_fixed_vflux, gs_load_regions, gs_get_qprof, gs_trace_surf, gs_b_interp, gs_prof_interp, &
+  gs_fixed_vflux, gs_get_qprof, gs_trace_surf, gs_b_interp, gs_prof_interp, &
   gs_plasma_mutual, gs_source, gs_err_reason, gs_coil_source_distributed, gs_vacuum_solve, &
   gs_coil_mutual, gs_coil_mutual_distributed
+#ifdef OFT_TOKAMAKER_LEGACY
+USE oft_gs, ONLY: gs_load_regions
+#endif
 USE oft_gs_util, ONLY: gs_comp_globals, gs_save_eqdsk, gs_save_ifile, gs_profile_load, gs_profile_save, &
   sauter_fc, gs_calc_vloop
 USE oft_gs_fit, ONLY: fit_gs, fit_pm
@@ -206,7 +209,11 @@ IF(TRIM(tMaker_obj%gs%coil_file)=='none')THEN
     END IF
   END DO
 ELSE
+#ifdef OFT_TOKAMAKER_LEGACY
   CALL gs_load_regions(tMaker_obj%gs)
+#else
+  CALL oft_abort("OFT not compiled with legacy TokaMaker support","tokamaker_setup_regions",__FILE__)
+#endif
 END IF
 END SUBROUTINE tokamaker_setup_regions
 !---------------------------------------------------------------------------------
@@ -1006,7 +1013,6 @@ tMaker_obj%gs%mode=settings%mode
 tMaker_obj%gs%urf=settings%urf
 tMaker_obj%gs%maxits=settings%maxits
 tMaker_obj%gs%nl_tol=settings%nl_tol
-tMaker_obj%gs%limited_only=settings%limited_only
 CALL c_f_pointer(settings%limiter_file,limfile_c,[OFT_PATH_SLEN])
 CALL copy_string_rev(limfile_c,tMaker_obj%gs%limiter_file)
 END SUBROUTINE tokamaker_set_settings

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -307,9 +307,9 @@ SUBROUTINE tokamaker_load_profiles(tMaker_ptr,f_file,f_offset,p_file,eta_file,f_
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
 CHARACTER(KIND=c_char), INTENT(in) :: f_file(OFT_PATH_SLEN) !< F*F' prof.in file
 CHARACTER(KIND=c_char), INTENT(in) :: p_file(OFT_PATH_SLEN) !< P' prof.in file
+REAL(c_double), VALUE, INTENT(in) :: f_offset !< Vacuum F_0 value (must be > -1E98 to update)
 CHARACTER(KIND=c_char), INTENT(in) :: eta_file(OFT_PATH_SLEN) !< Resistivity (eta) prof.in file
 CHARACTER(KIND=c_char), INTENT(in) :: f_NI_file(OFT_PATH_SLEN) !< Non-inductive F*F' prof.in file
-REAL(c_double), VALUE, INTENT(in) :: f_offset !< Needs docs
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 CHARACTER(LEN=OFT_PATH_SLEN) :: tmp_str
 TYPE(tokamaker_instance), POINTER :: tMaker_obj

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -29,8 +29,8 @@ USE oft_gs, ONLY: gs_eq, gs_save_fields, gs_save_fgrid, gs_setup_walls, build_de
   gs_fixed_vflux, gs_load_regions, gs_get_qprof, gs_trace_surf, gs_b_interp, gs_prof_interp, &
   gs_plasma_mutual, gs_source, gs_err_reason, gs_coil_source_distributed, gs_vacuum_solve, &
   gs_coil_mutual, gs_coil_mutual_distributed
-USE oft_gs_util, ONLY: gs_save, gs_load, gs_analyze, gs_comp_globals, gs_save_eqdsk, &
-  gs_profile_load, sauter_fc, gs_calc_vloop, gs_save_ifile
+USE oft_gs_util, ONLY: gs_comp_globals, gs_save_eqdsk, gs_save_ifile, gs_profile_load, gs_profile_save, &
+  sauter_fc, gs_calc_vloop
 USE oft_gs_fit, ONLY: fit_gs, fit_pm
 USE oft_gs_td, ONLY: oft_tmaker_td, eig_gs_td
 USE diagnostic, ONLY: bscal_surf_int
@@ -393,16 +393,6 @@ END SUBROUTINE tokamaker_vac_solve
 !---------------------------------------------------------------------------------
 !> Needs docs
 !---------------------------------------------------------------------------------
-SUBROUTINE tokamaker_analyze(tMaker_ptr,error_str) BIND(C,NAME="tokamaker_analyze")
-TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
-CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
-TYPE(tokamaker_instance), POINTER :: tMaker_obj
-IF(.NOT.tokamaker_ccast(tMaker_ptr,tMaker_obj,error_str))RETURN
-CALL gs_analyze(tMaker_obj%gs)
-END SUBROUTINE tokamaker_analyze
-!---------------------------------------------------------------------------------
-!> Needs docs
-!---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_recon_run(tMaker_ptr,vacuum,settings,error_flag) BIND(C,NAME="tokamaker_recon_run")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
 LOGICAL(c_bool), VALUE, INTENT(in) :: vacuum !< Needs docs
@@ -436,6 +426,8 @@ tMaker_obj%gs%timing=0.d0
 CALL fit_gs(tMaker_obj%gs,infile,outfile,fitI,fitP,fitPnorm,&
             fitAlam,fitR0,fitV0,fitCoils,fitF0, &
             fixedCentering)
+CALL gs_profile_save(TRIM(outfile)//'_fprof',tMaker_obj%gs%I)
+CALL gs_profile_save(TRIM(outfile)//'_pprof',tMaker_obj%gs%P)
 tMaker_obj%gs%has_plasma=.TRUE.
 END SUBROUTINE tokamaker_recon_run
 !---------------------------------------------------------------------------------

--- a/src/tests/physics/test_TokaMaker.py
+++ b/src/tests/physics/test_TokaMaker.py
@@ -489,6 +489,7 @@ def run_ITER_case(mesh_resolution,fe_orders,eig_test,stability_test,test_recon,m
         if eig_test:
             eig_vals, _ = mygs.eig_wall(10)
             mp_q.put([{'Tau_w': eig_vals[:5,0]}])
+            oftpy_dump_cov()
             return
         #
         mygs.set_coil_vsc({'VS': 1.0})
@@ -560,6 +561,7 @@ def run_ITER_case(mesh_resolution,fe_orders,eig_test,stability_test,test_recon,m
                 sim_time, _, nl_its, lin_its, nretry = mygs.step_td(sim_time,dt)
             psi1 = mygs.get_psi(False)
             mp_q.put([{'gamma': eig_vals[:5,0], 'nl_change': np.linalg.norm(psi1-psi0)}])
+            oftpy_dump_cov()
             return
         mygs.save_eqdsk('test.eqdsk',lcfs_pressure=6.E4)
         eq_info = mygs.get_stats(li_normalization='ITER')
@@ -778,6 +780,7 @@ def run_LTX_case(fe_order,eig_test,stability_test,mp_q):
     if eig_test:
         eig_vals, _ = mygs.eig_wall(10)
         mp_q.put([{'Tau_w': eig_vals[:5,0]}])
+        oftpy_dump_cov()
         return
     #
     mygs.set_coil_vsc({'INTERNALU': 1.0, 'INTERNALL': -1.0})
@@ -814,6 +817,7 @@ def run_LTX_case(fe_order,eig_test,stability_test,mp_q):
     if stability_test:
         eig_vals, _ = mygs.eig_td(-1.E3,10,False)
         mp_q.put([{'gamma': eig_vals[:5,0]}])
+        oftpy_dump_cov()
         return
     #
     psi_last = mygs.get_psi(False)


### PR DESCRIPTION
This pull request deprecates the TokaMaker command line drivers and removes unused legacy code. Additionally, updates to documentation and fixes to undetected coverage testing are included.

This pull request does not introduce changes for any existing APIs or input files.