### PR TITLE
TokaMaker: Add tests to catch invalid region IDs in mesh

### DIFF
--- a/src/lin_alg/umfpack_bridge.c
+++ b/src/lin_alg/umfpack_bridge.c
@@ -69,6 +69,7 @@ oft_umfpack_dgssv_c(int iopt, int n, int nnz, int nrhs,
         }
         status = umfpack_di_symbolic( n, n, rowptr, colind, values, &LUfactors->Symbolic, LUfactors->Control, Info);
         if ( status != 0 ){
+          printf("UMFPACK: Symbolic factorization failed %d\n", status);
           *info = status;
           return;
         }
@@ -78,6 +79,17 @@ oft_umfpack_dgssv_c(int iopt, int n, int nnz, int nrhs,
       }
       status = umfpack_di_numeric( rowptr, colind, values, LUfactors->Symbolic, &LUfactors->Numeric, LUfactors->Control, Info);
       *info = status;
+      if ( status != UMFPACK_OK) {
+        if ( status == UMFPACK_ERROR_out_of_memory) {
+          printf("UMFPACK: Out of Memory in factorization\n");
+        } else if ( status == UMFPACK_WARNING_singular_matrix ) {
+          printf("UMFPACK: Singular matrix detected in factorization\n");
+        } else if ( status == UMFPACK_WARNING_determinant_underflow ) {
+          printf("UMFPACK: Determinant underflow detected in factorization\n");
+        } else if ( status == UMFPACK_WARNING_determinant_overflow ) {
+          printf("UMFPACK: Determinant overflow detected in factorization\n");
+        }
+      }
 
     } else if ( iopt == 2 ) { /* Perform solve */
 

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -241,6 +241,8 @@ class TokaMaker():
             if reg is None:
                 reg = numpy.ones((nc.value,),dtype=numpy.int32)
             else:
+                if reg.min() <= 0:
+                    raise ValueError('Invalid "reg" array, values must be >= 0')
                 reg = numpy.ascontiguousarray(reg, dtype=numpy.int32)
             oft_setup_smesh(ndim,np,r,npc,nc,lc+1,reg,ctypes.byref(nregs),ctypes.byref(self._mesh_ptr))
         else:

--- a/src/python/OpenFUSIONToolkit/TokaMaker/meshing.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/meshing.py
@@ -463,6 +463,8 @@ class gs_Domain:
         self.mesh = Mesh(self.regions,debug=debug,extra_reg_defs=self._extra_reg_defs,merge_thresh=merge_thresh)
         if not setup_only:
             self._r, self._lc, self._reg = self.mesh.get_mesh()
+            if self._reg.min() <= 0:
+                raise ValueError('Meshing error: unclaimed region detected!')
             return self._r, self._lc, self._reg
         return None, None, None
     


### PR DESCRIPTION
This pull request fixes adds tests to catch invalid region IDs within the mesh passed to TokaMaker.

This pull request **does not** introduce changes for any existing python APIs or input files.
