### PR TITLE
Revive OFT internal debug/profiling stack

### DIFF
--- a/.github/workflows/ci_build.yaml
+++ b/.github/workflows/ci_build.yaml
@@ -77,7 +77,7 @@ jobs:
               os: ubuntu-22.04,
               cc: "gcc-12", cxx: "g++-12", fc: "gfortran-12",
               python: "python3",
-              mpi_build_flags: "--build_petsc=1 --petsc_version=3.20"
+              mpi_build_flags: "--build_petsc=1 --petsc_version=3.20 --build_cmake=1"
             }
 
     steps:

--- a/.github/workflows/cov_build.yaml
+++ b/.github/workflows/cov_build.yaml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Build external
       shell: bash
-      timeout-minutes: 30
+      timeout-minutes: 60
       working-directory: libs
       run: >
         python3 ../src/utilities/build_libs.py --no_dl_progress --nthread=2

--- a/.github/workflows/cov_build.yaml
+++ b/.github/workflows/cov_build.yaml
@@ -55,7 +55,7 @@ jobs:
       run: >
         python3 ../src/utilities/build_libs.py --no_dl_progress --nthread=2
         --build_mpich=1 --build_arpack=1 --build_petsc=1 --petsc_version=3.20
-        --oft_build_tests=1 --oft_build_coverage
+        --build_cmake=1 --oft_build_tests=1 --oft_build_coverage
 
     - name: Upload library failure log
       uses: actions/upload-artifact@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,29 @@
+name: Lint OFT
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+  
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      
+      - name: Install prerequisites
+        run: |
+          python3 -m venv ${{ github.workspace }}/oft_venv
+          echo "source ${{ github.workspace }}/oft_venv/bin/activate" > ${{ github.workspace }}/setup_env.sh
+
+      - name: Check stack entries
+        working-directory: src
+        run: |
+          source ${{ github.workspace }}/setup_env.sh
+          python utilities/generate_stack.py -l
+      
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ option(OFT_MPI_HEADER "Use MPI header interface instead of F08?" OFF)
 option(OFT_HDF5_HL "Search for and link with HDF5 HL interface?" OFF)
 option(OFT_USE_OpenMP "Build with OpenMP support?" ON)
 option(OFT_DEBUG_STACK "Build with internal debugging stack?" OFF)
-option(OFT_PROFILE "Build with internal profiling enabled?" OFF)
+option(OFT_PROFILING "Build with internal profiling enabled?" OFF)
 option(OFT_BUILD_PYTHON "Build experimental Python wrappers?" OFF)
 option(OFT_BUILD_DOCS "Build documentation?" OFF)
 option(OFT_DOCS_ONLY "Build documentation only?" OFF)
@@ -38,6 +38,10 @@ if(OFT_PACKAGE_NIGHTLY)
   set( OFT_VER_SUFFIX "-${GIT_REV_HASH}" CACHE INTERNAL "Version suffix" )
 endif()
 
+if(OFT_BUILD_DOCS OR OFT_PACKAGE_BUILD OR OFT_DEBUG_STACK)
+  find_package(Python REQUIRED)
+endif()
+
 ########################
 # Build documentation
 ########################
@@ -49,7 +53,6 @@ if(OFT_BUILD_DOCS)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/mainpage.in ${CMAKE_CURRENT_SOURCE_DIR}/docs/generated/mainpage.md @ONLY)
 
-  find_package(Python)
   add_custom_target( build_ex_docs
     COMMAND Python::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/utilities/generate_doc.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -126,7 +129,7 @@ elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
   endif()
 endif()
 # Internal profiling
-if( OFT_PROFILE )
+if( OFT_PROFILING )
   add_definitions( -DOFT_STACK -DOFT_PROFILE )
 endif()
 # Internal debugging stack
@@ -331,7 +334,6 @@ set( OFT_LIBS oftphysics oftfem oftla oftgrid oftbase oftext )
 add_subdirectory( utilities )
 # Build master lib for packaging to reduce size
 if(OFT_PACKAGE_BUILD)
-  find_package( Python REQUIRED )
   if (Python_VERSION_MAJOR VERSION_LESS 3)
     message( FATAL_ERROR "Python 3 required for packaging" )
   endif ()

--- a/src/base/oft_base.F90
+++ b/src/base/oft_base.F90
@@ -21,6 +21,8 @@
 !! @ingroup doxy_oft_base
 !--------------------------------------------------------------------------------
 MODULE oft_base
+#undef DEBUG_STACK_MOD_IND
+#define DEBUG_STACK_MOD_IND 5
 USE, INTRINSIC :: iso_fortran_env, ONLY: error_unit
 USE omp_lib
 USE oft_local

--- a/src/base/oft_base.F90
+++ b/src/base/oft_base.F90
@@ -21,8 +21,6 @@
 !! @ingroup doxy_oft_base
 !--------------------------------------------------------------------------------
 MODULE oft_base
-#undef DEBUG_STACK_MOD_IND
-#define DEBUG_STACK_MOD_IND 5
 USE, INTRINSIC :: iso_fortran_env, ONLY: error_unit
 USE omp_lib
 USE oft_local

--- a/src/base/oft_io.F90
+++ b/src/base/oft_io.F90
@@ -560,6 +560,7 @@ call h5open_f(error)
 call h5fopen_f(TRIM(filepath), H5F_ACC_RDONLY_F, file_id, error)
 IF(error/=0)THEN
   call h5close_f(error)
+  DEBUG_STACK_POP
   RETURN
 END IF
 CALL H5Fget_filesize_f(file_id,sizes(1),error)
@@ -612,9 +613,9 @@ integer(4), allocatable, dimension(:), intent(out) :: dim_sizes !< Size of each 
 integer(4) :: access_flag,error
 integer(hsize_t), allocatable, dimension(:) :: tmp_sizes,maxdims
 integer(HID_T) :: file_id,dset_id,dspace_id
-DEBUG_STACK_PUSH
 ndims=-1
 IF(.NOT.hdf5_field_exist(filepath,path))RETURN
+DEBUG_STACK_PUSH
 !---Try to open file as HDF5 file
 access_flag=H5F_ACC_RDONLY_F
 call h5open_f(error)

--- a/src/base/oft_local_c.c
+++ b/src/base/oft_local_c.c
@@ -33,11 +33,29 @@ void oft_signal_handler(int signum)
 		oft_finalize();
 	} else {
 		// Print signal type
-		fprintf(stderr,"OFT caught signal %d\n",signum);
+		switch (signum) {
+		case SIGSEGV:
+			fprintf(stderr,"OFT caught SIGSEGV signal\n");
+			break;
+		case SIGABRT:
+			fprintf(stderr,"OFT caught SIGABRT signal\n");
+			break;
+		case SIGBUS:
+			fprintf(stderr,"OFT caught SIGBUS signal\n");
+			break;
+		case SIGFPE:
+			fprintf(stderr,"OFT caught SIGFPE signal\n");
+			break;
+		default:
+			fprintf(stderr,"OFT caught unknown signal %d\n",signum);
+			break;
+		}
 		// Print stacktrace
 		oft_stack_print();
-		// Abort program
-		abort();
+		if (signum != SIGABRT) {
+			// Abort program
+			abort();
+		}
 	}
 }
 
@@ -47,6 +65,7 @@ void oft_set_signal_handlers()
 	signal(SIGINT, oft_signal_handler);
 	signal(SIGTERM, oft_signal_handler);
 	signal(SIGSEGV, oft_signal_handler);
+	signal(SIGABRT, oft_signal_handler);
 	signal(SIGBUS, oft_signal_handler);
 	signal(SIGFPE, oft_signal_handler);
 }

--- a/src/fem/fem_base.F90
+++ b/src/fem/fem_base.F90
@@ -1589,6 +1589,7 @@ IF(PRESENT(err_flag))THEN
     NULLIFY(lge)
     DEALLOCATE(infield)
     CALL hdf5_rst_destroy(rst_info)
