### PR TITLE
Add support for legacy HDF5 visualization files

### DIFF
--- a/src/base/oft_io.F90
+++ b/src/base/oft_io.F90
@@ -324,10 +324,11 @@ END SUBROUTINE bin_file_flush
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-subroutine xmdf_setup(self,group_name,basepath)
+subroutine xmdf_setup(self,group_name,basepath,persistent_space_tracking)
 class(xdmf_plot_file), intent(inout) :: self
 CHARACTER(LEN=*), intent(in) :: group_name !< Path to mesh in HDF5 file
 CHARACTER(LEN=*), OPTIONAL, INTENT(in) :: basepath
+LOGICAL, OPTIONAL, INTENT(in) :: persistent_space_tracking
 integer :: error
 IF(PRESENT(basepath))THEN
   call execute_command_line('mkdir -p '//TRIM(basepath), exitstat=error)
@@ -339,7 +340,7 @@ ELSE
 END IF
 self%group_name=TRIM(group_name)
 CALL string_to_lower(self%group_name)
-CALL hdf5_create_file(TRIM(self%file_path),.TRUE.)
+CALL hdf5_create_file(TRIM(self%file_path),persistent_space_tracking)
 CALL hdf5_create_group(TRIM(self%file_path),TRIM(self%group_name))
 end subroutine xmdf_setup
 !------------------------------------------------------------------------------

--- a/src/bin/marklin_eigs.F90
+++ b/src/bin/marklin_eigs.F90
@@ -21,7 +21,7 @@
 PROGRAM marklin_eigs
 !---Base
 USE oft_base
-USE oft_io, ONLY: hdf5_create_file, xdmf_plot_file
+USE oft_io, ONLY: xdmf_plot_file
 !--Grid
 USE multigrid, ONLY: multigrid_mesh
 USE multigrid_build, ONLY: multigrid_construct

--- a/src/bin/thincurr_eig.F90
+++ b/src/bin/thincurr_eig.F90
@@ -23,7 +23,7 @@
 PROGRAM thincurr_eig
 USE oft_base
 USE oft_sort, ONLY: sort_array
-USE oft_io, ONLY: oft_bin_file, hdf5_create_file, hdf5_write, &
+USE oft_io, ONLY: oft_bin_file, hdf5_write, &
   hdf5_create_group, hdf5_add_string_attribute
 USE oft_mesh_native, ONLY: native_read_nodesets, native_read_sidesets
 #ifdef HAVE_NCDF

--- a/src/python/OpenFUSIONToolkit/Marklin/_core.py
+++ b/src/python/OpenFUSIONToolkit/Marklin/_core.py
@@ -144,10 +144,11 @@ class Marklin():
         if error_string.value != b'':
             raise Exception(error_string.value.decode())
     
-    def setup_io(self,basepath=None):
+    def setup_io(self,basepath=None,legacy_hdf5=False):
         '''! Setup XDMF+HDF5 I/O for 3D visualization
 
         @param basepath Path to root directory to use for I/O
+        @param legacy_hdf5 Use legacy HDF5 format (required for VisIt)
         '''
         if basepath is None:
             basepath_c = self._oft_env.path2c('')
@@ -158,7 +159,7 @@ class Marklin():
             self._io_basepath = basepath[:-1]
             basepath_c = self._oft_env.path2c(basepath)
         error_string = self._oft_env.get_c_errorbuff()
-        marklin_setup_io(self._marklin_ptr,basepath_c,error_string)
+        marklin_setup_io(self._marklin_ptr,basepath_c,c_bool(legacy_hdf5),error_string)
         if error_string.value != b'':
             raise Exception(error_string.value.decode())
     

--- a/src/python/OpenFUSIONToolkit/Marklin/_interface.py
+++ b/src/python/OpenFUSIONToolkit/Marklin/_interface.py
@@ -33,9 +33,9 @@ marklin_compute_vac = ctypes_subroutine(oftpy_lib.marklin_compute_vac,
 marklin_compute_pardiff = ctypes_subroutine(oftpy_lib.marklin_compute_pardiff,
     [c_void_p, c_void_p, c_int, c_double, c_char_p])
 
-# marklin_setup_io(marklin_ptr,basepath,error_str)
+# marklin_setup_io(marklin_ptr,basepath,legacy_hdf5,error_str)
 marklin_setup_io = ctypes_subroutine(oftpy_lib.marklin_setup_io,
-    [c_void_p, c_char_p, c_char_p])
+    [c_void_p, c_char_p, c_bool, c_char_p])
 
 # marklin_save_visit(marklin_ptr,int_obj,int_type,key,error_str)
 marklin_save_visit = ctypes_subroutine(oftpy_lib.marklin_save_visit,

--- a/src/python/OpenFUSIONToolkit/ThinCurr/_core.py
+++ b/src/python/OpenFUSIONToolkit/ThinCurr/_core.py
@@ -141,11 +141,12 @@ class ThinCurr():
         self.nelems = sizes[7]
         self.n_icoils = sizes[8]
     
-    def setup_io(self,basepath=None,save_debug=False):
+    def setup_io(self,basepath=None,save_debug=False,legacy_hdf5=False):
         '''! Setup XDMF+HDF5 I/O for 3D visualization
 
         @param basepath Path to root directory to use for I/O
         @param save_debug Save model debug information?
+        @param legacy_hdf5 Use legacy HDF5 format (required for VisIt)
         '''
         # tw_ptr,basepath,save_debug,error_str
         if basepath is None:
@@ -157,7 +158,7 @@ class ThinCurr():
             self._io_basepath = basepath[:-1]
             basepath_c = self._oft_env.path2c(basepath)
         error_string = self._oft_env.get_c_errorbuff()
-        thincurr_setup_io(self.tw_obj,basepath_c,c_bool(save_debug),error_string)
+        thincurr_setup_io(self.tw_obj,basepath_c,c_bool(save_debug),c_bool(legacy_hdf5),error_string)
         if error_string.value != b'':
             raise Exception(error_string.value.decode())
     

--- a/src/python/OpenFUSIONToolkit/ThinCurr/_interface.py
+++ b/src/python/OpenFUSIONToolkit/ThinCurr/_interface.py
@@ -18,9 +18,9 @@ thincurr_setup = ctypes_subroutine(oftpy_lib.thincurr_setup,
     [c_char_p, c_int, ctypes_numpy_array(float64,2), c_int, ctypes_numpy_array(int32,2), ctypes_numpy_array(int32,1), 
      ctypes_numpy_array(int32,1), c_int, c_void_p, ctypes_numpy_array(int32,1), c_char_p])
 
-# ThinCurr setup plotting (tw_ptr,basepath,save_debug,error_str
+# ThinCurr setup plotting (tw_ptr,basepath,save_debug,legacy_hdf5,error_str
 thincurr_setup_io = ctypes_subroutine(oftpy_lib.thincurr_setup_io,
-    [c_void_p, c_char_p, c_bool, c_char_p])
+    [c_void_p, c_char_p, c_bool, c_bool, c_char_p])
 
 # thincurr_recon_curr(tw_ptr,vals,curr,format)
 thincurr_recon_curr = ctypes_subroutine(oftpy_lib.thincurr_recon_curr,

--- a/src/python/wrappers/marklin_f.F90
+++ b/src/python/wrappers/marklin_f.F90
@@ -12,7 +12,7 @@ USE iso_c_binding, ONLY: c_int, c_double, c_char, c_loc, c_null_char, c_ptr, &
     c_f_pointer, c_bool, c_null_ptr, c_associated
 !---Base
 USE oft_base
-USE oft_io, ONLY: hdf5_create_file, xdmf_plot_file
+USE oft_io, ONLY: xdmf_plot_file
 !--Grid
 USE oft_mesh_type, ONLY: mesh_findcell
 USE oft_mesh_native, ONLY: r_mem, lc_mem, reg_mem
@@ -341,9 +341,10 @@ END SUBROUTINE marklin_compute_pardiff
 !---------------------------------------------------------------------------------
 !> Needs docs
 !---------------------------------------------------------------------------------
-SUBROUTINE marklin_setup_io(marklin_ptr,basepath,error_str) BIND(C,NAME="marklin_setup_io")
+SUBROUTINE marklin_setup_io(marklin_ptr,basepath,legacy_hdf5,error_str) BIND(C,NAME="marklin_setup_io")
 TYPE(c_ptr), VALUE, INTENT(in) :: marklin_ptr !< Needs docs
 CHARACTER(KIND=c_char), INTENT(in) :: basepath(OFT_PATH_SLEN) !< Needs docs
+LOGICAL(c_bool), VALUE, INTENT(in) :: legacy_hdf5 !< Use legacy HDF5 format?
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Needs docs
 TYPE(marklin_obj), POINTER :: self
 CHARACTER(LEN=OFT_PATH_SLEN) :: pathprefix = ''
@@ -351,10 +352,10 @@ IF(.NOT.marklin_ccast(marklin_ptr,self,error_str))RETURN
 CALL copy_string_rev(basepath,pathprefix)
 !---Setup I/0
 IF(TRIM(pathprefix)/='')THEN
-  CALL self%xdmf_plot%setup('marklin',pathprefix)
+  CALL self%xdmf_plot%setup('marklin',pathprefix,.NOT.LOGICAL(legacy_hdf5))
   CALL self%ml_mesh%mesh%setup_io(self%xdmf_plot,self%ML_hcurl%current_level%order)
 ELSE
-  CALL self%xdmf_plot%setup('marklin')
+  CALL self%xdmf_plot%setup('marklin',persistent_space_tracking=.NOT.LOGICAL(legacy_hdf5))
   CALL self%ml_mesh%mesh%setup_io(self%xdmf_plot,self%ML_hcurl%current_level%order)
 END IF
 END SUBROUTINE marklin_setup_io

--- a/src/python/wrappers/thincurr_f.F90
+++ b/src/python/wrappers/thincurr_f.F90
@@ -13,7 +13,7 @@ USE iso_c_binding, ONLY: c_int, c_double, c_char, c_loc, c_null_char, c_ptr, &
 !---Base
 USE oft_base
 USE spline_mod
-USE oft_io, ONLY: hdf5_create_file, hdf5_field_get_sizes, hdf5_read, hdf5_field_exist, &
+USE oft_io, ONLY: hdf5_field_get_sizes, hdf5_read, hdf5_field_exist, &
   xdmf_plot_file
 !--Grid
 USE oft_trimesh_type, ONLY: oft_trimesh
@@ -225,10 +225,11 @@ END SUBROUTINE thincurr_setup
 !---------------------------------------------------------------------------------
 !> Needs docs
 !---------------------------------------------------------------------------------
-SUBROUTINE thincurr_setup_io(tw_ptr,basepath,save_debug,error_str) BIND(C,NAME="thincurr_setup_io")
+SUBROUTINE thincurr_setup_io(tw_ptr,basepath,save_debug,legacy_hdf5,error_str) BIND(C,NAME="thincurr_setup_io")
 TYPE(c_ptr), VALUE, INTENT(in) :: tw_ptr !< Needs docs
 CHARACTER(KIND=c_char), INTENT(in) :: basepath(OFT_PATH_SLEN) !< Needs docs
 LOGICAL(c_bool), VALUE, INTENT(in) :: save_debug !< Needs docs
+LOGICAL(c_bool), VALUE, INTENT(in) :: legacy_hdf5 !< Use legacy HDF5 format?
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Needs docs
 !
 INTEGER(4) :: i,j,k,npts,nedges
@@ -241,10 +242,10 @@ CALL c_f_pointer(tw_ptr, tw_obj)
 CALL copy_string_rev(basepath,pathprefix)
 !---Setup I/0
 IF(TRIM(pathprefix)/='')THEN
-  CALL tw_obj%xdmf%setup('thincurr',pathprefix)
+  CALL tw_obj%xdmf%setup('thincurr',pathprefix,.NOT.LOGICAL(legacy_hdf5))
   CALL tw_obj%mesh%setup_io(tw_obj%xdmf,1)
 ELSE
-  CALL tw_obj%xdmf%setup('thincurr')
+  CALL tw_obj%xdmf%setup('thincurr',persistent_space_tracking=.NOT.LOGICAL(legacy_hdf5))
   CALL tw_obj%mesh%setup_io(tw_obj%xdmf,1)
 END IF
 IF(tw_obj%n_vcoils>0)THEN


### PR DESCRIPTION
This pull request add support for legacy HDF5 visualization files (as required by VisIt), by adding a new `legacy_hdf5` argument to `TokaMaker.setup_io()` and `ThinCurr.setup_io()`.

This pull request **does not** introduce breaking change to any existing APIs or input files.