### PR TITLE
TokaMaker: Remove equilibrium solver constraints if set before reconstruction

### DIFF
--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -298,6 +298,7 @@ class TokaMaker():
                     'sub_coils': []
                 }
                 nCoils += 1
+            coil_dict[key]['name'] = key
             self.coil_sets[coil_set]['sub_coils'].append(coil_dict[key])
             self.coil_sets[coil_set]['sub_coils'][-1]['name'] = key
             self.coil_sets[coil_set]['net_turns'] += coil_dict[key].get('nturns',1.0)


### PR DESCRIPTION
This pull request add code to check for and remove any remaining inverse constraints (eg. isoflux, saddles, etc.) from the underlying equilibrium solver that may conflict with the equilibrium reconstruction interface.

Additionally, this pull request makes the following changes:
 - TokaMaker: Add sub-coil names to `TokaMaker.coil_sets` dictionary

This pull request **does not** introduce changes for any existing python APIs or input files.