+    DEBUG_STACK_POP
     RETURN
   END IF
 ELSE

--- a/src/fem/h1_basis.F90
+++ b/src/fem/h1_basis.F90
@@ -551,14 +551,9 @@ contains
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_h1_eval_all2()!self,cell,f,rop)
-! class(oft_fem_type), intent(in) :: self !< H^1 type for evaluation
-! integer(i4), intent(in) :: cell !< Cell for evaluation
-! real(r8), intent(in) :: f(4) !< Position in cell in logical space
-! real(r8), intent(out) :: rop(10) !< Value of interpolation functions at point (f) [ncdofs]
+subroutine oft_h1_eval_all2()
 integer(i4) :: i
 real(r8) :: x1,x2
-DEBUG_STACK_PUSH
 DO i=1,4
   rop(i) = f(i)
 END DO
@@ -566,21 +561,15 @@ DO i=1,6
   x1 = f(self%mesh%cell_ed(1,i)); x2 = f(self%mesh%cell_ed(2,i))
   rop(i+4) = -2.d0*x1*x2
 END DO
-DEBUG_STACK_POP
 end subroutine oft_h1_eval_all2
 !------------------------------------------------------------------------------
 !> Evaluate all H^1 interpolation functions (cubic)
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_h1_eval_all3()!self,cell,f,rop)
-! class(oft_fem_type), intent(in) :: self !< H^1 type for evaluation
-! integer(i4), intent(in) :: cell !< Cell for evaluation
-! real(r8), intent(in) :: f(4) !< Position in cell in logical space
-! real(r8), intent(out) :: rop(20) !< Value of interpolation functions at point (f) [ncdofs]
+subroutine oft_h1_eval_all3()
 integer(i4) :: i
 real(r8) :: x1,x2,x3
-DEBUG_STACK_PUSH
 DO i=1,4
   rop(i) = f(i)
 END DO
@@ -595,21 +584,15 @@ DO i=1,4
   x3 = f(self%mesh%cell_fc(3,i))
   rop(i+16) = -2.d0*x1*x2*x3
 END DO
-DEBUG_STACK_POP
 end subroutine oft_h1_eval_all3
 !------------------------------------------------------------------------------
 !> Evaluate all H^1 interpolation functions (quartic)
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_h1_eval_all4()!self,cell,f,rop)
-! class(oft_fem_type), intent(in) :: self !< H^1 type for evaluation
-! integer(i4), intent(in) :: cell !< Cell for evaluation
-! real(r8), intent(in) :: f(4) !< Position in cell in logical space
-! real(r8), intent(out) :: rop(35) !< Value of interpolation functions at point (f) [ncdofs]
+subroutine oft_h1_eval_all4()
 integer(i4) :: i
 real(r8) :: x1,x2,x3,x4
-DEBUG_STACK_PUSH
 DO i=1,4
   rop(i) = f(i)
 END DO
@@ -627,21 +610,15 @@ DO i=1,4
 END DO
 x1 = f(1); x2 = f(2); x3 = f(3); x4 = f(4)
 rop(35) = -2.d0*x1*x2*x3*x4
-DEBUG_STACK_POP
 end subroutine oft_h1_eval_all4
 !------------------------------------------------------------------------------
 !> Evaluate all H^1 interpolation functions (quartic)
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_h1_eval_all5()!self,cell,f,rop)
-! class(oft_fem_type), intent(in) :: self !< H^1 type for evaluation
-! integer(i4), intent(in) :: cell !< Cell for evaluation
-! real(r8), intent(in) :: f(4) !< Position in cell in logical space
-! real(r8), intent(out) :: rop(56) !< Value of interpolation functions at point (f) [ncdofs]
+subroutine oft_h1_eval_all5()
 integer(i4) :: i
 real(r8) :: x1,x2,x3,x4
-DEBUG_STACK_PUSH
 DO i=1,4
   rop(i) = f(i)
 END DO
@@ -666,7 +643,6 @@ rop(53) = -2.d0*x1*x2*x3*x4
 rop(54) = 2.d0*x1*x2*x3*x4*(x1 + x2 + x3 - x4)
 rop(55) = 2.d0*x1*x2*x3*x4*(x1 + x2 - x3)
 rop(56) = 2.d0*x1*x2*x3*x4*(-x1 + x2)
-DEBUG_STACK_POP
 end subroutine oft_h1_eval_all5
 end subroutine oft_h1_eval_all
 !------------------------------------------------------------------------------
@@ -1045,15 +1021,9 @@ contains
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_h1_geval_all2()!self,cell,f,rop,gop)
-! class(oft_fem_type), intent(in) :: self !< H^1 type for evaluation
-! integer(i4), intent(in) :: cell !< Cell for evaluation
-! real(r8), intent(in) :: f(4) !< Position in cell in logical space
-! real(r8), intent(out) :: rop(3,10) !< Value of interpolation functions at point (f) [ncdofs]
-! real(r8), intent(in) :: gop(3,4) !< Cell Jacobian matrix at point (f) [3,4]
+subroutine oft_h1_geval_all2()
 integer(i4) :: i,etmp(2)
 real(r8) :: x1,x2,u1(3),u2(3)
-DEBUG_STACK_PUSH
 DO i=1,4
   rop(:,i)=gop(:,i)
 END DO
@@ -1066,22 +1036,15 @@ DO i=1,6
   rop(:,i+4) = -2.d0*x2*u1 &
                -2.d0*x1*u2
 END DO
-DEBUG_STACK_POP
 end subroutine oft_h1_geval_all2
 !------------------------------------------------------------------------------
 !> Evaluate all H^1 interpolation functions (cubic)
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_h1_geval_all3()!self,cell,f,rop,gop)
-! class(oft_fem_type), intent(in) :: self !< H^1 type for evaluation
-! integer(i4), intent(in) :: cell !< Cell for evaluation
-! real(r8), intent(in) :: f(4) !< Position in cell in logical space
-! real(r8), intent(out) :: rop(3,20) !< Value of interpolation functions at point (f) [ncdofs]
-! real(r8), intent(in) :: gop(3,4) !< Cell Jacobian matrix at point (f) [3,4]
+subroutine oft_h1_geval_all3()
 integer(i4) :: i,etmp(2),ftmp(3)
 real(r8) :: x1,x2,x3,u1(3),u2(3),u3(3)
-DEBUG_STACK_PUSH
 DO i=1,4
   rop(:,i)=gop(:,i)
 END DO
@@ -1105,22 +1068,15 @@ DO i=1,4
                 -2.d0*x1*x3*u2 &
                 -2.d0*x1*x2*u3
 END DO
-DEBUG_STACK_POP
 end subroutine oft_h1_geval_all3
 !------------------------------------------------------------------------------
 !> Evaluate all H^1 interpolation functions (quartic)
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_h1_geval_all4()!self,cell,f,rop,gop)
-! class(oft_fem_type), intent(in) :: self !< H^1 type for evaluation
-! integer(i4), intent(in) :: cell !< Cell for evaluation
-! real(r8), intent(in) :: f(4) !< Position in cell in logical space
-! real(r8), intent(out) :: rop(3,35) !< Value of interpolation functions at point (f) [ncdofs]
-! real(r8), intent(in) :: gop(3,4) !< Cell Jacobian matrix at point (f) [3,4]
+subroutine oft_h1_geval_all4()
 integer(i4) :: i,etmp(2),ftmp(3)
 real(r8) :: x1,x2,x3,x4,u1(3),u2(3),u3(3)
-DEBUG_STACK_PUSH
 DO i=1,4
   rop(:,i)=gop(:,i)
 END DO
@@ -1161,22 +1117,15 @@ rop(:,35) = -2.d0*x2*x3*x4*gop(:,1) &
             -2.d0*x1*x3*x4*gop(:,2) &
             -2.d0*x1*x2*x4*gop(:,3) &
             -2.d0*x1*x2*x3*gop(:,4)
