### PR TITLE
TokaMaker: Reenable vacuum solves through normal `.solve()` method

### DIFF
--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -679,17 +679,20 @@ class TokaMaker():
         self.load_profiles(ffp_file,None,pp_file,eta_file,ffp_NI_file)
 
     def solve(self, vacuum=False):
-        '''! Solve G-S equation with specified constraints, profiles, etc.'''
-        if vacuum:
-            raise ValueError('"vacuum=True" no longer supported, use "vac_solve()"')
+        '''! Solve G-S equation with specified constraints, profiles, etc.
+        
+        @param vacuum Perform vacuum solve? Plasma-related targets (eg. `Ip`) will be ignored.
+        '''
         error_string = self._oft_env.get_c_errorbuff()
-        tokamaker_solve(self._tMaker_ptr,error_string)
+        tokamaker_solve(self._tMaker_ptr,c_bool(vacuum),error_string)
         if error_string.value != b'':
             raise ValueError("Error in solve: {0}".format(error_string.value.decode()))
     
     def vac_solve(self,psi=None,rhs_source=None):
         '''! Solve for vacuum solution (no plasma), with present coil currents
         and optional other currents
+
+        @note If isoflux, flux, or saddle constraints are desired use @ref solve instead.
         
         @param psi Boundary values for vacuum solve
         @param rhs_source Current source (optional)

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -66,9 +66,9 @@ tokamaker_load_profiles = ctypes_subroutine(oftpy_lib.tokamaker_load_profiles,
 tokamaker_init_psi = ctypes_subroutine(oftpy_lib.tokamaker_init_psi,
     [c_void_p, c_double, c_double, c_double, c_double, c_double, c_double_ptr, c_char_p])
 
-# tokamaker_solve(tMaker_ptr,error_str)
+# tokamaker_solve(tMaker_ptr,vacuum,error_str)
 tokamaker_solve = ctypes_subroutine(oftpy_lib.tokamaker_solve, 
-    [c_void_p, c_char_p])
+    [c_void_p, c_bool, c_char_p])
 
 # tokamaker_vac_solve(tMaker_ptr,psi_in,rhs_source,error_str)
 tokamaker_vac_solve = ctypes_subroutine(oftpy_lib.tokamaker_vac_solve, 

--- a/src/utilities/build_libs.py
+++ b/src/utilities/build_libs.py
@@ -1856,15 +1856,15 @@ class PETSC(package):
         self.display_name = "PETSc"
         self.version = version
         if self.version == '3.18':
-            self.url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.18.6.tar.gz"
+            self.url = "https://gitlab.com/petsc/petsc/-/archive/v3.18.6/petsc-v3.18.6.tar.gz"
         elif self.version == '3.19':
-            self.url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.19.6.tar.gz"
+            self.url = "https://gitlab.com/petsc/petsc/-/archive/v3.19.6/petsc-v3.19.6.tar.gz"
         elif self.version == '3.20':
-            self.url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.20.6.tar.gz"
+            self.url = "https://gitlab.com/petsc/petsc/-/archive/v3.20.6/petsc-v3.20.6.tar.gz"
         elif self.version == '3.21':
-            self.url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.21.6.tar.gz"
+            self.url = "https://gitlab.com/petsc/petsc/-/archive/v3.21.6/petsc-v3.21.6.tar.gz"
         elif self.version == '3.22':
-            self.url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.22.4.tar.gz"
+            self.url = "https://gitlab.com/petsc/petsc/-/archive/v3.22.5/petsc-v3.22.5.tar.gz"
         else:
             error_exit('Invalid PETSc version requested (3.18 <= version <= 3.22)')
         self.debug = debug


### PR DESCRIPTION
This pull request reenables the `vacuum` option for TokaMaker's `solve()` method to allow vacuum solves with isoflux, saddle, etc. constraints.

This pull request **does not** introduce breaking changes for any existing python APIs or input files.