### PR TITLE
TokaMaker: Improvements for double null and H-mode calculations

### DIFF
--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -1976,11 +1976,15 @@ DO j=1,self%isoflux_ntargets
   CALL bmesh_findcell(self%fe_rep%mesh,cells(j),self%isoflux_targets(1:2,j),f)
   CALL psi_eval%interp(cells(j),f,goptmp,pol_val)
   rhs(j)=pol_val(1)
-  IF(self%isoflux_grad_wt_lim>0.d0)THEN
-    CALL self%fe_rep%mesh%jacobian(cells(j),f,goptmp,v)
-    CALL psi_geval2%interp(cells(j),f,goptmp,gpsi)
-    wt_tmp(j)=SQRT(SUM(gpsi(1:2)**2))
-  END IF
+  cells(j)=-1
+  CALL bmesh_findcell(self%fe_rep%mesh,cells(j),self%isoflux_targets(4:5,j),f)
+  CALL psi_eval%interp(cells(j),f,goptmp,pol_val)
+  rhs(j)=rhs(j)-pol_val(1)
+!   IF(self%isoflux_grad_wt_lim>0.d0)THEN
+!     CALL self%fe_rep%mesh%jacobian(cells(j),f,goptmp,v)
+!     CALL psi_geval2%interp(cells(j),f,goptmp,gpsi)
+!     wt_tmp(j)=SQRT(SUM(gpsi(1:2)**2))
+!   END IF
 END DO
 roffset=self%isoflux_ntargets
 coffset=self%isoflux_ntargets
@@ -2005,9 +2009,16 @@ DO i=1,self%ncoils
   psi_geval%u=>self%psi_coil(i)%f
   CALL psi_geval%setup(self%fe_rep)
   DO j=1,self%isoflux_ntargets
+    cells(j)=-1
     CALL bmesh_findcell(self%fe_rep%mesh,cells(j),self%isoflux_targets(1:2,j),f)
     CALL psi_eval%interp(cells(j),f,goptmp,pol_val)
     err_mat(j,i)=pol_val(1)
+  END DO
+  DO j=1,self%isoflux_ntargets
+    cells(j)=-1
+    CALL bmesh_findcell(self%fe_rep%mesh,cells(j),self%isoflux_targets(4:5,j),f)
+    CALL psi_eval%interp(cells(j),f,goptmp,pol_val)
+    err_mat(j,i)=err_mat(j,i)-pol_val(1)
   END DO
   roffset=self%isoflux_ntargets
   coffset=self%isoflux_ntargets
@@ -2031,11 +2042,15 @@ DO i=1,self%ncoils
     + self%coil_vcont(i)*err_mat(:,i)
 END DO
 !---Enforce difference of fluxes
-wt_max=MAXVAL(wt_tmp)
-wt_min=self%isoflux_grad_wt_lim*wt_max
-DO j=1,self%isoflux_ntargets-1
-  err_mat(j+1,:)=(err_mat(j+1,:)-err_mat(1,:))*self%isoflux_targets(3,j+1)*wt_max/MAX(wt_min,wt_tmp(j+1))
-  rhs(j+1)=(rhs(j+1)-rhs(1))*self%isoflux_targets(3,j+1)*wt_max/MAX(wt_min,wt_tmp(j+1))
+! wt_max=MAXVAL(wt_tmp)
+! wt_min=self%isoflux_grad_wt_lim*wt_max
+! DO j=1,self%isoflux_ntargets-1
+!   err_mat(j+1,:)=(err_mat(j+1,:)-err_mat(1,:))*self%isoflux_targets(3,j+1)*wt_max/MAX(wt_min,wt_tmp(j+1))
+!   rhs(j+1)=(rhs(j+1)-rhs(1))*self%isoflux_targets(3,j+1)*wt_max/MAX(wt_min,wt_tmp(j+1))
+! END DO
+DO j=1,self%isoflux_ntargets
+  err_mat(j,:)=err_mat(j,:)*self%isoflux_targets(3,j)
+  rhs(j)=rhs(j)*self%isoflux_targets(3,j)
 END DO
 DEALLOCATE(wt_tmp)
 !---Apply weights to flux constraints