-DEBUG_STACK_POP
 end subroutine oft_h1_geval_all4
 !------------------------------------------------------------------------------
 !> Evaluate all H^1 interpolation functions (quartic)
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_h1_geval_all5()!self,cell,f,rop,gop)
-! class(oft_fem_type), intent(in) :: self !< H^1 type for evaluation
-! integer(i4), intent(in) :: cell !< Cell for evaluation
-! real(r8), intent(in) :: f(4) !< Position in cell in logical space
-! real(r8), intent(out) :: rop(3,56) !< Value of interpolation functions at point (f) [ncdofs]
-! real(r8), intent(in) :: gop(3,4) !< Cell Jacobian matrix at point (f) [3,4]
+subroutine oft_h1_geval_all5()
 integer(i4) :: i,etmp(2),ftmp(3)
 real(r8) :: x1,x2,x3,x4,u1(3),u2(3),u3(3)
-DEBUG_STACK_PUSH
 DO i=1,4
   rop(:,i)=gop(:,i)
 END DO
@@ -1247,7 +1196,6 @@ rop(:,56) = 2.d0*x2*x3*x4*(-2.d0*x1 + x2)*gop(:,1) &
           + 2.d0*x1*x3*x4*(-x1 + 2.d0*x2)*gop(:,2) &
           + 2.d0*x1*x2*x4*(-x1 + x2)*gop(:,3) &
           + 2.d0*x1*x2*x3*(-x1 + x2)*gop(:,4)
-DEBUG_STACK_POP
 end subroutine oft_h1_geval_all5
 end subroutine oft_h1_geval_all
 !------------------------------------------------------------------------------

--- a/src/fem/h1_operators.F90
+++ b/src/fem/h1_operators.F90
@@ -585,7 +585,6 @@ integer(i4), pointer :: lfde(:,:),lede(:,:)
 real(r8) :: f(4),incr,val,d(3),h_rop(3),goptmp(3,4),v,mop(1)
 type(oft_graph_ptr), pointer :: graphs(:,:)
 type(oft_graph), POINTER :: interp_graph
-DEBUG_STACK_PUSH
 !---
 if(ML_h1_rep%ml_mesh%level<1)then
   call oft_abort('Invalid mesh level','h1_setup_interp::build_ginterpmatrix',__FILE__)
@@ -688,7 +687,6 @@ DO i=1,cmesh%ne
   END DO
 END DO
 deallocate(emap)
-DEBUG_STACK_POP
 END SUBROUTINE build_ginterpmatrix
 !------------------------------------------------------------------------------
 !> Construct interpolation matrix for transfer between polynomial levels
@@ -707,7 +705,6 @@ CLASS(oft_vector), POINTER :: h1_vec_fine,h1_vec_cors
 type(oft_graph_ptr), pointer :: graphs(:,:)
 class(oft_mesh), pointer :: mesh
 type(oft_graph), POINTER :: interp_graph
-DEBUG_STACK_PUSH
 !---
 IF(.NOT.oft_3D_h1_cast(h1_fine,ML_h1_rep%levels(ML_h1_rep%level)%fe))CALL oft_abort("Error casting fine level", "h1_setup_interp::build_pinterpmatrix",__FILE__)
 IF(.NOT.oft_3D_h1_cast(h1_cors,ML_h1_rep%levels(ML_h1_rep%level-1)%fe))CALL oft_abort("Error casting coarse level", "h1_setup_interp::build_pinterpmatrix",__FILE__)
@@ -855,7 +852,6 @@ DO i=1,mesh%nc
     CALL mat%add_values(i_ind,j_ind,mop,1,1)
   END DO
 END DO
-DEBUG_STACK_POP
 END SUBROUTINE build_pinterpmatrix
 END SUBROUTINE h1_setup_interp
 !------------------------------------------------------------------------------

--- a/src/fem/hcurl_basis.F90
+++ b/src/fem/hcurl_basis.F90
@@ -20,7 +20,6 @@
 !! @ingroup doxy_oft_hcurl
 !------------------------------------------------------------------------------
 MODULE oft_hcurl_basis
-! USE timer
 USE oft_base
 USE oft_lag_poly
 USE oft_mesh_type, ONLY: oft_mesh, oft_bmesh
@@ -796,15 +795,9 @@ contains
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_hcurl_eval_all2()!self,cell,f,rop,gop)
-! class(oft_fem_type), intent(in) :: self
-! integer(i4), intent(in) :: cell !< Cell for evaluation
-! real(r8), intent(in) :: f(4) !< Position in cell in logical space
-! real(r8), intent(in) :: gop(3,4)
-! real(r8), intent(out) :: rop(3,14)
+subroutine oft_hcurl_eval_all2()
 integer(i4) :: i,etmp(2),ftmp(3)
 real(r8) :: f1,f2,f3,u1(3),u2(3),u3(3)
-DEBUG_STACK_PUSH
 DO i=1,6
   etmp=oriented_edges(:,i)
   rop(:,i) = -f(etmp(2))*gop(:,etmp(1)) &
@@ -823,22 +816,15 @@ DO i=1,4
                -f1*f3*u2 &
               + 0*u3
 END DO
-DEBUG_STACK_POP
 end subroutine oft_hcurl_eval_all2
 !------------------------------------------------------------------------------
 !> Evaluate all lagrange interpolation functions (cubic)
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_hcurl_eval_all3()!self,cell,f,rop,gop)
-! class(oft_fem_type), intent(in) :: self
-! integer(i4), intent(in) :: cell !< Cell for evaluation
-! real(r8), intent(in) :: f(4) !< Position in cell in logical space
-! real(r8), intent(in) :: gop(3,4)
-! real(r8), intent(out) :: rop(3,29)
+subroutine oft_hcurl_eval_all3()
 integer(i4) :: i,etmp(2),ftmp(3)
 real(r8) :: f1,f2,f3,f4,u1(3),u2(3),u3(3)
-DEBUG_STACK_PUSH
 DO i=1,6
   etmp=oriented_edges(:,i)
   rop(:,i) = -f(etmp(2))*gop(:,etmp(1)) &
@@ -885,22 +871,15 @@ rop(:,29) = f2*f3*f4*gop(:,1) &
             -f1*f3*f4*gop(:,2) &
           +  0*gop(:,3) &
           +  0*gop(:,4)
-DEBUG_STACK_POP
 end subroutine oft_hcurl_eval_all3
 !------------------------------------------------------------------------------
 !> Evaluate all lagrange interpolation functions (quartic)
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_hcurl_eval_all4()!self,cell,f,rop,gop)
-! class(oft_fem_type), intent(in) :: self
-! integer(i4), intent(in) :: cell !< Cell for evaluation
-! real(r8), intent(in) :: f(4) !< Position in cell in logical space
-! real(r8), intent(in) :: gop(3,4)
-! real(r8), intent(out) :: rop(3,53)
+subroutine oft_hcurl_eval_all4()
 integer(i4) :: i,etmp(2),ftmp(3)
 real(r8) :: f1,f2,f3,f4,u1(3),u2(3),u3(3)
-DEBUG_STACK_PUSH
 DO i=1,6
   etmp=oriented_edges(:,i)
   rop(:,i) = -f(etmp(2))*gop(:,etmp(1)) &
@@ -1003,7 +982,6 @@ rop(:,53) = f2*f3*f4*(-4.d0*f1 + 2.d0*f2)*gop(:,1) &
           + f1*f3*f4*(-2.d0*f1 + 4.d0*f2)*gop(:,2) &
           + f1*f2*f4*(2.d0*f1 - 2.d0*f2)*gop(:,3) &
           + f1*f2*f3*(2.d0*f1 - 2.d0*f2)*gop(:,4)
-DEBUG_STACK_POP
 end subroutine oft_hcurl_eval_all4
 end subroutine oft_hcurl_eval_all
 !------------------------------------------------------------------------------
