### PR TITLE
TokaMaker: Add option to update bounds when manually setting psi

### DIFF
--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -3693,6 +3693,7 @@ integer(4) :: i,j,m,n_unique,stype,stypes(max_unique),cell,nx_points
 integer(4), allocatable :: ncuts(:)
 real(8) :: saddle_loc(2),saddle_psi,unique_saddles(3,max_unique),ptmp(2),f(3),loc_vals(3),psi_scale_len
 real(8) :: region(2,2) = RESHAPE([-1.d99,1.d99,-1.d99,1.d99], [2,2])
+character(len=20) :: loc_str
 type(oft_lag_brinterp), target :: psi_eval
 type(oft_lag_bginterp), target :: psi_geval
 type(oft_lag_bg2interp), target :: psi_g2eval
@@ -3752,7 +3753,13 @@ DO i=1,smesh%np
       IF(ncuts(i)==0)stype=1
       IF(ncuts(i)>3)stype=3
     END IF
-    IF(stype<0)CYCLE
+    IF(stype<0)THEN
+      IF(oft_debug_print(1))THEN
+        WRITE(loc_str,'(2ES10.2)')smesh%r(1:2,i)
+        CALL oft_warn("Failed to refine candidate o-point at "//loc_str)
+      END IF
+      CYCLE
+    END IF
     IF(saddle_psi>-1.d98)THEN
       DO m=1,n_unique
         IF(SQRT(SUM((saddle_loc-unique_saddles(1:2,m))**2))<2.d-2)EXIT

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1048,16 +1048,17 @@ class TokaMaker():
                 psi = 1.0 - psi
         return psi
 
-    def set_psi(self,psi):
+    def set_psi(self,psi,update_bounds=False):
         '''! Set poloidal flux values on node points
 
         @param psi Poloidal flux values (should not be normalized!)
+        @param update_bounds Update plasma bounds by determining new limiting points
         '''
         if psi.shape[0] != self.np:
             raise IndexError('Incorrect shape of "psi", should be [np]')
         psi = numpy.ascontiguousarray(psi, dtype=numpy.float64)
         error_string = self._oft_env.get_c_errorbuff()
-        tokamaker_set_psi(self._tMaker_ptr,psi,error_string)
+        tokamaker_set_psi(self._tMaker_ptr,psi,c_bool(update_bounds),error_string)
         if error_string.value != b'':
             raise Exception(error_string.value)
     

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -169,9 +169,9 @@ tokamaker_get_field_eval = ctypes_subroutine(oftpy_lib.tokamaker_get_field_eval,
 tokamaker_apply_field_eval = ctypes_subroutine(oftpy_lib.tokamaker_apply_field_eval,
     [c_void_p, c_void_p, c_int, ctypes_numpy_array(numpy.float64,1), c_double, c_int_ptr, c_int, ctypes_numpy_array(numpy.float64,1)])
 
-# tokamaker_set_psi(tMaker_ptr,psi_vals,error_str)
+# tokamaker_set_psi(tMaker_ptr,psi_vals,update_bounds,error_str)
 tokamaker_set_psi = ctypes_subroutine(oftpy_lib.tokamaker_set_psi,
-    [c_void_p, ctypes_numpy_array(numpy.float64,1), c_char_p])
+    [c_void_p, ctypes_numpy_array(numpy.float64,1), c_bool, c_char_p])
 
 # tokamaker_set_psi_dt(tMaker_ptr,psi_vals,dt,error_str)
 tokamaker_set_psi_dt = ctypes_subroutine(oftpy_lib.tokamaker_set_psi_dt,

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -28,7 +28,7 @@ USE axi_green, ONLY: green
 USE oft_gs, ONLY: gs_eq, gs_save_fields, gs_setup_walls, build_dels, &
   gs_fixed_vflux, gs_get_qprof, gs_trace_surf, gs_b_interp, gs_j_interp, gs_prof_interp, &
   gs_plasma_mutual, gs_source, gs_err_reason, gs_coil_source_distributed, gs_vacuum_solve, &
-  gs_coil_mutual, gs_coil_mutual_distributed, gs_project_b, gs_save_mug
+  gs_coil_mutual, gs_coil_mutual_distributed, gs_project_b, gs_save_mug, gs_update_bounds
 #ifdef OFT_TOKAMAKER_LEGACY
 USE oft_gs, ONLY: gs_load_regions
 #endif
@@ -1095,15 +1095,17 @@ END SUBROUTINE tokamaker_apply_field_eval
 !---------------------------------------------------------------------------------
 !> Needs docs
 !---------------------------------------------------------------------------------
-SUBROUTINE tokamaker_set_psi(tMaker_ptr,psi_vals,error_str) BIND(C,NAME="tokamaker_set_psi")
+SUBROUTINE tokamaker_set_psi(tMaker_ptr,psi_vals,update_bounds,error_str) BIND(C,NAME="tokamaker_set_psi")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
 TYPE(c_ptr), VALUE, INTENT(in) :: psi_vals !< Needs docs
+LOGICAL(c_bool), VALUE, INTENT(in) :: update_bounds !< Update bounds by determining new limiting points
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 REAL(8), POINTER, DIMENSION(:) :: vals_tmp
 TYPE(tokamaker_instance), POINTER :: tMaker_obj
 IF(.NOT.tokamaker_ccast(tMaker_ptr,tMaker_obj,error_str))RETURN
 CALL c_f_pointer(psi_vals, vals_tmp, [tMaker_obj%gs%psi%n])
 CALL tMaker_obj%gs%psi%restore_local(vals_tmp)
+IF(update_bounds)CALL gs_update_bounds(tMaker_obj%gs)
 END SUBROUTINE tokamaker_set_psi
 !---------------------------------------------------------------------------------
 !> Needs docs


### PR DESCRIPTION
This pull request adds a new `update_bounds` argument to TokaMaker's `set_psi()` method, which will recompute limiting flux values and points (O-/X-points and limiters) to be consistent with the new values of `psi`.

This pull request **does not** introduce breaking changes for any existing python APIs or input files.