@@ -2061,17 +2076,17 @@ INTEGER(4), ALLOCATABLE, DIMENSION(:) :: index
 REAL(8) :: rnorm
 REAL(8), ALLOCATABLE, DIMENSION(:) :: w
 ALLOCATE(w(self%ncoils+1),index(self%ncoils+1))
-  CALL bvls(ncon-1,self%ncoils+1,err_mat(2:nCon,:),rhs(2:nCon), &
+  CALL bvls(ncon,self%ncoils+1,err_mat(1:nCon,:),rhs(1:nCon), &
     self%coil_bounds,currs,rnorm,nsetp,w,index,ierr)
   ! WRITE(*,*)ierr,currs
 DEALLOCATE(w,index)
 END BLOCK
 ELSE
-  err_inv=MATMUL(TRANSPOSE(err_mat(2:nCon,:)),err_mat(2:nCon,:))
+  err_inv=MATMUL(TRANSPOSE(err_mat(1:nCon,:)),err_mat(1:nCon,:))
   pm_save=oft_env%pm; oft_env%pm=.FALSE.
   CALL lapack_matinv(self%ncoils+1,err_inv,ierr)
   oft_env%pm=pm_save
-  currs=MATMUL(err_inv,MATMUL(TRANSPOSE(err_mat(2:nCon,:)),rhs(2:nCon)))
+  currs=MATMUL(err_inv,MATMUL(TRANSPOSE(err_mat(1:nCon,:)),rhs(1:nCon)))
 END IF
 !---Add coil/conductor fields to IC
 self%vcontrol_val=-currs(self%ncoils+1)
@@ -4395,7 +4410,7 @@ SELECT CASE(self%mode)
     CALL self%psi_eval%interp(cell,f,gop,psitmp)
     val(1)=self%gs%psiscale*psitmp(1)
   CASE(2)
-    pt=self%gs%fe_rep%mesh%log2phys(cell,f)
+    ! pt=self%gs%fe_rep%mesh%log2phys(cell,f)
     CALL self%psi_eval%interp(cell,f,gop,psitmp)
     IF(in_plasma.AND.(psitmp(1)>self%gs%plasma_bounds(1)))THEN
       IF(self%gs%mode==0)THEN
@@ -4410,6 +4425,14 @@ SELECT CASE(self%mode)
     CALL self%psi_eval%interp(cell,f,gop,psitmp)
     IF(in_plasma.AND.(psitmp(1)>self%gs%plasma_bounds(1)))THEN
       val(1)=(self%gs%psiscale**2)*self%gs%pnorm*self%gs%P%F(psitmp(1))/mu0
+    ELSE
+      val(1)=0.d0
+    END IF
+  CASE(4)
+    ! pt=self%gs%fe_rep%mesh%log2phys(cell,f)
+    CALL self%psi_eval%interp(cell,f,gop,psitmp)
+    IF(in_plasma.AND.(psitmp(1)>self%gs%plasma_bounds(1)))THEN
+      val(1)=(psitmp(1)-self%gs%plasma_bounds(1))/(self%gs%plasma_bounds(2)-self%gs%plasma_bounds(1))
     ELSE
       val(1)=0.d0
     END IF

--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -1958,7 +1958,7 @@ logical :: pm_save
 nCon = self%isoflux_ntargets+self%flux_ntargets+2*self%saddle_ntargets+self%nregularize
 ALLOCATE(err_mat(nCon,self%ncoils+1),err_inv(self%ncoils+1,self%ncoils+1))
 ALLOCATE(rhs(nCon),currs(self%ncoils+1))
-ALLOCATE(cells(self%isoflux_ntargets+self%flux_ntargets+self%saddle_ntargets))
+ALLOCATE(cells(2*self%isoflux_ntargets+self%flux_ntargets+self%saddle_ntargets))
 err_mat=0.d0
 rhs=0.d0
 cells=-1
@@ -1973,21 +1973,20 @@ IF(self%isoflux_grad_wt_lim>0.d0)THEN
 END IF
 !---Get RHS
 DO j=1,self%isoflux_ntargets
-  CALL bmesh_findcell(self%fe_rep%mesh,cells(j),self%isoflux_targets(1:2,j),f)
-  CALL psi_eval%interp(cells(j),f,goptmp,pol_val)
+  CALL bmesh_findcell(self%fe_rep%mesh,cells((j-1)*2+1),self%isoflux_targets(1:2,j),f)
+  CALL psi_eval%interp(cells((j-1)*2+1),f,goptmp,pol_val)
   rhs(j)=pol_val(1)
-  cells(j)=-1
-  CALL bmesh_findcell(self%fe_rep%mesh,cells(j),self%isoflux_targets(4:5,j),f)
-  CALL psi_eval%interp(cells(j),f,goptmp,pol_val)
+  CALL bmesh_findcell(self%fe_rep%mesh,cells((j-1)*2+2),self%isoflux_targets(4:5,j),f)
+  CALL psi_eval%interp(cells((j-1)*2+2),f,goptmp,pol_val)
   rhs(j)=rhs(j)-pol_val(1)
-!   IF(self%isoflux_grad_wt_lim>0.d0)THEN
-!     CALL self%fe_rep%mesh%jacobian(cells(j),f,goptmp,v)
-!     CALL psi_geval2%interp(cells(j),f,goptmp,gpsi)
-!     wt_tmp(j)=SQRT(SUM(gpsi(1:2)**2))
-!   END IF
+  IF(self%isoflux_grad_wt_lim>0.d0)THEN
+    CALL self%fe_rep%mesh%jacobian(cells((j-1)*2+1),f,goptmp,v)
+    CALL psi_geval2%interp(cells((j-1)*2+1),f,goptmp,gpsi)
+    wt_tmp(j)=SQRT(SUM(gpsi(1:2)**2))
+  END IF
 END DO
 roffset=self%isoflux_ntargets
-coffset=self%isoflux_ntargets
+coffset=2*self%isoflux_ntargets
 DO j=1,self%flux_ntargets
   CALL bmesh_findcell(self%fe_rep%mesh,cells(coffset+j),self%flux_targets(1:2,j),f)
   CALL psi_eval%interp(cells(coffset+j),f,goptmp,pol_val)
@@ -2009,19 +2008,17 @@ DO i=1,self%ncoils
   psi_geval%u=>self%psi_coil(i)%f
   CALL psi_geval%setup(self%fe_rep)
   DO j=1,self%isoflux_ntargets
-    cells(j)=-1
-    CALL bmesh_findcell(self%fe_rep%mesh,cells(j),self%isoflux_targets(1:2,j),f)
-    CALL psi_eval%interp(cells(j),f,goptmp,pol_val)
+    CALL bmesh_findcell(self%fe_rep%mesh,cells((j-1)*2+1),self%isoflux_targets(1:2,j),f)
+    CALL psi_eval%interp(cells((j-1)*2+1),f,goptmp,pol_val)
     err_mat(j,i)=pol_val(1)
   END DO
   DO j=1,self%isoflux_ntargets
-    cells(j)=-1
-    CALL bmesh_findcell(self%fe_rep%mesh,cells(j),self%isoflux_targets(4:5,j),f)
-    CALL psi_eval%interp(cells(j),f,goptmp,pol_val)
+    CALL bmesh_findcell(self%fe_rep%mesh,cells((j-1)*2+2),self%isoflux_targets(4:5,j),f)
+    CALL psi_eval%interp(cells((j-1)*2+2),f,goptmp,pol_val)
     err_mat(j,i)=err_mat(j,i)-pol_val(1)
   END DO
   roffset=self%isoflux_ntargets
-  coffset=self%isoflux_ntargets
+  coffset=2*self%isoflux_ntargets
   DO j=1,self%flux_ntargets
     CALL bmesh_findcell(self%fe_rep%mesh,cells(coffset+j),self%flux_targets(1:2,j),f)
     CALL psi_eval%interp(cells(coffset+j),f,goptmp,pol_val)
@@ -2042,15 +2039,11 @@ DO i=1,self%ncoils
     + self%coil_vcont(i)*err_mat(:,i)
 END DO
 !---Enforce difference of fluxes
-! wt_max=MAXVAL(wt_tmp)
-! wt_min=self%isoflux_grad_wt_lim*wt_max
-! DO j=1,self%isoflux_ntargets-1
-!   err_mat(j+1,:)=(err_mat(j+1,:)-err_mat(1,:))*self%isoflux_targets(3,j+1)*wt_max/MAX(wt_min,wt_tmp(j+1))
-!   rhs(j+1)=(rhs(j+1)-rhs(1))*self%isoflux_targets(3,j+1)*wt_max/MAX(wt_min,wt_tmp(j+1))
-! END DO
+wt_max=MAXVAL(wt_tmp)
+wt_min=self%isoflux_grad_wt_lim*wt_max
 DO j=1,self%isoflux_ntargets
-  err_mat(j,:)=err_mat(j,:)*self%isoflux_targets(3,j)
-  rhs(j)=rhs(j)*self%isoflux_targets(3,j)
+  err_mat(j,:)=err_mat(j,:)*self%isoflux_targets(3,j)*wt_max/MAX(wt_min,wt_tmp(j))
+  rhs(j)=rhs(j)*self%isoflux_targets(3,j)*wt_max/MAX(wt_min,wt_tmp(j))
 END DO
 DEALLOCATE(wt_tmp)
 !---Apply weights to flux constraints
@@ -2076,17 +2069,17 @@ INTEGER(4), ALLOCATABLE, DIMENSION(:) :: index
 REAL(8) :: rnorm
 REAL(8), ALLOCATABLE, DIMENSION(:) :: w
 ALLOCATE(w(self%ncoils+1),index(self%ncoils+1))
-  CALL bvls(ncon,self%ncoils+1,err_mat(1:nCon,:),rhs(1:nCon), &
+  CALL bvls(ncon,self%ncoils+1,err_mat,rhs, &
     self%coil_bounds,currs,rnorm,nsetp,w,index,ierr)
   ! WRITE(*,*)ierr,currs
 DEALLOCATE(w,index)
 END BLOCK
 ELSE
-  err_inv=MATMUL(TRANSPOSE(err_mat(1:nCon,:)),err_mat(1:nCon,:))
+  err_inv=MATMUL(TRANSPOSE(err_mat),err_mat)
   pm_save=oft_env%pm; oft_env%pm=.FALSE.
   CALL lapack_matinv(self%ncoils+1,err_inv,ierr)
   oft_env%pm=pm_save
-  currs=MATMUL(err_inv,MATMUL(TRANSPOSE(err_mat(1:nCon,:)),rhs(1:nCon)))
+  currs=MATMUL(err_inv,MATMUL(TRANSPOSE(err_mat),rhs))
 END IF
 !---Add coil/conductor fields to IC
 self%vcontrol_val=-currs(self%ncoils+1)

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -109,6 +109,10 @@ tokamaker_get_dels_curr = ctypes_subroutine(oftpy_lib.tokamaker_get_dels_curr,
 tokamaker_area_int = ctypes_subroutine(oftpy_lib.tokamaker_area_int,
     [c_void_p, ctypes_numpy_array(numpy.float64,1), c_int, c_double_ptr, c_char_p])
 
+# tokamaker_flux_int(tMaker_ptr,psi_vals,field_vals,nvals,result,error_str)
+tokamaker_flux_int = ctypes_subroutine(oftpy_lib.tokamaker_flux_int,
+    [c_void_p, ctypes_numpy_array(numpy.float64,1), ctypes_numpy_array(numpy.float64,1), c_int, c_double_ptr, c_char_p])
+
 # tokamaker_get_coil_currents(tMaker_ptr,currents,reg_currents,error_str)
 tokamaker_get_coil_currents = ctypes_subroutine(oftpy_lib.tokamaker_get_coil_currents,
     [c_void_p, ctypes_numpy_array(numpy.float64,1), ctypes_numpy_array(numpy.float64,1), c_char_p])
@@ -176,9 +180,9 @@ tokamaker_set_settings = ctypes_subroutine(oftpy_lib.tokamaker_set_settings,
 tokamaker_set_targets = ctypes_subroutine(oftpy_lib.tokamaker_set_targets,
     [c_void_p, c_double, c_double, c_double, c_double, c_double, c_double, c_char_p])
 
-# tokamaker_set_isoflux(tMaker_ptr,targets,weights,ntargets,grad_wt_lim,error_str)
+# tokamaker_set_isoflux(tMaker_ptr,targets,ref_points,weights,ntargets,grad_wt_lim,error_str)
 tokamaker_set_isoflux = ctypes_subroutine(oftpy_lib.tokamaker_set_isoflux,
-    [c_void_p, ctypes_numpy_array(numpy.float64,2), ctypes_numpy_array(numpy.float64,1), c_int, c_double, c_char_p])
+    [c_void_p, ctypes_numpy_array(numpy.float64,2), ctypes_numpy_array(numpy.float64,2), ctypes_numpy_array(numpy.float64,1), c_int, c_double, c_char_p])
 
 # tokamaker_set_flux(tMaker_ptr,locations,targets,weights,ntargets,grad_wt_lim,error_str)
 tokamaker_set_flux = ctypes_subroutine(oftpy_lib.tokamaker_set_flux,

--- a/src/tests/physics/test_TokaMaker.py
+++ b/src/tests/physics/test_TokaMaker.py
@@ -713,12 +713,13 @@ def test_ITER_eq(order):
 @pytest.mark.coverage
 def test_ITER_recon():
     ITER_recon_dict = ITER_eq_dict.copy()
-    ITER_recon_dict['q_95'] = 2.727373194556296
-    ITER_recon_dict['P_ax'] = 653312.4614673054
-    ITER_recon_dict['W_MHD'] = 256930543.79179734
-    ITER_recon_dict['beta_pol'] = 44.08617559839085
-    ITER_recon_dict['beta_tor'] = 1.887092454605829
-    ITER_recon_dict['beta_n'] = 1.2523366970906669
+    ITER_recon_dict['q_95'] = 2.7274510732722375
+    ITER_recon_dict['P_ax'] = 655693.6031014244
+    ITER_recon_dict['W_MHD'] = 257915984.01397622
+    ITER_recon_dict['l_i'] = 0.895954395982195
+    ITER_recon_dict['beta_pol'] = 44.16835089714342
+    ITER_recon_dict['beta_tor'] = 1.8950360948919174
+    ITER_recon_dict['beta_n'] = 1.2576100533550467
     results = mp_run(run_ITER_case,(1.0,(2,),False,False,True))
     assert validate_dict(results,ITER_recon_dict)
 


### PR DESCRIPTION
This pull request adds improvements for TokaMaker calculations including:

- Add the ability to specify reference points for isoflux targets through new `ref_points` argument
- Add a new `TokaMaker.flux_integral()` method for computing the surface integral of a flux function
- Fix bug where isoflux/flux target solve may fail when no VSC is defined
- Fix bug where first flux or saddle target is skipped if no isoflux targets are set

This pull request **does not** introduce breaking changes in any existing APIs or input files.