@@ -1587,16 +1565,10 @@ contains
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_hcurl_ceval_all2()!self,cell,f,rop,cgop)
-! class(oft_fem_type), intent(in) :: self
-! integer(i4), intent(in) :: cell
-! real(r8), intent(in) :: f(4)
-! real(r8), intent(in) :: cgop(3,6)
-! real(r8), intent(out) :: rop(3,14)
+subroutine oft_hcurl_ceval_all2()
 integer(i4) :: i,etmp(2),ftmp(3)
 real(r8) :: f1,f2,f3
 real(r8) :: g1xg2(3),g1xg3(3),g2xg3(3)
-DEBUG_STACK_PUSH
 DO i=1,6
   etmp=oriented_edges(:,i)
   rop(:,i) = 2.d0*cgop(:,ABS(cgop_map(etmp(1),etmp(2))))*SIGN(1,cgop_map(etmp(1),etmp(2)))
@@ -1616,23 +1588,16 @@ DO i=1,4
               - f2*g1xg3 &
               + f1*g2xg3
 END DO
-DEBUG_STACK_POP
 end subroutine oft_hcurl_ceval_all2
 !------------------------------------------------------------------------------
 !> Evaluate all lagrange interpolation functions (cubic)
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_hcurl_ceval_all3()!self,cell,f,rop,cgop)
-! class(oft_fem_type), intent(in) :: self
-! integer(i4), intent(in) :: cell
-! real(r8), intent(in) :: f(4)
-! real(r8), intent(in) :: cgop(3,6)
-! real(r8), intent(out) :: rop(3,29)
+subroutine oft_hcurl_ceval_all3()
 integer(i4) :: i,etmp(2),ftmp(3)
 real(r8) :: f1,f2,f3,f4
 real(r8) :: g1xg2(3),g1xg3(3),g2xg3(3)
-DEBUG_STACK_PUSH
 DO i=1,6
   etmp=oriented_edges(:,i)
   rop(:,i) = 2.d0*cgop(:,ABS(cgop_map(etmp(1),etmp(2))))*SIGN(1,cgop_map(etmp(1),etmp(2)))
@@ -1686,23 +1651,16 @@ rop(:,29) = -2*f3*f4*cgop(:,1) &
           + f1*f4*cgop(:,4) &
           + f1*f3*cgop(:,5) &
           + 0*cgop(:,6)
-DEBUG_STACK_POP
 end subroutine oft_hcurl_ceval_all3
 !------------------------------------------------------------------------------
 !> Evaluate all lagrange interpolation functions (quartic)
 !!
 !! @note Evaluation is performed in logical coordinates
 !------------------------------------------------------------------------------
-subroutine oft_hcurl_ceval_all4()!self,cell,f,rop,cgop)
-! class(oft_fem_type), intent(in) :: self
-! integer(i4), intent(in) :: cell
-! real(r8), intent(in) :: f(4)
-! real(r8), intent(in) :: cgop(3,6)
-! real(r8), intent(out) :: rop(3,53)
+subroutine oft_hcurl_ceval_all4()
 integer(i4) :: i,etmp(2),ftmp(3)
 real(r8) :: f1,f2,f3,f4
 real(r8) :: g1xg2(3),g1xg3(3),g2xg3(3)
-DEBUG_STACK_PUSH
 DO i=1,6
   etmp=oriented_edges(:,i)
   rop(:,i) = 2.d0*cgop(:,ABS(cgop_map(etmp(1),etmp(2))))*SIGN(1,cgop_map(etmp(1),etmp(2)))
@@ -1828,7 +1786,6 @@ rop(:,53) = 0*cgop(:,1) &
           + f1*f4*(4.d0*f1 - 8.d0*f2)*cgop(:,4) &
           + f1*f3*(4.d0*f1 - 8.d0*f2)*cgop(:,5) &
           + 0*cgop(:,6)
-DEBUG_STACK_POP
 end subroutine oft_hcurl_ceval_all4
 end subroutine oft_hcurl_ceval_all
 end module oft_hcurl_basis

--- a/src/fem/hcurl_grad_operators.F90
+++ b/src/fem/hcurl_grad_operators.F90
@@ -1437,7 +1437,6 @@ integer(i4), pointer :: lcdg(:),lfde(:,:),lede(:,:),lcde(:,:)
 real(r8) :: f(4),incr,val,d(3),h_rop(3),goptmp(3,4),v,mop(1)
 type(oft_graph_ptr), pointer :: graphs(:,:)
 type(oft_graph), pointer :: interp_graph
-DEBUG_STACK_PUSH
 !---
 if(ML_grad%ml_mesh%level<1)call oft_abort('Invalid mesh level','hgrad_ginterpmatrix',__FILE__)
 mesh=>ML_grad%ml_mesh%mesh
@@ -1621,7 +1620,6 @@ DO i=1,cmesh%nc ! loop over coarse cells
     CALL mat%add_values(i_ind,j_ind,mop,1,1)
   END DO
 END DO
-DEBUG_STACK_POP
 END SUBROUTINE hgrad_ginterpmatrix
 END SUBROUTINE hcurl_grad_setup_interp
 !------------------------------------------------------------------------------

--- a/src/fem/hcurl_operators.F90
+++ b/src/fem/hcurl_operators.F90
@@ -1144,7 +1144,6 @@ real(r8) :: f(4),incr,val,d(3),goptmp(3,4),v,mop(1),h_rop(3,6)
 type(oft_graph_ptr), pointer :: graphs(:,:)
 type(oft_graph), POINTER :: interp_graph
 CLASS(oft_mesh), POINTER :: mesh
-DEBUG_STACK_PUSH
 !---
 if(ML_hcurl_rep%ml_mesh%level<1)then
   call oft_abort('Invalid mesh level','hcurl_ginterpmatrix',__FILE__)
@@ -1329,7 +1328,6 @@ DO i=1,cmesh%nc ! loop over coarse cells
     CALL mat%add_values(i_ind,j_ind,mop,1,1)
   END DO
 END DO
-DEBUG_STACK_POP
 END SUBROUTINE hcurl_ginterpmatrix
 !------------------------------------------------------------------------------
 !> Construct interpolation matrix for polynomial levels
@@ -1347,7 +1345,6 @@ CLASS(oft_vector), POINTER :: hcurl_vec_fine,hcurl_vec_cors
 type(oft_graph_ptr), pointer :: graphs(:,:)
 type(oft_graph), POINTER :: interp_graph
 CLASS(oft_mesh), POINTER :: mesh
-DEBUG_STACK_PUSH
 !---
 SELECT TYPE(this=>ML_hcurl_rep%levels(ML_hcurl_rep%level)%fe)
 CLASS IS(oft_hcurl_fem)
@@ -1483,7 +1480,6 @@ DO i=1,mesh%nc
     CALL mat%add_values(i_ind,j_ind,mop,1,1)
   END DO
 END DO
-DEBUG_STACK_POP
 END SUBROUTINE hcurl_pinterpmatrix
 END SUBROUTINE hcurl_setup_interp
 !------------------------------------------------------------------------------

--- a/src/fem/lagrange_basis.F90
+++ b/src/fem/lagrange_basis.F90
@@ -738,14 +738,9 @@ contains
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-subroutine tet_eval_all2()!self,cell,f,rop)
-! class(oft_scalar_fem), intent(in) :: self
-! integer(i4), intent(in) :: cell
-! real(r8), intent(in) :: f(:)
-! real(r8), intent(out) :: rop(10)
+subroutine tet_eval_all2()
 integer(i4) :: i,offset,etmp(2)
 real(r8) :: pnorm,nodes1(4)
-DEBUG_STACK_PUSH
 !---Vertices
 pnorm = 1.d0/PRODUCT(self%xnodes(3)-self%xnodes(1:2))
 DO i=1,4
