### PR TITLE
ThinCurr: Fix bug with jumper setup when no boundary points are included

### DIFF
--- a/src/bin/thincurr_td.F90
+++ b/src/bin/thincurr_td.F90
@@ -121,8 +121,10 @@ IF(ASSOCIATED(mesh_ssets))THEN
   END IF
 END IF
 tw_sim%mesh=>mg_mesh%smesh
-IF(jumper_start>0)THEN
+IF(jumper_start/=0)THEN
   n=SIZE(mesh_nsets)
+  IF(ABS(jumper_start)>n)CALL oft_abort('"jumper_start" exceeds number of nodesets in file',"thincurr_td",__FILE__)
+  IF(jumper_start<0)jumper_start=n+1+jumper_start
   hole_nsets=>mesh_nsets(1:jumper_start-1)
   ALLOCATE(tw_sim%jumper_nsets(n-jumper_start+1))
   DO i=jumper_start,n


### PR DESCRIPTION
This pull request fixes a bug in the setup of some jumpers in ThinCurr when the jumper does not include any boundary points. Additionally, the jumper setup process has been made more robust to capture corners and other edge cases.

This pull request **does not** introduce changes for any existing python APIs or input files.