### PR TITLE
TokaMaker: Fix bugs in `get_jtor_plasma()` and `psi_init()`

### DIFF
--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -1482,7 +1482,7 @@ call lmdif(circ_error,ncons,ncofs,coord_tmp,gpsitmp, &
 deallocate(diag,fjac,qtf,wa1,wa2)
 deallocate(wa3,wa4,ipvt)
 !
-lam=self%a*10.d0
+lam=self%a/5.d0
 val=(1.d0-TANH((coord_tmp(1)-self%a)/lam))/2.d0
 CONTAINS
 !---
@@ -4607,20 +4607,24 @@ subroutine gs_j_interp_setup(self,gs)
 class(gs_j_interp), intent(inout) :: self
 class(gs_eq), target, intent(inout) :: gs
 CALL gs_prof_interp_setup(self,gs)
-CALL self%gs%dipole_B0%update(self%gs)
-CALL self%gs%psi%new(self%bcross_kappa_fun%u)
-CALL gs_bcrosskappa(self%gs,self%bcross_kappa_fun%u)
-CALL self%bcross_kappa_fun%setup(self%gs%fe_rep)
+IF(self%gs%dipole_mode)THEN
+  CALL self%gs%dipole_B0%update(self%gs)
+  CALL self%gs%psi%new(self%bcross_kappa_fun%u)
+  CALL gs_bcrosskappa(self%gs,self%bcross_kappa_fun%u)
+  CALL self%bcross_kappa_fun%setup(self%gs%fe_rep)
+END IF
 end subroutine gs_j_interp_setup
 !------------------------------------------------------------------------------
 !> Destroy temporary internal storage and nullify references
 !------------------------------------------------------------------------------
 subroutine gs_j_interp_delete(self)
 class(gs_j_interp), intent(inout) :: self
+IF(ASSOCIATED(self%bcross_kappa_fun%u))THEN
+  CALL self%bcross_kappa_fun%u%delete()
+  DEALLOCATE(self%bcross_kappa_fun%u)
+  CALL self%bcross_kappa_fun%delete
+END IF
 CALL gs_prof_interp_delete(self)
-CALL self%bcross_kappa_fun%u%delete()
-DEALLOCATE(self%bcross_kappa_fun%u)
-CALL self%bcross_kappa_fun%delete
 end subroutine gs_j_interp_delete
 !------------------------------------------------------------------------------
 !> Reconstruct magnetic field from a Grad-Shafranov solution


### PR DESCRIPTION
This pull request fixes bugs in `TokaMaker.TokaMaker.get_jtor_plasma()` and `TokaMaker.TokaMaker.psi_init()`.

- Prior to this pull request `TokaMaker.TokaMaker.get_jtor_plasma()` could result in a crash in non-Dipole configuration. 
- Prior to this pull request `TokaMaker.TokaMaker.psi_init()` created erroneously broad current distributions when shape parameters were provided. This generally did not cause problems as `psi_init()` is only used as a starting guess, but could cause unexpected results when viewing the initialization fields.

This pull request **does not** introduce changes for any existing python APIs or input files.