@@ -759,19 +754,13 @@ DO i=1,6
   etmp=self%mesh%cell_ed(:,i)
   rop(offset+1) = nodes1(etmp(1))*nodes1(etmp(2))*pnorm
 END DO
-DEBUG_STACK_POP
 end subroutine tet_eval_all2
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-subroutine tet_eval_all3()!self,cell,f,rop)
-! class(oft_scalar_fem), intent(in) :: self
-! integer(i4), intent(in) :: cell
-! real(r8), intent(in) :: f(:)
-! real(r8), intent(out) :: rop(20)
+subroutine tet_eval_all3()
 integer(i4) :: i,offset,etmp(2),ftmp(3)
 real(r8) :: pnorm,enorm,fnorm,nodes1(4),nodes2(4)
-DEBUG_STACK_PUSH
 IF(oriented_cell/=cell)CALL mesh_local_orient(self%mesh,cell)
 !---Vertices
 pnorm = 1.d0/PRODUCT(self%xnodes(4)-self%xnodes(1:3))
@@ -795,19 +784,13 @@ DO i=1,4
   ftmp=oriented_faces(:,i)
   rop(offset+1) = nodes1(ftmp(1))*nodes1(ftmp(2))*nodes1(ftmp(3))*fnorm
 END DO
-DEBUG_STACK_POP
 end subroutine tet_eval_all3
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-subroutine tet_eval_all4()!self,cell,f,rop)
-! class(oft_scalar_fem), intent(in) :: self
-! integer(i4), intent(in) :: cell
-! real(r8), intent(in) :: f(:)
-! real(r8), intent(out) :: rop(35)
+subroutine tet_eval_all4()
 integer(i4) :: i,offset,etmp(2),ftmp(3)
 real(r8) :: pnorm,enorm(2),fnorm,nodes1(4),nodes2(4),nodes3(4)
-DEBUG_STACK_PUSH
 IF(oriented_cell/=cell)CALL mesh_local_orient(self%mesh,cell)
 !---Vertices
 pnorm = 1.d0/PRODUCT(self%xnodes(5)-self%xnodes(1:4))
@@ -839,7 +822,6 @@ END DO
 !---Cell
 offset=4*3 + 6*3 + 4
 rop(offset+1) = PRODUCT(f-self%xnodes(1))/((self%xnodes(2)-self%xnodes(1))**4)
-DEBUG_STACK_POP
 end subroutine tet_eval_all4
 end subroutine oft_lag_eval_all
 !------------------------------------------------------------------------------
@@ -1132,18 +1114,9 @@ contains
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-subroutine tet_geval_all2()!self,cell,f,gop,rop)
-! class(oft_scalar_fem), intent(in) :: self
-! integer(i4), intent(in) :: cell
-! real(r8), intent(in) :: f(:)
-! real(r8), intent(in) :: gop(3,4)
-! real(r8), intent(out) :: rop(3,10)
-! integer(i4) :: i,j,k,offset,ind,inc,etmp(2),ftmp(3)
-! integer(i4), ALLOCATABLE, DIMENSION(:) :: finds
-! real(r8) :: cof1,cofs2(2),pnorm,nodes1(4)
+subroutine tet_geval_all2()
 integer(i4) :: i,offset,etmp(2)
 real(r8) :: cof1,cofs2(2),pnorm,nodes1(4)
-DEBUG_STACK_PUSH
 !---Vertices
 pnorm = 1.d0/PRODUCT(self%xnodes(3)-self%xnodes(1:2))
 DO i=1,4
@@ -1158,20 +1131,13 @@ DO i=1,6
   rop(:,offset+1) = (gop(:,etmp(1))*nodes1(etmp(2)) &
     + gop(:,etmp(2))*nodes1(etmp(1)))*pnorm
 END DO
-DEBUG_STACK_POP
 end subroutine tet_geval_all2
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-subroutine tet_geval_all3()!self,cell,f,gop,rop)
-! class(oft_scalar_fem), intent(in) :: self
-! integer(i4), intent(in) :: cell
-! real(r8), intent(in) :: f(:)
-! real(r8), intent(in) :: gop(3,4)
-! real(r8), intent(out) :: rop(3,20)
+subroutine tet_geval_all3()
 integer(i4) :: i,offset,etmp(2),ftmp(3)
 real(r8) :: pnorm,enorm,fnorm,nodes1(4),nodes2(4),dnodes2(4)
-DEBUG_STACK_PUSH
 IF(oriented_cell/=cell)CALL mesh_local_orient(self%mesh,cell)
 !---Vertices
 pnorm = 1.d0/PRODUCT(self%xnodes(4)-self%xnodes(1:3))
@@ -1200,22 +1166,14 @@ DO i=1,4
     + gop(:,ftmp(2))*nodes1(ftmp(1))*nodes1(ftmp(3)) &
     + gop(:,ftmp(3))*nodes1(ftmp(1))*nodes1(ftmp(2)))*fnorm
 END DO
-DEBUG_STACK_POP
 end subroutine tet_geval_all3
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-subroutine tet_geval_all4()!self,cell,f,gop,rop)
-! class(oft_scalar_fem), intent(in) :: self
-! integer(i4), intent(in) :: cell
-! real(r8), intent(in) :: f(:)
-! real(r8), intent(in) :: gop(3,4)
-! real(r8), intent(out) :: rop(3,35)
-! integer(i4) :: i,offset,etmp(2),ftmp(3)
+subroutine tet_geval_all4()
 integer(i4) :: i,offset,etmp(2),ftmp(3)
 real(r8) :: pnorm,enorm(2),fnorm,cofs4(4)
 real(r8) :: nodes1(4),nodes2(4),nodes3(4),dnodes2(4),dnodes3(4)
-DEBUG_STACK_PUSH
 IF(oriented_cell/=cell)CALL mesh_local_orient(self%mesh,cell)
 !---Vertices
 pnorm = 1.d0/PRODUCT(self%xnodes(5)-self%xnodes(1:4))
@@ -1260,7 +1218,6 @@ offset=4*3 + 6*3 + 4
 cofs4 = (/PRODUCT(nodes1(2:4)),PRODUCT(nodes1((/1,3,4/))), &
   PRODUCT(nodes1((/1,2,4/))),PRODUCT(nodes1(1:3))/)
 rop(:,offset+1) = MATMUL(gop,cofs4)/((self%xnodes(2)-self%xnodes(1))**4)
-DEBUG_STACK_POP
 end subroutine tet_geval_all4
 end subroutine oft_lag_geval_all
 !------------------------------------------------------------------------------

--- a/src/fem/lagrange_operators.F90
+++ b/src/fem/lagrange_operators.F90
@@ -1541,7 +1541,6 @@ class(oft_mesh), pointer :: cmesh
 CLASS(oft_vector), POINTER :: lag_vec_fine,lag_vec_cors
 type(oft_graph_ptr), pointer :: graphs(:,:)
 type(oft_graph), POINTER :: interp_graph
-DEBUG_STACK_PUSH
 !---
 if(ML_lag_rep%ml_mesh%level<1)call oft_abort('Invalid mesh level','lag_ginterpmatrix',__FILE__)
 cmesh=>ML_lag_rep%ml_mesh%meshes(ML_lag_rep%ml_mesh%level-1)
@@ -1640,7 +1639,6 @@ DO i=1,cmesh%ne
   END DO
 END DO
 deallocate(emap)
-DEBUG_STACK_POP
 END SUBROUTINE lag_ginterpmatrix
 !------------------------------------------------------------------------------
 !> Construct interpolation matrix for polynomial levels
@@ -1658,7 +1656,6 @@ CLASS(oft_vector), POINTER :: lag_vec_fine,lag_vec_cors
 type(oft_graph_ptr), pointer :: graphs(:,:)
 type(oft_graph), POINTER :: interp_graph
 class(oft_mesh), pointer :: mesh
-DEBUG_STACK_PUSH
 IF(.NOT.oft_3D_lagrange_cast(lag_fine,ML_lag_rep%current_level))CALL oft_abort("Incorrect fine FE type","lag_pinterpmatrix",__FILE__)
 mesh=>lag_fine%mesh
 allocate(ftmp(mesh%face_np),fetmp(mesh%face_np),ctmp(mesh%cell_np))
@@ -1947,7 +1944,6 @@ END DO
 !---
 DEALLOCATE(ed_nodes,fc_nodes,c_nodes)
 DEALLOCATE(ftmp,fetmp,ctmp)
-DEBUG_STACK_POP
 END SUBROUTINE lag_pinterpmatrix
 END SUBROUTINE lag_setup_interp
 !------------------------------------------------------------------------------

--- a/src/grid/bezier_cad.F90
+++ b/src/grid/bezier_cad.F90
@@ -871,7 +871,6 @@ real(r8) function bernstein(x,i,j)
 real(r8), intent(in) :: x !< Point to evaluate
 integer(i4), intent(in) :: i !< Polynomial degree
 integer(i4), intent(in) :: j !< Polynomial kind
-DEBUG_STACK_PUSH
 bernstein=0.d0
 select case(i)
   case(1) ! Degree 1
@@ -899,6 +898,5 @@ select case(i)
       bernstein = x**3
     endif
 end select
-DEBUG_STACK_POP
 end function bernstein
 end module bezier_cad

--- a/src/grid/mesh_gmsh.F90
+++ b/src/grid/mesh_gmsh.F90
@@ -271,8 +271,8 @@ subroutine mesh_gmsh_hobase(mesh)
 class(oft_mesh), intent(inout) :: mesh
 real(r8) :: pt(3)
 integer(i4) :: i,j,k,etmp(2),ind
-DEBUG_STACK_PUSH
 IF(order==1)RETURN
+DEBUG_STACK_PUSH
 if(oft_debug_print(1))write(*,*)'Quadratic mesh nodes imported'
 !---Setup quadratic mesh
 mesh%order=1

--- a/src/grid/mesh_native.F90
+++ b/src/grid/mesh_native.F90
@@ -445,8 +445,8 @@ END SUBROUTINE native_read_sidesets
 !---------------------------------------------------------------------------------
 subroutine native_hobase(self)
 CLASS(oft_amesh), INTENT(inout) :: self
-DEBUG_STACK_PUSH
 IF(np_ho==0)RETURN
+DEBUG_STACK_PUSH
 if(oft_debug_print(1))write(*,'(2A)')oft_indent,'Importing quadratic mesh nodes'
 SELECT CASE(self%type)
 CASE(1) ! Tet/Tri

--- a/src/grid/tetmesh_type.F90
+++ b/src/grid/tetmesh_type.F90
@@ -370,12 +370,10 @@ integer(i4), intent(in) :: i
 real(r8), intent(in) :: pt(3)
 real(r8) :: f(4),gop(3,4),v
 integer(i4) :: k
-DEBUG_STACK_PUSH
 call tetmesh_jacl(self,i,gop,v)
 do k=1,4
   f(k)=1.d0+dot_product(pt-self%r(:,self%lc(k,i)),gop(:,k))
 end do
-DEBUG_STACK_POP
 end function tetmesh_phys2logl
 !---------------------------------------------------------------------------------
 ! General high-order implementation of @ref tetmesh_phys2log
@@ -401,7 +399,6 @@ real(r8) :: wa1(neq),wa2(neq),wa3(neq),wa4(nerr),error(nerr)
 integer(i4) :: ipvt(neq)
 real(r8) :: ftol,xtol,gtol,epsfcn,factor,dmin
 integer :: info,ldfjac,maxfev,mode,nfev,nprint
-DEBUG_STACK_PUSH
 !---
 mode = 1
 factor = 1.d0
@@ -423,7 +420,6 @@ call lmdif(tm_findcell_error,nerr,neq,uv,error, &
             nfev,fjac,ldfjac,ipvt,qtf,wa1,wa2,wa3,wa4)
 !IF(info>4)WRITE(*,*)'High-order find failed',i,info,nfev
 f(1:3)=uv; f(4)=1.d0-SUM(uv)
-DEBUG_STACK_POP
 end function tetmesh_phys2logho
 !------------------------------------------------------------------------------
 !> Evalute the error between a logical point and the current active point
@@ -438,11 +434,9 @@ real(r8), intent(in) :: uv(n) !< Parametric possition [n]
 real(r8), intent(out) :: err(m) !< Error vector between current and desired point [3]
 integer(i4), intent(inout) :: iflag !< Unused flag
 real(r8) :: pt(3),f(4)
-DEBUG_STACK_PUSH
 f(1:3)=uv; f(4)=1.d0-SUM(uv)
 pt=tetmesh_log2phys(active_mesh,active_cell,f)
 err=active_pt-pt
-DEBUG_STACK_POP
 end subroutine tm_findcell_error
 end subroutine tetmesh_phys2log
 !---------------------------------------------------------------------------------

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -4,4 +4,19 @@ ADD_CUSTOM_COMMAND(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 configure_file( local.h ${CMAKE_CURRENT_BINARY_DIR} @ONLY )
-ADD_CUSTOM_TARGET(oftheaders DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/local.h ${CMAKE_CURRENT_BINARY_DIR}/git_info.h)
+
+if( OFT_DEBUG_STACK )
+  ADD_CUSTOM_COMMAND(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/stack_defs.h always_rebuild
+    COMMAND Python::Interpreter ${CMAKE_SOURCE_DIR}/utilities/generate_stack.py -o ${CMAKE_CURRENT_BINARY_DIR}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  )
+  ADD_CUSTOM_TARGET(oftheaders DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/stack_defs.h ${CMAKE_CURRENT_BINARY_DIR}/local.h ${CMAKE_CURRENT_BINARY_DIR}/git_info.h)
+  add_custom_target(stack_clean
+    COMMAND Python::Interpreter ${CMAKE_SOURCE_DIR}/utilities/generate_stack.py -c
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target clean
+  )
+else()
+  ADD_CUSTOM_TARGET(oftheaders DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/local.h ${CMAKE_CURRENT_BINARY_DIR}/git_info.h)
+endif()

--- a/src/lin_alg/native_la.F90
+++ b/src/lin_alg/native_la.F90
@@ -1310,7 +1310,6 @@ contains
 subroutine full_restore_local(array_loc)
 complex(c8), intent(inout) :: array_loc(:)
 integer(i4) :: i
-DEBUG_STACK_PUSH
 IF(do_add)THEN
   call oft_global_stitch(self%stitch_info,array_loc,1)
   !$omp parallel do if(self%n>OFT_OMP_VTHRESH)
@@ -1324,7 +1323,6 @@ ELSE
   END DO
   IF(.NOT.do_wait)CALL self%stitch(0)
 END IF
-DEBUG_STACK_POP
 end subroutine full_restore_local
 end subroutine cvec_restore_local
 !---------------------------------------------------------------------------------

--- a/src/physics/tracing.F90
+++ b/src/physics/tracing.F90
@@ -1067,7 +1067,10 @@ ALLOCATE(ydot(self%neq))
 call mesh_findcell(self%ml_mesh%mesh,self%cell,self%y(1:3),self%f)
 fmin=MINVAL(self%f); fmax=MAXVAL(self%f)
 IF(( fmax>=1.d0+offmesh_tol ).OR.( fmin<=-offmesh_tol ))self%cell=0
-IF(self%cell==0)RETURN
+IF(self%cell==0)THEN
+  DEBUG_STACK_POP
+  RETURN
+END IF
 CALL self%ml_mesh%mesh%jacobian(self%cell,self%f,goptmp,v)
 CALL self%B%interp(self%cell,self%f,goptmp,B)
 self%dyp=self%dy
@@ -1083,7 +1086,10 @@ self%y=self%y+self%dt*self%dy
 call mesh_findcell(self%ml_mesh%mesh,self%cell,self%y(1:3),self%f)
 fmin=MINVAL(self%f); fmax=MAXVAL(self%f)
 IF(( fmax>=1.d0+offmesh_tol ).OR.( fmin<=-offmesh_tol ))self%cell=0
-IF(self%cell==0)RETURN
+IF(self%cell==0)THEN
+  DEBUG_STACK_POP
+  RETURN
+END IF
 CALL self%ml_mesh%mesh%jacobian(self%cell,self%f,goptmp,v)
 CALL self%B%interp(self%cell,self%f,goptmp,B)
 IF(ASSOCIATED(active_tracer%ydot))THEN
@@ -1352,7 +1358,10 @@ real(r8) :: goptmp(3,4),v,B(3)
 DEBUG_STACK_PUSH
 ydot=active_tracer%dy
 call mesh_findcell(active_tracer%ml_mesh%mesh,active_tracer%cell,y(1:3),active_tracer%f)
-IF(active_tracer%cell==0)RETURN
+IF(active_tracer%cell==0)THEN
+  DEBUG_STACK_POP
+  RETURN
+END IF
 CALL active_tracer%ml_mesh%mesh%jacobian(active_tracer%cell,active_tracer%f,goptmp,v)
 CALL active_tracer%B%interp(active_tracer%cell,active_tracer%f,goptmp,B)
 IF(ASSOCIATED(active_tracer%ydot))THEN

--- a/src/utilities/build_libs.py
+++ b/src/utilities/build_libs.py
@@ -769,7 +769,7 @@ class METIS(package):
             '-DGKRAND:BOOL=ON',
             '-DGKLIB_PATH=$GKLIB_PATH'
         ]
-        if ver_gt(self.config_dict["CMAKE_VERSION"], "3.99"):
+        if ver_gt(self.config_dict.get("CMAKE_VERSION","0.0"), "3.99"):
             cmake_options.append("-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
         if 'MACOS_SDK_PATH' in self.config_dict:
             cmake_options.append('-DCMAKE_OSX_SYSROOT={0}'.format(self.config_dict['MACOS_SDK_PATH']))
@@ -1945,6 +1945,8 @@ class PETSC(package):
         return self.config_dict
 
     def build(self):
+        if ver_gt(self.config_dict.get('CMAKE_VERSION','0.0'),"3.99"):
+            error_exit('CMAKE >= 4.0 not presently supported with PETSc', ('Update or retry with "--build_cmake=1" to build a compatible version',))
         #
         def_lines = []
         options = []

--- a/src/utilities/build_libs.py
+++ b/src/utilities/build_libs.py
@@ -718,8 +718,7 @@ class CMAKE(package):
 class METIS(package):
     def __init__(self, comp_wrapper=False):
         self.name = "METIS"
-        self.url = "https://hitsi.ap.columbia.edu/hosted/libs/metis-5.1.0-mod.tar.gz"
-        self.build_dir = "metis-5.1.0"
+        self.url = "https://karypis.github.io/glaros/files/sw/metis/metis-5.1.0.tar.gz"
         self.comp_wrapper = comp_wrapper
 
     def detect_sizes(self):
@@ -770,6 +769,8 @@ class METIS(package):
             '-DGKRAND:BOOL=ON',
             '-DGKLIB_PATH=$GKLIB_PATH'
         ]
+        if ver_gt(self.config_dict["CMAKE_VERSION"], "3.99"):
+            cmake_options.append("-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
         if 'MACOS_SDK_PATH' in self.config_dict:
             cmake_options.append('-DCMAKE_OSX_SYSROOT={0}'.format(self.config_dict['MACOS_SDK_PATH']))
         build_lines = [

--- a/src/utilities/build_libs.py
+++ b/src/utilities/build_libs.py
@@ -357,7 +357,8 @@ def setup_build_env(build_dir="build", build_cmake_ver=None):
 
 
 def build_cmake_script(mydict,build_debug=False,use_openmp=False,build_python=False,build_tests=False, 
-                       build_examples=False,build_docs=False,build_coverage=False,package_build=False,package_release=False):
+                       build_examples=False,build_docs=False,build_coverage=False,package_build=False,
+                       package_release=False,enable_debug_stack=False,enable_profiling=False):
     def bool_to_string(val):
         if val:
             return "TRUE"
@@ -384,6 +385,8 @@ def build_cmake_script(mydict,build_debug=False,use_openmp=False,build_python=Fa
         "-DOFT_PACKAGE_BUILD:BOOL={0}".format(bool_to_string(package_build)),
         "-DOFT_PACKAGE_NIGHTLY:BOOL={0}".format(bool_to_string(not package_release)),
         "-DOFT_COVERAGE:BOOL={0}".format(bool_to_string(build_coverage)),
+        "-DOFT_DEBUG_STACK:BOOL={0}".format(bool_to_string(enable_debug_stack)),
+        "-DOFT_PROFILING:BOOL={0}".format(bool_to_string(enable_profile)),
         "-DCMAKE_C_COMPILER:FILEPATH={CC}",
         "-DCMAKE_CXX_COMPILER:FILEPATH={CXX}",
         "-DCMAKE_Fortran_COMPILER:FILEPATH={FC}"
@@ -2025,6 +2028,8 @@ group.add_argument("--oft_build_docs", default=0, type=int, choices=(0,1), help=
 group.add_argument("--oft_package", action="store_true", default=False, help="Perform a packaging build of OFT?")
 group.add_argument("--oft_package_release", action="store_true", default=False, help="Perform a release package of OFT?")
 group.add_argument("--oft_build_coverage", action="store_true", default=False, help="Build OFT with code coverage flags?")
+group.add_argument("--oft_debug_stack", action="store_true", default=False, help="Enable internal debug stack?")
+group.add_argument("--oft_profiling", action="store_true", default=False, help="Enable internal profiling?")
 #
 group = parser.add_argument_group("MPI", "MPI package options")
 group.add_argument("--build_mpich", "--build_mpi", default=0, type=int, choices=(0,1), help="Build MPICH libraries?")
@@ -2218,5 +2223,7 @@ if not (config_dict['DOWN_ONLY'] or config_dict['SETUP_ONLY']):
         build_docs=(options.oft_build_docs == 1),
         build_coverage=options.oft_build_coverage,
         package_build=options.oft_package,
-        package_release=options.oft_package_release
+        package_release=options.oft_package_release,
+        enable_debug_stack=options.oft_debug_stack,
+        enable_profiling=options.oft_profiling,
     )

--- a/src/utilities/build_libs.py
+++ b/src/utilities/build_libs.py
@@ -386,7 +386,7 @@ def build_cmake_script(mydict,build_debug=False,use_openmp=False,build_python=Fa
         "-DOFT_PACKAGE_NIGHTLY:BOOL={0}".format(bool_to_string(not package_release)),
         "-DOFT_COVERAGE:BOOL={0}".format(bool_to_string(build_coverage)),
         "-DOFT_DEBUG_STACK:BOOL={0}".format(bool_to_string(enable_debug_stack)),
-        "-DOFT_PROFILING:BOOL={0}".format(bool_to_string(enable_profile)),
+        "-DOFT_PROFILING:BOOL={0}".format(bool_to_string(enable_profiling)),
         "-DCMAKE_C_COMPILER:FILEPATH={CC}",
         "-DCMAKE_CXX_COMPILER:FILEPATH={CXX}",
         "-DCMAKE_Fortran_COMPILER:FILEPATH={FC}"

--- a/src/utilities/generate_stack.py
+++ b/src/utilities/generate_stack.py
@@ -17,6 +17,7 @@ import sys
 import os
 import pathlib
 import re
+import hashlib
 # Regular expressions
 TEST_LINE_REGEX = re.compile(r'[ ]*(PURE|IMPURE|ELEMENTAL|RECURSIVE|PROGRAM|MODULE|SUBROUTINE|FUNCTION)+[ ]+', re.I)
 SUB_MOD_REGEX = re.compile(r'[ ]*(PURE|IMPURE|ELEMENTAL|RECURSIVE)+', re.I)
@@ -86,21 +87,31 @@ def parse_fortran_file(fid,modules,functions,debug=False):
             return name.lower(), 'sub'
         return None, None
     # Main body
+    old_file = ""
     file_buffer = ""
     current_module = ""
     current_function = "default"
     fun_depth = 0
     line_number = 0
     entry_count = 0
+    line = ""
     mod_id = 1
-    for line in fid:
+    for line_next in fid:
+        line_prev = line.strip()
+        line = line_next
         line_number += 1
+        old_file += line
         if (line.count("#define DEBUG_STACK_") > 0) or (line.count("#undef DEBUG_STACK_") > 0):
             continue
         if line.startswith("DEBUG_STACK_PUSH"):
             entry_count += 1
             if entry_count > 1:
                 print('  WARNING: Multiple entry points to subroutine "{0}" at line {1}'.format(current_function, line_number))
+        line_striped = line.strip().upper()
+        if len(line_striped) > 0:
+            if line_striped[0] != "!" and line_striped.endswith("RETURN"):
+                if entry_count > 0 and not line_prev.startswith("DEBUG_STACK_POP"):
+                    print('  WARNING: "RETURN" statement without "*_POP" in subroutine "{0}" at line {1}'.format(current_function, line_number))
         file_buffer += line
         if fun_depth > 0:
             end_match = END_SUB_REGEX.match(line)
@@ -145,11 +156,12 @@ def parse_fortran_file(fid,modules,functions,debug=False):
             file_buffer += "#undef DEBUG_STACK_SUB_IND\n#define DEBUG_STACK_SUB_IND " + str(ind) + "\n"
             entry_count = 0
             fun_depth = 1
-    return modules, functions, file_buffer
+    file_unchanged = (hashlib.md5(old_file.encode()).hexdigest() == hashlib.md5(file_buffer.encode()).hexdigest())
+    return modules, functions, file_buffer, file_unchanged
 #----------------------------------------------------------------
 # Create stack variables in FORTRAN syntax
 #----------------------------------------------------------------
-def create_debug_list(modules,functions):
+def create_debug_list(modules,functions,include_path):
     file_buffer = "! Stack definitions for OFT\n"
     #
     file_buffer = file_buffer + "INTEGER(i4), PARAMETER :: stack_len = " + str(stack_len) + "\n"
@@ -193,18 +205,26 @@ def create_debug_list(modules,functions):
         else:
             file_buffer = file_buffer + str(functions[i].module) + "] \n"
     #
-    with open("include/stack_defs.h","w+") as fid:
+    try:
+        file_unchanged = (hashlib.md5(open(os.path.join(include_path,"stack_defs.h"),'rb').read()).hexdigest() == hashlib.md5(file_buffer.encode()).hexdigest())
+    except:
+        file_unchanged = False
+    if file_unchanged:
+        return
+    with open(os.path.join(include_path,"stack_defs.h"),"w+") as fid:
         fid.write(file_buffer)
 #----------------------------------------------------------------
 # Remove STACK preprocessor definitions from a FORTRAN source file
 #----------------------------------------------------------------
 def clean_fortran_file(fid):
     file_buffer = ""
+    file_unchanged = True
     for line in fid:
         if line.count("#define DEBUG_STACK_") > 0 or line.count("#undef DEBUG_STACK_") > 0:
+            file_unchanged = False
             continue
         file_buffer = file_buffer + line
-    return file_buffer
+    return file_buffer, file_unchanged
 #----------------------------------------------------------------
 # Script driver
 #----------------------------------------------------------------
@@ -218,6 +238,7 @@ if __name__ == '__main__':
     parser.add_argument('-t', '--test_run', help='Run without writing any changes.', action="store_true")
     parser.add_argument('-d', '--debug', help='Display debug information.', action="store_true")
     parser.add_argument('-c', '--clean', help='Clean stack declarations from sources.', action="store_true")
+    parser.add_argument('-o', '--out_path', help='Output path for stack include file.', type=str, default="include")
     args=parser.parse_args()
     #
     if args.test_run:
@@ -233,21 +254,22 @@ if __name__ == '__main__':
         print("Must be run from root source directory.")
         sys.exit(1)
     # Set source directories for search
-    obj_dirs = ["base", "grid", "lin_alg", "fem", "physics", "."]
+    obj_dirs = ["base", "grid", "lin_alg", "fem", "physics"]
     stack_len = 40
     # Initialize containers
     skip_files = []
-    modules = [module("dummy",1)]
-    functions = [function("dummy",1,1)]
+    modules = [module("unknown",1)]
+    functions = [function("unknown",1,1)]
     # If clean is set remove all preprocessor defs
     if clean:
-        print("\n%========================================%")
-        print("Cleaning Source Files")
+        if debug:
+            print("Cleaning stack from source files")
     # Otherwise parse source files and add STACK definitions
     else:
-        print("\n%========================================%")
-        print("Parsing Source Files")
+        if debug:
+            print("Creating stack from source files")
     # Look in each source directory
+    nupdate = 0
     for dir in obj_dirs:
         files = os.listdir(dir)
         # Check each file in this directory
@@ -257,30 +279,38 @@ if __name__ == '__main__':
             # If file is a FORTRAN file parse and remove definitions
             if ".F90" == extension:
                 path = os.path.join(dir,filename)
-                print(path)
+                if debug:
+                    print('  '+path)
                 with open(path,'r') as fid:
                     if clean:
-                        new_file = clean_fortran_file(fid)
+                        new_file, file_unchanged = clean_fortran_file(fid)
                     else:
-                        modules, functions, new_file = parse_fortran_file(fid,modules,functions,debug)
+                        modules, functions, new_file, file_unchanged = parse_fortran_file(fid,modules,functions,debug)
                 # If in test mode do not replace file
-                if test_run:
+                if test_run or file_unchanged:
                     continue
+                nupdate += 1
                 with open(path,"w+") as fid:
                     fid.write(new_file)
+    if nupdate == 0:
+        print("  No updates")
+    else:
+        print("  Updated {0} files".format(nupdate))
     if not clean:
         # Print module statistics from search
-        print("\n%========================================%")
-        print("Found {0} Modules".format(len(modules)))
+        if debug:
+            print("%========================================%")
+            print("Found {0} Modules".format(len(modules)))
         if debug:
             for mod in modules:
-                print(mod)
+                print('  '+mod)
         # Print subroutine statistics from search
-        print("\n%========================================%")
-        print("Found {0} Functions".format(len(functions)))
+        if debug:
+            print("%========================================%")
+            print("Found {0} Functions".format(len(functions)))
         if debug:
             for func in functions:
-                print(repr(func))
+                print('  '+repr(func))
         # Create header file with STACK variables
         if not test_run:
-            create_debug_list(modules,functions)
+            create_debug_list(modules,functions,include_path=args.out_path)

--- a/src/utilities/generate_stack.py
+++ b/src/utilities/generate_stack.py
@@ -303,7 +303,7 @@ if __name__ == '__main__':
                     fid.write(new_file)
     if args.lint and (nupdate > 0):
         print()
-        print("Linting error: Found updates in {0} files".format(nupdate))
+        print("Linting error: Found errors in {0} file(s)".format(nupdate))
         sys.exit(1)
     if nupdate == 0:
         print("  No updates")


### PR DESCRIPTION
This pull request revives OFT's internal debug/profiling stack options that provides some level of cross-platform support for backtracing and profiling, including:

- Improve signal handling
- Add linting GitHub actions workflow to catch debug stack information

Additionally, the following changes to core code were made:

- Fix issue with 3rd party library builds for CMAKE >= 4.XX

This pull request **does not** introduce changes for any existing APIs or input files.