### PR TITLE
TokaMaker: Add support for saving and loading equilibrium objects

### DIFF
--- a/src/base/oft_io.F90
+++ b/src/base/oft_io.F90
@@ -94,6 +94,7 @@ end type xdmf_plot_file
 !> Write data to an HDF5 file
 !------------------------------------------------------------------------------
 INTERFACE hdf5_write
+  MODULE PROCEDURE hdf5_write_string
   MODULE PROCEDURE hdf5_write_scalar_r8
   MODULE PROCEDURE hdf5_write_scalar_i4
   MODULE PROCEDURE hdf5_write_scalar_l
@@ -107,6 +108,7 @@ END INTERFACE hdf5_write
 !> Read data from an HDF5 file
 !------------------------------------------------------------------------------
 INTERFACE hdf5_read
+  MODULE PROCEDURE hdf5_read_string
   MODULE PROCEDURE hdf5_read_scalar_r8
   MODULE PROCEDURE hdf5_read_scalar_i4
   MODULE PROCEDURE hdf5_read_scalar_l
@@ -767,6 +769,42 @@ call h5close_f(error)
 DEBUG_STACK_POP
 end subroutine hdf5_add_string_attribute
 !------------------------------------------------------------------------------
+!> String implementation of \ref oft_io::hdf5_write
+!------------------------------------------------------------------------------
+subroutine hdf5_write_string(string,filename,path)
+character(LEN=*), intent(in) :: string !< String to write to file
+character(LEN=*), intent(in) :: filename !< Path to file
+character(LEN=*), intent(in) :: path !< Variable path in file
+logical :: write_single
+integer(i4) :: error
+integer(i4), parameter :: one=1
+integer(HID_T) :: file_id,dspace_id,dset_id
+INTEGER(HSIZE_T), DIMENSION(1) :: dims
+DEBUG_STACK_PUSH
+!---Remove field if it already exists
+IF(hdf5_field_exist(filename,path))THEN
+  CALL oft_warn('Overwriting existing object "'//TRIM(path)//'" in file '//TRIM(filename))
+  CALL hdf5_delete_obj(filename,path)
+END IF
+!---Initialize HDF5 and open file
+call h5open_f(error)
+call h5fopen_f(TRIM(filename), H5F_ACC_RDWR_F, file_id, error)
+IF(error/=0)CALL oft_abort('Error opening file','hdf5_write_string',__FILE__)
+!---Create dataset and perform write
+dims=LEN(string)
+call h5screate_simple_f(one,dims,dspace_id,error)
+call h5dcreate_f(file_id, "/"//TRIM(path), H5T_NATIVE_CHARACTER, &
+  dspace_id, dset_id, error)
+call h5dwrite_f(dset_id, H5T_NATIVE_CHARACTER, string, dims, error)
+!---Close dataset
+call h5dclose_f(dset_id, error)
+call h5sclose_f(dspace_id, error)
+!---Close file and HDF5
+call h5fclose_f(file_id, error)
+call h5close_f(error)
+DEBUG_STACK_POP
+end subroutine hdf5_write_string
+!------------------------------------------------------------------------------
 !> real(r8) scalar implementation of \ref oft_io::hdf5_write
 !------------------------------------------------------------------------------
 subroutine hdf5_write_scalar_r8(val,filename,path,single_prec)
@@ -1106,6 +1144,55 @@ CALL oft_mpi_barrier(error)
 DEBUG_STACK_POP
 end subroutine hdf5_write_rst
 !------------------------------------------------------------------------------
+!> String implementation of \ref oft_io::hdf5_read
+!------------------------------------------------------------------------------
+subroutine hdf5_read_string(string,filename,path,success)
+character(LEN=:), allocatable, intent(inout) :: string !< String to read from file
+character(LEN=*), intent(in) :: filename !< Path to file
+character(LEN=*), intent(in) :: path !< Variable path in file
+logical, optional, intent(out) :: success !< Successful read?
+integer(i4) :: error
+integer(i4), parameter :: one=1,zero=0
+INTEGER(HSIZE_T) :: space_count
+integer(HID_T) :: file_id,dset_id,dspace_id
+INTEGER(HSIZE_T), DIMENSION(1) :: dims
+! DEBUG_STACK_PUSH
+IF(PRESENT(success))THEN
+  success=.FALSE.
+  CALL h5eset_auto_f(zero, error)
+END IF
+!---Initialize HDF5 and open file
+call h5open_f(error)
+call h5fopen_f(TRIM(filename), H5F_ACC_RDONLY_F, file_id, error)
+IF(error/=0)GOTO 103
+CALL h5dopen_f(file_id, "/"//TRIM(path), dset_id, error)
+IF(error/=0)GOTO 102
+!---
+CALL h5dget_space_f(dset_id, dspace_id, error)
+IF(error/=0)GOTO 101
+CALL h5sget_simple_extent_npoints_f(dspace_id, space_count, error)
+IF(error/=0)GOTO 100
+dims = space_count
+ALLOCATE(CHARACTER(LEN=dims(1)) :: string)
+call h5dread_f(dset_id, H5T_NATIVE_CHARACTER, string, dims, error)
+IF(error/=0)GOTO 100
+!---Close and finalize HDF5
+call h5dclose_f(dset_id, error)
+call h5fclose_f(file_id, error)
+call h5close_f(error)
+! DEBUG_STACK_POP
+IF(PRESENT(success))THEN
+  success=.TRUE.
+  CALL h5eset_auto_f(one, error)
+END IF
+RETURN
+100 CALL h5sclose_f(dspace_id, error)
+101 CALL h5dclose_f(dset_id, error)
+102 CALL h5fclose_f(file_id, error)
+103 CALL h5close_f(error)
+IF(PRESENT(success))CALL h5eset_auto_f(one, error)
+end subroutine hdf5_read_string
+!------------------------------------------------------------------------------
 !> real(r8) scalar implementation of \ref oft_io::hdf5_read
 !------------------------------------------------------------------------------
 subroutine hdf5_read_scalar_r8(val,filename,path,success)
@@ -1135,7 +1222,7 @@ IF(.NOT.success_read)THEN
 END IF
 IF(tmpval(1)==0)THEN
   val=.FALSE.
-ELSE IF(tmpval(1)==0)THEN
+ELSE IF(tmpval(1)==1)THEN
   val=.TRUE.
 ELSE
   val=.FALSE.

--- a/src/base/oft_io.F90
+++ b/src/base/oft_io.F90
@@ -1175,7 +1175,10 @@ IF(error/=0)GOTO 100
 dims = space_count
 ALLOCATE(CHARACTER(LEN=dims(1)) :: string)
 call h5dread_f(dset_id, H5T_NATIVE_CHARACTER, string, dims, error)
-IF(error/=0)GOTO 100
+IF(error/=0)THEN
+  DEALLOCATE(string)
+  GOTO 100
+END IF
 !---Close and finalize HDF5
 call h5dclose_f(dset_id, error)
 call h5fclose_f(file_id, error)

--- a/src/base/oft_io.F90
+++ b/src/base/oft_io.F90
@@ -1180,6 +1180,7 @@ IF(error/=0)THEN
   GOTO 100
 END IF
 !---Close and finalize HDF5
+CALL h5sclose_f(dspace_id, error)
 call h5dclose_f(dset_id, error)
 call h5fclose_f(file_id, error)
 call h5close_f(error)

--- a/src/base/oft_io.F90
+++ b/src/base/oft_io.F90
@@ -96,6 +96,7 @@ end type xdmf_plot_file
 INTERFACE hdf5_write
   MODULE PROCEDURE hdf5_write_scalar_r8
   MODULE PROCEDURE hdf5_write_scalar_i4
+  MODULE PROCEDURE hdf5_write_scalar_l
   MODULE PROCEDURE hdf5_write_1d_r8
   MODULE PROCEDURE hdf5_write_1d_i4
   MODULE PROCEDURE hdf5_write_2d_r8
@@ -108,6 +109,7 @@ END INTERFACE hdf5_write
 INTERFACE hdf5_read
   MODULE PROCEDURE hdf5_read_scalar_r8
   MODULE PROCEDURE hdf5_read_scalar_i4
+  MODULE PROCEDURE hdf5_read_scalar_l
   MODULE PROCEDURE hdf5_read_1d_r8
   MODULE PROCEDURE hdf5_read_1d_i4
   MODULE PROCEDURE hdf5_read_2d_r8
@@ -779,6 +781,23 @@ end subroutine hdf5_write_scalar_r8
 !------------------------------------------------------------------------------
 !> integer(i4) scalar implementation of \ref oft_io::hdf5_write
 !------------------------------------------------------------------------------
+subroutine hdf5_write_scalar_l(val,filename,path)
+logical, intent(in) :: val !< Value to write to file
+character(LEN=*), intent(in) :: filename !< Path to file
+character(LEN=*), intent(in) :: path !< Variable path in file
+integer(i4) :: tmpval(1)
+DEBUG_STACK_PUSH
+IF(val)THEN
+  tmpval(1)=1
+ELSE
+  tmpval(1)=0
+END IF
+CALL hdf5_write_1d_i4(tmpval,filename,path)
+DEBUG_STACK_POP
+end subroutine hdf5_write_scalar_l
+!------------------------------------------------------------------------------
+!> integer(i4) scalar implementation of \ref oft_io::hdf5_write
+!------------------------------------------------------------------------------
 subroutine hdf5_write_scalar_i4(val,filename,path)
 integer(i4), intent(in) :: val !< Value to write to file
 character(LEN=*), intent(in) :: filename !< Path to file
@@ -1098,6 +1117,33 @@ real(r8) :: tmpval(1)
 CALL hdf5_read_1d_r8(tmpval,filename,path,success)
 val=tmpval(1)
 end subroutine hdf5_read_scalar_r8
+!------------------------------------------------------------------------------
+!> logical scalar implementation of \ref oft_io::hdf5_read
+!------------------------------------------------------------------------------
+subroutine hdf5_read_scalar_l(val,filename,path,success)
+logical, intent(out) :: val !< Value to read from file
+character(LEN=*), intent(in) :: filename !< Path to file
+character(LEN=*), intent(in) :: path !< Variable path in file
+logical, optional, intent(out) :: success !< Successful read?
+logical :: success_read
+integer(i4) :: tmpval(1)
+CALL hdf5_read_1d_i4(tmpval,filename,path,success_read)
+IF(.NOT.success_read)THEN
+  val=.FALSE.
+  IF(PRESENT(success))success=.FALSE.
+  RETURN
+END IF
+IF(tmpval(1)==0)THEN
+  val=.FALSE.
+ELSE IF(tmpval(1)==0)THEN
+  val=.TRUE.
+ELSE
+  val=.FALSE.
+  IF(PRESENT(success))success=.FALSE.
+  RETURN
+END IF
+IF(PRESENT(success))success=.TRUE.
+end subroutine hdf5_read_scalar_l
 !------------------------------------------------------------------------------
 !> integer(i4) scalar implementation of \ref oft_io::hdf5_read
 !------------------------------------------------------------------------------

--- a/src/docs/doc_tokamaker_main.md
+++ b/src/docs/doc_tokamaker_main.md
@@ -20,7 +20,7 @@ conductors (eg. coils and structures).
 where \f$ \mathcal{P} \f$, \f$ \mathcal{S} \f$, and \f$ \mathcal{C} \f$ are axisymmetric domains corresponding to the plasma, passive conducting structures (eg. vacuum vessels), coils respectively.
 
 TokaMaker should primarily be used through the python interface using the \ref OpenFUSIONToolkit.TokaMaker "OpenFUSIONToolkit.TokaMaker" python module
-and the \ref OpenFUSIONToolkit.TokaMaker._core.TokaMaker "OpenFUSIONToolkit.TokaMaker.TokaMaker" class.
+and the \ref OpenFUSIONToolkit.TokaMaker._core.TokaMaker "OpenFUSIONToolkit.TokaMaker.TokaMaker" and \ref OpenFUSIONToolkit.TokaMaker._core.TokaMaker_equilibrium "OpenFUSIONToolkit.TokaMaker.TokaMaker_equilibrium" classes.
 
 \section doc_gs_main_ex TokaMaker examples
 The following examples illustrate usage of TokaMaker to compute different Grad-Shafranov equilibria. For examples of how to create

--- a/src/examples/TokaMaker/HBT/HBT_eq_ex.ipynb
+++ b/src/examples/TokaMaker/HBT/HBT_eq_ex.ipynb
@@ -522,7 +522,7 @@
    "metadata": {},
    "source": [
     "### Solve for updated equilibrium\n",
-    "As this solve is somewhat more challenging we increase the maximum number of solver iterations using the \\ref OpenFUSIONToolkit.TokaMaker.tokamaker_settings_struct \"settings\" object and \\ref OpenFUSIONToolkit.TokaMaker.TokaMaker.update_settings \"update_settings()\"."
+    "As this solve is somewhat more challenging we increase the maximum number of solver iterations using the \\ref OpenFUSIONToolkit.TokaMaker.tokamaker_settings \"settings\" object and \\ref OpenFUSIONToolkit.TokaMaker.TokaMaker.update_settings \"update_settings()\"."
    ]
   },
   {

--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -2453,7 +2453,9 @@ DO i=1,self%maxits
   IF(oft_env%pm)WRITE(*,'(A,I4,6ES12.4)')oft_indent,i,equil%ffp_scale,equil%p_scale, &
     SQRT(nl_res),equil%o_point(1),equil%o_point(2),equil%vcontrol_val/mu0
   !---Check if converged
-  IF((equil%R0_target>0.d0).AND.(i<self%nR0_ramp))CYCLE
+  IF((equil%R0_target>0.d0).AND.(ABS(R0_tmp-equil%R0_target)>1.d-8))CYCLE
+  IF((equil%V0_target>-1.d98).AND.(ABS(V0_tmp-equil%V0_target)>1.d-8))CYCLE
+  ! IF((equil%R0_target>0.d0).AND.(i<self%nR0_ramp))CYCLE
   IF(SQRT(nl_res)<self%nl_tol)EXIT
 end do
 IF(oft_env%pm)CALL oft_decrease_indent

--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -279,7 +279,7 @@ TYPE :: gs_equil
   REAL(r8) :: pax_target = -1.d0 !< On-axis pressure target
   REAL(r8) :: Ip_ratio_target = -1.d99 !< Ip ratio target
   REAL(r8) :: R0_target = -1.d0 !< Magnetic axis radial target
-  REAL(r8) :: V0_target = -1.d99 !< Magnetic axis vertical target
+  REAL(r8) :: Z0_target = -1.d99 !< Magnetic axis vertical target
   REAL(r8) :: plasma_bounds(2) = [-1.d99,1.d99] !< Boundaing \f$ \psi \f$ values on [LCFS, axis]
   REAL(r8) :: o_point(2) = [-1.d0,1.d99] !< Location of magnetic axis
   REAL(r8) :: lim_point(2) = [-1.d0,1.d99] !< Location of limiting point or active X-point
@@ -1041,7 +1041,7 @@ self%estore_target=source%estore_target
 self%pax_target=source%pax_target
 self%Ip_ratio_target=source%Ip_ratio_target
 self%R0_target=source%R0_target
-self%V0_target=source%V0_target
+self%Z0_target=source%Z0_target
 self%plasma_bounds=source%plasma_bounds
 self%o_point=source%o_point
 self%lim_point=source%lim_point
@@ -1997,7 +1997,7 @@ class(oft_vector), pointer :: tmp_vec,psi_ffp,psi_press,psi_vac,psi_vcont,psi_au
 real(r8), pointer, DIMENSION(:) :: vals_tmp
 type(oft_lag_bginterp), target :: psi_geval
 real(8) :: goptmp(3,3),pt(2),v,pmax,pmin,dpnorm,curr
-real(8) :: opoint(2),R0_in,f(3),V0_in,V0_tmp,estored
+real(8) :: opoint(2),R0_in,f(3),Z0_in,Z0_tmp,estored
 REAL(8) :: nl_res,psimax,ffp_scale_in,ffp_scale_prev,itor,pnorm0,pnormp,itor_ffp,itor_press
 REAL(8) :: R0_tmp,R0_hist(2),gpsi0(3),gpsi1(3),gpsi2(3),t0,t1
 REAL(8) :: param_mat(3,3),param_vec(3),param_rhs(3)
@@ -2102,7 +2102,7 @@ nl_res=1.d99
 pnorm0 = equil%p_scale
 pnormp = equil%p_scale
 R0_in = equil%o_point(1)
-V0_in = equil%o_point(2)
+Z0_in = equil%o_point(2)
 cell=0
 IF(equil%R0_target>0.d0)THEN
   IF((equil%estore_target>0.d0).OR.(equil%pax_target>0.d0).OR.(equil%Ip_ratio_target>-1.d98))THEN
@@ -2118,10 +2118,10 @@ IF((equil%pax_target>0.d0).AND.(equil%Ip_ratio_target>-1.d98))THEN
   CALL oft_warn("Conflicting pressure targets specified, ignoring pax_target")
   equil%pax_target=-1.d0
 END IF
-IF(equil%V0_target>-1.d98)THEN
+IF(equil%Z0_target>-1.d98)THEN
   IF(equil%isoflux_ntargets>0.OR.equil%flux_ntargets>0)THEN
-    CALL oft_warn("V0_target and isoflux_targets specified, ignoring V0_target")
-    equil%V0_target=-1.d99
+    CALL oft_warn("Z0_target and isoflux_targets specified, ignoring Z0_target")
+    equil%Z0_target=-1.d99
     equil%vcontrol_val=0.d0
   END IF
 END IF
@@ -2133,9 +2133,9 @@ END IF
 DO i=1,self%maxits
   !---Ramp R0 target
   R0_tmp=(i-1)*(equil%R0_target-R0_in)/REAL(self%nR0_ramp,8) + R0_in
-  V0_tmp=(i-1)*(equil%V0_target-V0_in)/REAL(self%nR0_ramp,8) + V0_in
+  Z0_tmp=(i-1)*(equil%Z0_target-Z0_in)/REAL(self%nR0_ramp,8) + Z0_in
   IF(i>self%nR0_ramp)R0_tmp=equil%R0_target
-  IF(i>self%nR0_ramp)V0_tmp=equil%V0_target
+  IF(i>self%nR0_ramp)Z0_tmp=equil%Z0_target
   !---
   CALL psip%add(0.d0,1.d0,equil%psi)
 
@@ -2178,7 +2178,7 @@ DO i=1,self%maxits
   cell=0
   pt=equil%o_point
   IF(equil%R0_target>0.d0)pt(1)=R0_tmp
-  IF(equil%V0_target>-1.d98)pt(2)=V0_tmp
+  IF(equil%Z0_target>-1.d98)pt(2)=Z0_tmp
   CALL bmesh_findcell(self%fe_rep%mesh,cell,pt,f)
   CALL self%fe_rep%mesh%jacobian(cell,f,goptmp,v)
 
@@ -2233,7 +2233,7 @@ DO i=1,self%maxits
   END IF
 
   !---Add row for vertical control
-  IF(equil%V0_target>-1.d98)THEN
+  IF(equil%Z0_target>-1.d98)THEN
     ! 
     CALL bmesh_findcell(self%fe_rep%mesh,cell,pt,f)
     CALL self%fe_rep%mesh%jacobian(cell,f,goptmp,v)
@@ -2454,7 +2454,7 @@ DO i=1,self%maxits
     SQRT(nl_res),equil%o_point(1),equil%o_point(2),equil%vcontrol_val/mu0
   !---Check if converged
   IF((equil%R0_target>0.d0).AND.(ABS(R0_tmp-equil%R0_target)>1.d-8))CYCLE
-  IF((equil%V0_target>-1.d98).AND.(ABS(V0_tmp-equil%V0_target)>1.d-8))CYCLE
+  IF((equil%Z0_target>-1.d98).AND.(ABS(Z0_tmp-equil%Z0_target)>1.d-8))CYCLE
   ! IF((equil%R0_target>0.d0).AND.(i<self%nR0_ramp))CYCLE
   IF(SQRT(nl_res)<self%nl_tol)EXIT
 end do
@@ -2599,7 +2599,7 @@ END IF
 cell=0
 pt=equil%o_point
 IF(equil%R0_target>0.d0)pt(1)=equil%R0_target
-IF(equil%V0_target>-1.d98)pt(2)=equil%V0_target
+IF(equil%Z0_target>-1.d98)pt(2)=equil%Z0_target
 CALL bmesh_findcell(self%fe_rep%mesh,cell,pt,f)
 CALL self%fe_rep%mesh%jacobian(cell,f,goptmp,v)
 
@@ -2627,7 +2627,7 @@ ELSE
 END IF
 
 !---Add row for vertical control
-IF((equil%V0_target>-1.d98).AND.adjust_r0)THEN
+IF((equil%Z0_target>-1.d98).AND.adjust_r0)THEN
   ! 
   CALL bmesh_findcell(self%fe_rep%mesh,cell,pt,f)
   CALL self%fe_rep%mesh%jacobian(cell,f,goptmp,v)

--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -80,6 +80,18 @@ CONTAINS
   PROCEDURE(flux_cofs_set), DEFERRED :: set_cofs
   !> Get current function parameterization
   PROCEDURE(flux_cofs_get), DEFERRED :: get_cofs
+  !> Save flux function definition to file
+  GENERIC :: save => save_hdf5, save_txt
+  !> Save flux function definition to HDF5 file
+  PROCEDURE(flux_save_hdf5), DEFERRED :: save_hdf5
+  !> Save flux function definition to text file
+  PROCEDURE(flux_save_txt), DEFERRED :: save_txt
+  !> Load flux function definition from file
+  GENERIC :: load => load_hdf5, load_txt
+  !> Load flux function definition from HDF5 file
+  PROCEDURE(flux_load_hdf5), DEFERRED :: load_hdf5
+  !> Load flux function definition from text file
+  PROCEDURE(flux_load_txt), DEFERRED :: load_txt
 END TYPE flux_func
 !------------------------------------------------------------------------------
 !> Internal coil region structure
@@ -414,6 +426,41 @@ abstract interface
     class(flux_func), intent(inout) :: self
     real(r8), intent(out) :: c(:)
   end subroutine flux_cofs_get
+  !------------------------------------------------------------------------------
+  !> Needs Docs
+  !------------------------------------------------------------------------------
+  subroutine flux_save_hdf5(self,filename,path)
+    import flux_func
+    class(flux_func), intent(inout) :: self
+    character(LEN=*), intent(in) :: filename
+    character(LEN=*), intent(in) :: path
+  end subroutine flux_save_hdf5
+  !------------------------------------------------------------------------------
+  !> Needs Docs
+  !------------------------------------------------------------------------------
+  subroutine flux_save_txt(self,io_unit)
+    import flux_func
+    class(flux_func), intent(inout) :: self
+    integer, intent(in) :: io_unit
+  end subroutine flux_save_txt
+  !------------------------------------------------------------------------------
+  !> Needs Docs
+  !------------------------------------------------------------------------------
+  subroutine flux_load_hdf5(self,filename,path,success)
+    import flux_func
+    class(flux_func), intent(inout) :: self
+    character(LEN=*), intent(in) :: filename
+    character(LEN=*), intent(in) :: path
+    logical, intent(out) :: success
+  end subroutine flux_load_hdf5
+  !------------------------------------------------------------------------------
+  !> Needs Docs
+  !------------------------------------------------------------------------------
+  subroutine flux_load_txt(self,io_unit)
+    import flux_func
+    class(flux_func), intent(inout) :: self
+    integer, intent(in) :: io_unit
+  end subroutine flux_load_txt
   !------------------------------------------------------------------------------
   !> Needs Docs
   !------------------------------------------------------------------------------

--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -66,6 +66,8 @@ TYPE, ABSTRACT :: flux_func
   REAL(r8) :: f_offset = 0.d0 !< Offset value
   REAL(r8) :: plasma_bounds(2) = [-1.d99,1.d99] !< Current plasma bounds (for normalization)
 CONTAINS
+  !> Delete profile
+  PROCEDURE(flux_func_delete), DEFERRED :: delete
   !> Copy profile
   PROCEDURE(flux_func_copy), DEFERRED :: copy
   !> Evaluate function
@@ -384,6 +386,13 @@ contains
 end type gsinv_interp
 !---
 abstract interface
+  !------------------------------------------------------------------------------
+  !> Needs Docs
+  !------------------------------------------------------------------------------
+  subroutine flux_func_delete(self)
+    import flux_func
+    class(flux_func), intent(inout) :: self
+  end subroutine flux_func_delete
   !------------------------------------------------------------------------------
   !> Needs Docs
   !------------------------------------------------------------------------------
@@ -5569,7 +5578,6 @@ end subroutine factory_destroy
 !------------------------------------------------------------------------------
 subroutine equil_destroy(self)
 class(gs_equil), intent(inout) :: self !< G-S object
-! integer(i4) :: i,j
 ! IF(ASSOCIATED(self%cond_weights))DEALLOCATE(self%cond_weights)
 IF(ASSOCIATED(self%isoflux_targets))DEALLOCATE(self%isoflux_targets)
 IF(ASSOCIATED(self%saddle_targets))DEALLOCATE(self%saddle_targets)
@@ -5577,7 +5585,7 @@ IF(ASSOCIATED(self%flux_targets))DEALLOCATE(self%flux_targets)
 IF(ASSOCIATED(self%coil_reg_mat))DEALLOCATE(self%coil_reg_mat)
 IF(ASSOCIATED(self%coil_reg_targets))DEALLOCATE(self%coil_reg_targets)
 IF(ASSOCIATED(self%coil_currs))DEALLOCATE(self%coil_currs)
-!---
+!---Destroy solution fields
 IF(ASSOCIATED(self%psi))THEN
   CALL self%psi%delete()
   DEALLOCATE(self%psi)
@@ -5586,9 +5594,24 @@ IF(ASSOCIATED(self%chi))THEN
   CALL self%chi%delete()
   DEALLOCATE(self%chi)
 END IF
-!---
-! Destory I and P in the future
-NULLIFY(self%I,self%P)
+!---Destroy flux functions
+IF(ASSOCIATED(self%I))THEN
+  CALL self%I%delete()
+  DEALLOCATE(self%I)
+END IF
+IF(ASSOCIATED(self%P))THEN
+  CALL self%P%delete()
+  DEALLOCATE(self%P)
+END IF
+IF(ASSOCIATED(self%I_NI))THEN
+  CALL self%I_NI%delete()
+  DEALLOCATE(self%I_NI)
+END IF
+IF(ASSOCIATED(self%eta))THEN
+  CALL self%eta%delete()
+  DEALLOCATE(self%eta)
+END IF
+! TODO: Destroy P_ani
 end subroutine equil_destroy
 !------------------------------------------------------------------------------
 !> Compute boundary condition matrix for free-boundary case

--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -158,6 +158,7 @@ end type gs_ani_press
 TYPE :: gs_factory
   INTEGER(i4) :: ierr = 0 !< Error flag from most recent solve
   INTEGER(i4) :: maxits = 30 !< Maximum number of iterations for nonlinear solve
+  INTEGER(i4) :: nl_its = 0 !< Number of nonlinear iterations to converge most recent solve
   INTEGER(i4) :: nR0_ramp = 6 !< Number of iterations for R0 ramp if R0 target is used
   INTEGER(i4) :: ncoils = 0 !< Number of coils in device
   INTEGER(i4) :: ncoils_ext = 0 !< Number of external (non-meshed) coils in device
@@ -2016,6 +2017,7 @@ CHARACTER(LEN=40) :: err_reason
 logical :: pm_save,fail_test
 !---
 error_flag=0
+self%nl_its=0
 IF(TRIM(self%lu_solver%package)=='none')THEN
   CALL oft_abort("LU solver required for GS solve","gs_solve",__FILE__)
 ELSE
@@ -2469,6 +2471,11 @@ DO i=1,self%maxits
 end do
 IF(oft_env%pm)CALL oft_decrease_indent
 IF(i>self%maxits)error_flag=-1
+IF(error_flag==0)THEN
+  self%nl_its=i
+ELSE
+  self%nl_its=-i
+END IF
 !---Output
 IF(self%save_visit.AND.self%plot_final)THEN
   eq_count=eq_count+1

--- a/src/physics/grad_shaf_fit.F90
+++ b/src/physics/grad_shaf_fit.F90
@@ -326,7 +326,7 @@ ELSE IF(gs_active%estore_target>0.d0)THEN
   offset=offset+1
 END IF
 IF(fit_V0)THEN
-  cofs(offset+1)=gs_active%V0_target
+  cofs(offset+1)=gs_active%Z0_target
   cofs_scale(offset+1)=40.d0/(gs_active%device%spatial_bounds(2,2)-gs_active%device%spatial_bounds(1,2))
   offset=offset+1
 END IF
@@ -646,7 +646,7 @@ IF(iflag==1)THEN
     offset=offset+1
   END IF
   IF(fit_V0)THEN
-    gs_active%V0_target=cofs(offset+1)
+    gs_active%Z0_target=cofs(offset+1)
     offset=offset+1
   END IF
   IF(gs_active%P%ncofs>0.AND.fit_P)THEN
@@ -731,8 +731,8 @@ IF(iflag==1)THEN
     IF(gs_active%R0_target>0.d0)THEN
       WRITE(*,'(2A,ES11.3)')oft_indent,'R0_target         =',gs_active%R0_target
     END IF
-    IF(gs_active%V0_target>-1.d98)THEN
-      WRITE(*,'(2A,ES11.3)')oft_indent,'V0_target         =',gs_active%V0_target
+    IF(gs_active%Z0_target>-1.d98)THEN
+      WRITE(*,'(2A,ES11.3)')oft_indent,'Z0_target         =',gs_active%Z0_target
     END IF
     IF(gs_active%device%free)THEN
       IF(fit_FFPscale)THEN
@@ -905,10 +905,10 @@ ELSE
   IF(fit_V0)THEN
     CALL reset_eq
     dx = 50.0*dxi/cofs_scale(offset+1)
-    gs_active%V0_target=cofs(offset+1) + dx
+    gs_active%Z0_target=cofs(offset+1) + dx
     CALL run_err(.FALSE.,jac_mat(:,offset+1),m,ierr)
     jac_mat(:,offset+1)=(jac_mat(:,offset+1)-err)/dx
-    gs_active%V0_target=cofs(offset+1)
+    gs_active%Z0_target=cofs(offset+1)
     offset=offset+1
   END IF
   IF(gs_active%P%ncofs>0.AND.fit_P)THEN
@@ -1050,7 +1050,7 @@ READ(io_unit,*)n
 !---
 ncons=n
 IF(fit_coils)ncons=n+gs_active%device%ncoils
-! IF(gs_active%V0_target>-1.d98)ncons=ncons+1
+! IF(gs_active%Z0_target>-1.d98)ncons=ncons+1
 ALLOCATE(cons(ncons))
 j=1
 !---
@@ -1064,7 +1064,7 @@ IF(fit_coils)THEN
     j=j+1
   END DO
 END IF
-! IF(gs_active%V0_target>-1.d98)THEN
+! IF(gs_active%Z0_target>-1.d98)THEN
 !   ALLOCATE(vcont_constraint::cons(j)%con)
 !   cons(j)%con%val=0.d0
 !   cons(j)%con%wt=2.d-8

--- a/src/physics/grad_shaf_fit.F90
+++ b/src/physics/grad_shaf_fit.F90
@@ -196,7 +196,7 @@ LOGICAL, PRIVATE :: fit_P = .TRUE. !< Needs docs
 LOGICAL, PRIVATE :: fit_Pscale = .TRUE. !< Needs docs
 LOGICAL, PRIVATE :: fit_FFPscale = .FALSE. !< Needs docs
 LOGICAL, PRIVATE :: fit_R0 = .FALSE. !< Needs docs
-LOGICAL, PRIVATE :: fit_V0 = .FALSE. !< Needs docs
+LOGICAL, PRIVATE :: fit_Z0 = .FALSE. !< Needs docs
 LOGICAL, PRIVATE :: fit_coils = .FALSE. !< Needs docs
 LOGICAL, PRIVATE :: fit_F0 = .FALSE. !< Needs docs
 LOGICAL, PRIVATE :: fixed_centering = .FALSE. !< Needs docs
@@ -209,7 +209,7 @@ CONTAINS
 !---------------------------------------------------------------------------------
 !> Needs Docs
 !---------------------------------------------------------------------------------
-SUBROUTINE fit_gs(gs,inpath,outpath,fitI,fitP,fit_p_scale,fit_ffp_scale,fitR0,fitV0,fitCoils,fitF0,fixedCentering)
+SUBROUTINE fit_gs(gs,inpath,outpath,fitI,fitP,fit_p_scale,fit_ffp_scale,fitR0,fitZ0,fitCoils,fitF0,fixedCentering)
 TYPE(gs_equil), TARGET, INTENT(inout) :: gs !< Needs docs
 CHARACTER(LEN=*), INTENT(in) :: inpath !< Needs docs
 CHARACTER(LEN=*), INTENT(in) :: outpath !< Needs docs
@@ -218,7 +218,7 @@ LOGICAL, OPTIONAL, INTENT(in) :: fitP !< Needs docs
 LOGICAL, OPTIONAL, INTENT(in) :: fit_p_scale !< Needs docs
 LOGICAL, OPTIONAL, INTENT(in) :: fit_ffp_scale !< Needs docs
 LOGICAL, OPTIONAL, INTENT(in) :: fitR0 !< Needs docs
-LOGICAL, OPTIONAL, INTENT(in) :: fitV0 !< Needs docs
+LOGICAL, OPTIONAL, INTENT(in) :: fitZ0 !< Needs docs
 LOGICAL, OPTIONAL, INTENT(in) :: fitCoils !< Needs docs
 LOGICAL, OPTIONAL, INTENT(in) :: fitF0 !< Needs docs
 LOGICAL, OPTIONAL, INTENT(in) :: fixedCentering !< Needs docs
@@ -241,8 +241,8 @@ fit_FFPscale = .FALSE.
 IF(PRESENT(fit_ffp_scale))fit_FFPscale=fit_ffp_scale
 fit_R0 = .FALSE.
 IF(PRESENT(fitR0))fit_R0=fitR0
-fit_V0 = .FALSE.
-IF(PRESENT(fitV0))fit_V0=fitV0
+fit_Z0 = .FALSE.
+IF(PRESENT(fitZ0))fit_Z0=fitZ0
 fit_coils = .FALSE.
 IF(PRESENT(fitCoils))fit_coils=fitCoils
 fit_F0 = .FALSE.
@@ -277,7 +277,7 @@ IF(gs_active%I%ncofs>0.AND.fit_I)THEN
   ncofs = ncofs+gs_active%I%ncofs
 END IF
 IF(fit_Pscale.OR.fit_R0)ncofs = ncofs+1
-IF(fit_V0)ncofs = ncofs + 1
+IF(fit_Z0)ncofs = ncofs + 1
 IF(gs_active%P%ncofs>0.AND.fit_P)THEN
   ncofs = ncofs+gs_active%P%ncofs
 END IF
@@ -325,7 +325,7 @@ ELSE IF(gs_active%estore_target>0.d0)THEN
   cofs_scale(offset+1)=1.d0/MAX(gs_active%estore_target,1.d-2)
   offset=offset+1
 END IF
-IF(fit_V0)THEN
+IF(fit_Z0)THEN
   cofs(offset+1)=gs_active%Z0_target
   cofs_scale(offset+1)=40.d0/(gs_active%device%spatial_bounds(2,2)-gs_active%device%spatial_bounds(1,2))
   offset=offset+1
@@ -645,7 +645,7 @@ IF(iflag==1)THEN
     gs_active%estore_target=cofs(offset+1)
     offset=offset+1
   END IF
-  IF(fit_V0)THEN
+  IF(fit_Z0)THEN
     gs_active%Z0_target=cofs(offset+1)
     offset=offset+1
   END IF
@@ -759,7 +759,7 @@ IF(iflag==1)THEN
       offset = je
     END IF
     IF(fit_Pscale.OR.fit_R0.OR.(gs_active%estore_target>0.d0))offset=offset+1
-    IF(fit_V0)offset=offset+1
+    IF(fit_Z0)offset=offset+1
     IF(gs_active%P%ncofs>0.AND.fit_P)THEN
       js = offset; je = offset+gs_active%P%ncofs
       WRITE(*,'(2A)',ADVANCE="NO")oft_indent,'P_cofs            ='
@@ -902,7 +902,7 @@ ELSE
     gs_active%estore_target=cofs(offset+1)
     offset=offset+1
   END IF
-  IF(fit_V0)THEN
+  IF(fit_Z0)THEN
     CALL reset_eq
     dx = 50.0*dxi/cofs_scale(offset+1)
     gs_active%Z0_target=cofs(offset+1) + dx

--- a/src/physics/grad_shaf_prof_phys.F90
+++ b/src/physics/grad_shaf_prof_phys.F90
@@ -12,6 +12,7 @@
 !! @ingroup doxy_oft_physics
 !------------------------------------------------------------------------------
 module grad_shaf_prof_phys
+USE oft_io, only: hdf5_write, hdf5_read, hdf5_field_exist
 use oft_base
 use oft_mesh_type, only: oft_bmesh, bmesh_findcell
 USE oft_la_base, ONLY: oft_vector
@@ -57,6 +58,12 @@ type, extends(linterp_flux_func) :: jphi_flux_func
   real(8), pointer, dimension(:) :: jphi => NULL() !< Jphi(psi) profile values
 contains
   !> Needs docs
+  procedure :: save_hdf5 => jphi_save_hdf5
+  procedure :: save_txt => jphi_save_txt
+  !> Needs docs
+  procedure :: load_hdf5 => jphi_load_hdf5
+  procedure :: load_txt => jphi_load_txt
+  !> Needs docs
   procedure :: copy => jphi_copy
   !> Update F*F' profile from Jphi, P', and current equilibrium
   procedure :: update => jphi_update
@@ -77,6 +84,12 @@ end type minbinv_interp
 type, extends(spline_flux_func) :: dipole_b0_flux_func
   real(r8) :: psi_pad = 1.d-1
 contains
+  !> Needs docs
+  procedure :: save_hdf5 => dipole_b0_save_hdf5
+  procedure :: save_txt => dipole_b0_save_txt
+  !> Needs docs
+  procedure :: load_hdf5 => dipole_b0_load_hdf5
+  procedure :: load_txt => dipole_b0_load_txt
   !> Needs docs
   procedure :: copy => dipole_b0_copy
   !> Needs docs
@@ -108,6 +121,12 @@ end type dipole_ani_press
 type, extends(spline_flux_func) :: mirror_b0_flux_func
   real(r8) :: z_midplane = 0.d0 !< Z location of mirror midplane
 contains
+  !> Needs docs
+  procedure :: save_hdf5 => mirror_b0_save_hdf5
+  procedure :: save_txt => mirror_b0_save_txt
+  !> Needs docs
+  procedure :: load_hdf5 => mirror_b0_load_hdf5
+  procedure :: load_txt => mirror_b0_load_txt
   !> Needs docs
   procedure :: copy => mirror_b0_copy
   !> Needs docs
@@ -352,16 +371,79 @@ val(3:8)=val(3:8)*val(2)
 deallocate(j)
 end subroutine minterpinv_apply
 !------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine jphi_save_hdf5(self,filename,path)
+class(jphi_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+IF(.NOT.hdf5_field_exist(filename,path//'/TYPE'))CALL hdf5_write('jphi',filename,path//'/TYPE')
+CALL hdf5_write(self%npsi,filename,path//'/NPSI')
+CALL hdf5_write(self%x,filename,path//'/XVALS')
+CALL hdf5_write(self%jphi,filename,path//'/YVALS')
+CALL hdf5_write(self%j0,filename,path//'/J0')
+end subroutine jphi_save_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine jphi_save_txt(self,io_unit)
+class(jphi_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+WRITE(io_unit,*)'jphi'
+WRITE(io_unit,*)self%npsi,self%j0
+WRITE(io_unit,*)self%x
+WRITE(io_unit,*)self%jphi
+end subroutine jphi_save_txt
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine jphi_load_hdf5(self,filename,path,success)
+class(jphi_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+logical, intent(out) :: success
+integer(i4) :: npsi
+real(r8) :: J0
+real(r8), allocatable :: xvals(:),yvals(:)
+CALL hdf5_read(npsi,filename,path//'/NPSI',success=success)
+IF(.NOT.success)RETURN
+ALLOCATE(xvals(npsi),yvals(npsi))
+CALL hdf5_read(xvals,filename,path//'/XVALS',success=success)
+IF(.NOT.success)RETURN
+CALL hdf5_read(yvals,filename,path//'/YVALS',success=success)
+IF(.NOT.success)RETURN
+CALL hdf5_read(J0,filename,path//'/J0',success=success)
+IF(.NOT.success)RETURN
+CALL create_jphi_ff(self,npsi,xvals,yvals,J0)
+DEALLOCATE(xvals,yvals)
+end subroutine jphi_load_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine jphi_load_txt(self,io_unit)
+class(jphi_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+integer(i4) :: npsi
+real(r8) :: J0
+real(r8), allocatable :: xvals(:),yvals(:)
+READ(io_unit,*)npsi,J0
+ALLOCATE(xvals(npsi),yvals(npsi))
+READ(io_unit,*)xvals
+READ(io_unit,*)yvals
+CALL create_jphi_ff(self,npsi,xvals,yvals,J0)
+DEALLOCATE(xvals,yvals)
+end subroutine jphi_load_txt
+!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_jphi_ff(func,npsi,psivals,yvals,y0)
-CLASS(flux_func), POINTER, INTENT(out) :: func
+CLASS(flux_func), INTENT(inout) :: func
 INTEGER(4), INTENT(in) :: npsi
 REAL(8), INTENT(in) :: psivals(npsi)
 REAL(8), INTENT(in) :: yvals(npsi)
 REAL(8), INTENT(in) :: y0
 INTEGER(4) :: i,ierr
-ALLOCATE(jphi_flux_func::func)
+! IF(.NOT.ASSOCIATED(func))ALLOCATE(jphi_flux_func::func)
 SELECT TYPE(self=>func)
   TYPE IS(jphi_flux_func)
   !---
@@ -383,6 +465,8 @@ SELECT TYPE(self=>func)
   self%yp = self%yp/(SUM(ABS(self%yp))/REAL(self%npsi,8)) ! Consistent (hopefully) normalization
   ierr=self%set_cofs(self%yp)
   IF(oft_debug_print(1))WRITE(*,*)'Jphi linear interpolator Created',self%ncofs,self%x,self%j0
+class default
+  CALL oft_abort('Invalid flux function type in create_jphi_ff','create_jphi_ff',__FILE__)
 END SELECT
 
 END SUBROUTINE create_jphi_ff
@@ -504,10 +588,9 @@ END SUBROUTINE gs_flux_int
 !> Needs Docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_dipole_b0_prof(func,npsi)
-CLASS(flux_func), POINTER, INTENT(out) :: func
+CLASS(flux_func), INTENT(inout) :: func
 INTEGER(4), INTENT(in) :: npsi
 INTEGER(4) :: i
-ALLOCATE(dipole_b0_flux_func::func)
 select type(self=>func)
   type is(dipole_b0_flux_func)
     !---
@@ -517,8 +600,56 @@ select type(self=>func)
     DO i=1,omp_get_max_threads()
       CALL spline_alloc(self%fun_loc(i),self%npsi,1)
     END DO
+class default
+  CALL oft_abort('Invalid flux function type in create_dipole_b0_prof','create_dipole_b0_prof',__FILE__)
 end select
 END SUBROUTINE create_dipole_b0_prof
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine dipole_b0_save_hdf5(self,filename,path)
+class(dipole_b0_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+IF(.NOT.hdf5_field_exist(filename,path//'/TYPE'))CALL hdf5_write('dipole_b0',filename,path//'/TYPE')
+CALL hdf5_write(self%npsi,filename,path//'/NPSI')
+CALL hdf5_write(self%psi_pad,filename,path//'/PSI_PAD')
+end subroutine dipole_b0_save_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine dipole_b0_save_txt(self,io_unit)
+class(dipole_b0_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+WRITE(io_unit,*)'dipole_b0'
+WRITE(io_unit,*)self%npsi,self%psi_pad
+end subroutine dipole_b0_save_txt
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine dipole_b0_load_hdf5(self,filename,path,success)
+class(dipole_b0_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+logical, intent(out) :: success
+integer(i4) :: npsi
+real(r8), allocatable :: xvals(:),yvals(:)
+CALL hdf5_read(npsi,filename,path//'/NPSI',success=success)
+IF(.NOT.success)RETURN
+CALL hdf5_read(self%psi_pad,filename,path//'/PSI_PAD',success=success)
+IF(.NOT.success)RETURN
+CALL create_dipole_b0_prof(self,npsi)
+end subroutine dipole_b0_load_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine dipole_b0_load_txt(self,io_unit)
+class(dipole_b0_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+integer(i4) :: npsi
+READ(io_unit,*)npsi,self%psi_pad
+CALL create_dipole_b0_prof(self,npsi)
+end subroutine dipole_b0_load_txt
 !------------------------------------------------------------------------------
 !> Needs Docs
 !------------------------------------------------------------------------------
@@ -695,6 +826,7 @@ ALLOCATE(self%psi_eval,self%psi_geval)
 self%psi_eval%u=>self%gs%psi
 CALL self%psi_eval%setup(self%gs%device%fe_rep)
 CALL self%psi_geval%shared_setup(self%psi_eval)
+ALLOCATE(dipole_b0_flux_func::self%B0_prof)
 CALL create_dipole_b0_prof(self%B0_prof,64)
 end subroutine dipole_ani_setup
 !------------------------------------------------------------------------------
@@ -749,10 +881,10 @@ end subroutine dipole_ani_apply
 !> Needs Docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_mirror_b0_prof(func,npsi)
-CLASS(flux_func), POINTER, INTENT(out) :: func
+CLASS(flux_func), INTENT(inout) :: func
 INTEGER(4), INTENT(in) :: npsi
 INTEGER(4) :: i
-ALLOCATE(mirror_b0_flux_func::func)
+! IF(.NOT.ASSOCIATED(func))ALLOCATE(mirror_b0_flux_func::func)
 select type(self=>func)
   type is(mirror_b0_flux_func)
     !---
@@ -762,8 +894,58 @@ select type(self=>func)
     DO i=1,omp_get_max_threads()
       CALL spline_alloc(self%fun_loc(i),self%npsi,1)
     END DO
+class default
+  CALL oft_abort('Invalid flux function type in create_mirror_b0_prof','create_mirror_b0_prof',__FILE__)
 end select
 END SUBROUTINE create_mirror_b0_prof
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine mirror_b0_save_hdf5(self,filename,path)
+class(mirror_b0_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+IF(.NOT.hdf5_field_exist(filename,path//'/TYPE'))CALL hdf5_write('mirror_b0',filename,path//'/TYPE')
+CALL hdf5_write(self%npsi,filename,path//'/NPSI')
+CALL hdf5_write(self%z_midplane,filename,path//'/Z_MIDPLANE')
+end subroutine mirror_b0_save_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine mirror_b0_save_txt(self,io_unit)
+class(mirror_b0_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+WRITE(io_unit,*)'mirror_b0'
+WRITE(io_unit,*)self%npsi
+WRITE(io_unit,*)self%z_midplane
+end subroutine mirror_b0_save_txt
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine mirror_b0_load_hdf5(self,filename,path,success)
+class(mirror_b0_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+logical, intent(out) :: success
+integer(i4) :: npsi
+real(r8), allocatable :: xvals(:),yvals(:)
+CALL hdf5_read(npsi,filename,path//'/NPSI',success=success)
+IF(.NOT.success)RETURN
+CALL hdf5_read(self%z_midplane,filename,path//'/Z_MIDPLANE',success=success)
+IF(.NOT.success)RETURN
+CALL create_mirror_b0_prof(self,npsi)
+end subroutine mirror_b0_load_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine mirror_b0_load_txt(self,io_unit)
+class(mirror_b0_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+integer(i4) :: npsi
+READ(io_unit,*)npsi
+READ(io_unit,*)self%z_midplane
+CALL create_mirror_b0_prof(self,npsi)
+end subroutine mirror_b0_load_txt
 !------------------------------------------------------------------------------
 !> Needs Docs
 !------------------------------------------------------------------------------
@@ -873,6 +1055,7 @@ ALLOCATE(self%psi_eval,self%psi_geval)
 self%psi_eval%u=>self%gs%psi
 CALL self%psi_eval%setup(self%gs%device%fe_rep)
 CALL self%psi_geval%shared_setup(self%psi_eval)
+ALLOCATE(mirror_b0_flux_func::self%B0_prof)
 CALL create_mirror_b0_prof(self%B0_prof,64)
 end subroutine mirror_slosh_setup
 !------------------------------------------------------------------------------

--- a/src/physics/grad_shaf_prof_phys.F90
+++ b/src/physics/grad_shaf_prof_phys.F90
@@ -23,7 +23,8 @@ use oft_gs, only: gs_equil, flux_func, gs_psi2r, gs_itor_nl, oft_indent, &
   oft_increase_indent, oft_decrease_indent, gsinv_interp, gs_prof_interp, &
   gs_get_qprof, gs_ani_press, gs_epsilon
 use tracing_2d, only: set_tracer, active_tracer, tracinginv_fs
-use oft_gs_profiles, only: spline_flux_func, linterp_flux_func, linterp_copy, spline_func_copy
+use oft_gs_profiles, only: spline_flux_func, linterp_flux_func, linterp_copy, &
+  spline_func_copy, spline_func_delete
 use spline_mod
 USE mhd_utils, ONLY: mu0
 implicit none
@@ -47,6 +48,8 @@ contains
   !> Needs docs
   procedure :: copy => mercier_copy
   !> Needs docs
+  procedure :: delete => mercier_delete
+  !> Needs docs
   procedure :: update => mercier_update
 end type mercier_flux_func
 !------------------------------------------------------------------------------
@@ -65,6 +68,8 @@ contains
   procedure :: load_txt => jphi_load_txt
   !> Needs docs
   procedure :: copy => jphi_copy
+  !> Needs docs
+  procedure :: delete => jphi_delete
   !> Update F*F' profile from Jphi, P', and current equilibrium
   procedure :: update => jphi_update
 end type jphi_flux_func
@@ -92,6 +97,8 @@ contains
   procedure :: load_txt => dipole_b0_load_txt
   !> Needs docs
   procedure :: copy => dipole_b0_copy
+  !> Needs docs
+  procedure :: delete => dipole_b0_delete
   !> Needs docs
   procedure :: update => dipole_b0_update
 end type dipole_b0_flux_func
@@ -129,6 +136,8 @@ contains
   procedure :: load_txt => mirror_b0_load_txt
   !> Needs docs
   procedure :: copy => mirror_b0_copy
+  !> Needs docs
+  procedure :: delete => mirror_b0_delete
   !> Needs docs
   procedure :: update => mirror_b0_update
 end type mirror_b0_flux_func
@@ -193,6 +202,14 @@ SELECT TYPE(new)
     CALL spline_copy(self%funcp,new%funcp)
 END SELECT
 end subroutine mercier_copy
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine mercier_delete(self)
+class(mercier_flux_func), intent(inout) :: self
+IF(ASSOCIATED(self%fun_loc))CALL spline_dealloc(self%funcp)
+CALL spline_func_delete(self)
+end subroutine mercier_delete
 !------------------------------------------------------------------------------
 !> Needs Docs
 !------------------------------------------------------------------------------
@@ -487,6 +504,17 @@ SELECT TYPE(new)
 END SELECT
 end subroutine jphi_copy
 !------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine jphi_delete(self)
+class(jphi_flux_func), intent(inout) :: self
+self%j0=0.d0
+IF(ASSOCIATED(self%jphi))DEALLOCATE(self%jphi)
+IF(ASSOCIATED(self%x))DEALLOCATE(self%x)
+IF(ASSOCIATED(self%yp))DEALLOCATE(self%yp)
+IF(ASSOCIATED(self%y))DEALLOCATE(self%y)
+end subroutine jphi_delete
+!------------------------------------------------------------------------------
 !> Update F*F' profile from Jphi, P', and current equilibrium
 !------------------------------------------------------------------------------
 subroutine jphi_update(self,gseq)
@@ -664,6 +692,14 @@ SELECT TYPE(new)
     new%psi_pad=self%psi_pad
 END SELECT
 end subroutine dipole_b0_copy
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine dipole_b0_delete(self)
+class(dipole_b0_flux_func), intent(inout) :: self
+integer(i4) :: i
+CALL spline_func_delete(self)
+end subroutine dipole_b0_delete
 !------------------------------------------------------------------------------
 !> Needs Docs
 !------------------------------------------------------------------------------
@@ -960,6 +996,14 @@ SELECT TYPE(new)
     new%z_midplane = self%z_midplane
 END SELECT
 end subroutine mirror_b0_copy
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine mirror_b0_delete(self)
+class(mirror_b0_flux_func), intent(inout) :: self
+integer(i4) :: i
+CALL spline_func_delete(self)
+end subroutine mirror_b0_delete
 !------------------------------------------------------------------------------
 !> Needs Docs
 !------------------------------------------------------------------------------

--- a/src/physics/grad_shaf_prof_phys.F90
+++ b/src/physics/grad_shaf_prof_phys.F90
@@ -394,7 +394,7 @@ subroutine jphi_save_hdf5(self,filename,path)
 class(jphi_flux_func), intent(inout) :: self
 character(LEN=*), intent(in) :: filename
 character(LEN=*), intent(in) :: path
-IF(.NOT.hdf5_field_exist(filename,path//'/TYPE'))CALL hdf5_write('jphi',filename,path//'/TYPE')
+IF(.NOT.hdf5_field_exist(filename,path//'/TYPE'))CALL hdf5_write('jphi-linterp',filename,path//'/TYPE')
 CALL hdf5_write(self%npsi,filename,path//'/NPSI')
 CALL hdf5_write(self%x,filename,path//'/XVALS')
 CALL hdf5_write(self%jphi,filename,path//'/YVALS')
@@ -406,7 +406,7 @@ end subroutine jphi_save_hdf5
 subroutine jphi_save_txt(self,io_unit)
 class(jphi_flux_func), intent(inout) :: self
 integer, intent(in) :: io_unit
-WRITE(io_unit,*)'jphi'
+WRITE(io_unit,*)'jphi-linterp'
 WRITE(io_unit,*)self%npsi,self%j0
 WRITE(io_unit,*)self%x
 WRITE(io_unit,*)self%jphi

--- a/src/physics/grad_shaf_profiles.F90
+++ b/src/physics/grad_shaf_profiles.F90
@@ -792,6 +792,7 @@ IF(ASSOCIATED(self%fun_loc))THEN
   DO i=1,omp_get_max_threads()
     CALL spline_dealloc(self%fun_loc(i))
   END DO
+  DEALLOCATE(self%fun_loc)
 END IF
 end subroutine spline_func_delete
 !------------------------------------------------------------------------------

--- a/src/physics/grad_shaf_profiles.F90
+++ b/src/physics/grad_shaf_profiles.F90
@@ -204,6 +204,7 @@ character(LEN=*), intent(in) :: filename
 character(LEN=*), intent(in) :: path
 logical, intent(out) :: success
 self%ncofs=0
+success=.TRUE.
 end subroutine zero_load_hdf5
 !------------------------------------------------------------------------------
 !> Needs Docs
@@ -291,6 +292,7 @@ character(LEN=*), intent(in) :: filename
 character(LEN=*), intent(in) :: path
 logical, intent(out) :: success
 self%ncofs=0
+success=.TRUE.
 end subroutine flat_load_hdf5
 !------------------------------------------------------------------------------
 !> Needs Docs

--- a/src/physics/grad_shaf_profiles.F90
+++ b/src/physics/grad_shaf_profiles.F90
@@ -34,6 +34,12 @@ contains
   procedure :: set_cofs => zero_cofs_update
   !> Needs docs
   procedure :: get_cofs => zero_cofs_get
+  !> Needs docs
+  procedure :: save_hdf5 => zero_save_hdf5
+  procedure :: save_txt => zero_save_txt
+  !> Needs docs
+  procedure :: load_hdf5 => zero_load_hdf5
+  procedure :: load_txt => zero_load_txt
 end type zero_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
@@ -52,24 +58,13 @@ contains
   procedure :: set_cofs => flat_cofs_update
   !> Needs docs
   procedure :: get_cofs => flat_cofs_get
+  !> Needs docs
+  procedure :: save_hdf5 => flat_save_hdf5
+  procedure :: save_txt => flat_save_txt
+  !> Needs docs
+  procedure :: load_hdf5 => flat_load_hdf5
+  procedure :: load_txt => flat_load_txt
 end type flat_flux_func
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! type, extends(flux_func) :: linear_flux_func
-!   real(8) :: alpha = 0.d0 !< Slope parameter
-! contains
-!   !> Needs docs
-!   procedure :: f => linear_f
-!   !> Needs docs
-!   procedure :: fp => linear_fp
-!   !> Needs docs
-!   procedure :: update => linear_update
-!   !> Needs docs
-!   procedure :: set_cofs => linear_cofs_update
-!   !> Needs docs
-!   procedure :: get_cofs => linear_cofs_get
-! end type linear_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -91,6 +86,12 @@ contains
   procedure :: set_cofs => poly_cofs_update
   !> Needs docs
   procedure :: get_cofs => poly_cofs_get
+  !> Needs docs
+  procedure :: save_hdf5 => poly_save_hdf5
+  procedure :: save_txt => poly_save_txt
+  !> Needs docs
+  procedure :: load_hdf5 => poly_load_hdf5
+  procedure :: load_txt => poly_load_txt
 end type poly_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
@@ -118,6 +119,12 @@ contains
   procedure :: set_cofs => spline_cofs_update
   !> Needs docs
   procedure :: get_cofs => spline_cofs_get
+  !> Needs docs
+  procedure :: save_hdf5 => spline_save_hdf5
+  procedure :: save_txt => spline_save_txt
+  !> Needs docs
+  procedure :: load_hdf5 => spline_load_hdf5
+  procedure :: load_txt => spline_load_txt
 end type spline_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
@@ -143,45 +150,13 @@ contains
   procedure :: set_cofs => linterp_cofs_update
   !> Needs docs
   procedure :: get_cofs => linterp_cofs_get
+  !> Needs docs
+  procedure :: save_hdf5 => linterp_save_hdf5
+  procedure :: save_txt => linterp_save_txt
+  !> Needs docs
+  procedure :: load_hdf5 => linterp_load_hdf5
+  procedure :: load_txt => linterp_load_txt
 end type linterp_flux_func
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! type, extends(flux_func) :: twolam_flux_func
-!   real(8) :: alpha = 0.d0 !< Jump height
-!   real(8) :: sep = .5d0 !< Jump location (poloidal flux)
-!   real(8) :: width = 200.d0 !< Width factor for TANH
-! contains
-!   !> Needs docs
-!   procedure :: f => twolam_f
-!   !> Needs docs
-!   procedure :: fp => twolam_fp
-!   !> Needs docs
-!   procedure :: update => twolam_update
-!   !> Needs docs
-!   procedure :: set_cofs => twolam_cofs_update
-!   !> Needs docs
-!   procedure :: get_cofs => twolam_cofs_get
-! end type twolam_flux_func
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! type, extends(twolam_flux_func) :: stepslant_flux_func
-!   real(8) :: beta = 0.d0
-! contains
-!   !> Needs docs
-!   procedure :: f => stepslant_f
-!   !> Needs docs
-!   procedure :: fp => stepslant_fp
-!   !> Needs docs
-!   procedure :: update => stepslant_update
-!   !> Needs docs
-!   procedure :: set_cofs => stepslant_cofs_update
-!   !> Needs docs
-!   procedure :: get_cofs => stepslant_cofs_get
-! end type stepslant_flux_func
-!------------------------------------------------------------------------------
-! CLASS wesson_flux_func
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -194,8 +169,48 @@ contains
   procedure :: update => wesson_update
   procedure :: set_cofs => wesson_cofs_update
   procedure :: get_cofs => wesson_cofs_get
+  !> Needs docs
+  procedure :: save_hdf5 => wesson_save_hdf5
+  procedure :: save_txt => wesson_save_txt
+  !> Needs docs
+  procedure :: load_hdf5 => wesson_load_hdf5
+  procedure :: load_txt => wesson_load_txt
 end type wesson_flux_func
 contains
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine zero_save_hdf5(self,filename,path)
+class(zero_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+end subroutine zero_save_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine zero_save_txt(self,io_unit)
+class(zero_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+WRITE(io_unit,*)'zero'
+end subroutine zero_save_txt
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine zero_load_hdf5(self,filename,path,success)
+class(zero_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+logical, intent(out) :: success
+self%ncofs=0
+end subroutine zero_load_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine zero_load_txt(self,io_unit)
+class(zero_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+self%ncofs=0
+end subroutine zero_load_txt
 !------------------------------------------------------------------------------
 !> Needs Docs
 !------------------------------------------------------------------------------
@@ -249,11 +264,45 @@ class(zero_flux_func), intent(inout) :: self
 real(8), intent(out) :: c(:)
 end subroutine zero_cofs_get
 !------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine flat_save_hdf5(self,filename,path)
+class(flat_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+end subroutine flat_save_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine flat_save_txt(self,io_unit)
+class(flat_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+WRITE(io_unit,*)'flat'
+end subroutine flat_save_txt
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine flat_load_hdf5(self,filename,path,success)
+class(flat_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+logical, intent(out) :: success
+self%ncofs=0
+end subroutine flat_load_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine flat_load_txt(self,io_unit)
+class(flat_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+self%ncofs=0
+end subroutine flat_load_txt
+!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_flat_f(func)
-CLASS(flux_func), POINTER, INTENT(out) :: func
-ALLOCATE(flat_flux_func::func)
+CLASS(flux_func), POINTER, INTENT(inout) :: func
+IF(.NOT.ASSOCIATED(func))ALLOCATE(flat_flux_func::func)
 select type(self=>func)
   type is(flat_flux_func)
     self%ncofs=0
@@ -332,101 +381,80 @@ subroutine flat_cofs_get(self,c)
 class(flat_flux_func), intent(inout) :: self
 real(8), intent(out) :: c(:)
 end subroutine flat_cofs_get
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! SUBROUTINE create_linear_ff(func,alpha)
-! CLASS(flux_func), POINTER, INTENT(out) :: func
-! REAL(8), INTENT(in) :: alpha
-! ALLOCATE(linear_flux_func::func)
-! select type(self=>func)
-!   type is(linear_flux_func)
-!     self%ncofs=1
-!     self%alpha=alpha
-! end select
-! END SUBROUTINE create_linear_ff
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! function linear_f(self,psi) result(b)
-! class(linear_flux_func), intent(inout) :: self
-! real(8), intent(in) :: psi
-! real(8) :: b,x1,x2
-! IF(self%plasma_bounds(1)<-1.d98)THEN
-!   b=self%alpha*(psi**2 - psi) + psi
-!   RETURN
-! END IF
-! x1=self%plasma_bounds(1)
-! x2=self%plasma_bounds(2)
-! IF(psi>x1)THEN
-!   b = psi*(self%alpha*(psi - 2.d0*x1 - (x2-x1)) + (x2-x1))/(x2-x1) &
-!   - x1*(self%alpha*(x1 - 2.d0*x1 - (x2-x1)) + (x2-x1))/(x2-x1)
-! ELSE
-!   b = 0.d0
-! END IF
-! end function linear_f
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! function linear_fp(self,psi) result(b)
-! class(linear_flux_func), intent(inout) :: self
-! real(8), intent(in) :: psi
-! real(8) :: b,x1,x2
-! IF(self%plasma_bounds(1)<-1.d98)THEN
-!   b=1.d0 + self%alpha*(2.d0*psi - 1.d0)
-!   RETURN
-! END IF
-! x1=self%plasma_bounds(1)
-! x2=self%plasma_bounds(2)
-! IF(psi>x1)THEN
-!   b=1.d0 + self%alpha*(2.d0*(psi-x1)/(x2-x1) - 1.d0)
-! ELSE
-!   b=0.d0
-! END IF
-! end function linear_fp
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! subroutine linear_update(self,gseq)
-! class(linear_flux_func), intent(inout) :: self
-! class(gs_equil), intent(inout) :: gseq
-! self%plasma_bounds=gseq%plasma_bounds
-! end subroutine linear_update
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! function linear_cofs_update(self,c) result(ierr)
-! class(linear_flux_func), intent(inout) :: self
-! real(8), intent(in) :: c(:)
-! integer(4) :: ierr
-! ierr=0
-! self%alpha=c(1)
-! end function linear_cofs_update
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! subroutine linear_cofs_get(self,c)
-! class(linear_flux_func), intent(inout) :: self
-! real(8), intent(out) :: c(:)
-! c(1)=self%alpha
-! end subroutine linear_cofs_get
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine poly_save_hdf5(self,filename,path)
+class(poly_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+CALL hdf5_write(self%ncofs,filename,path//'/NCOFS')
+CALL hdf5_write(self%cofs,filename,path//'/COFS')
+CALL hdf5_write(self%zero_grad,filename,path//'/ZERO_GRAD')
+end subroutine poly_save_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine poly_save_txt(self,io_unit)
+class(poly_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+WRITE(io_unit,*)'poly'
+IF(self%zero_grad)THEN
+  WRITE(io_unit,*)self%ncofs+1,self%zero_grad
+  WRITE(io_unit,*)0.d0,cofs
+ELSE
+  WRITE(io_unit,*)self%ncofs,self%zero_grad
+  WRITE(io_unit,*)cofs
+END IF
+end subroutine poly_save_txt
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine poly_load_hdf5(self,filename,path,success)
+class(poly_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+logical, intent(out) :: success
+CALL hdf5_read(self%ncofs,filename,path//'/NCOFS',success=success)
+IF(.NOT.success)RETURN
+ALLOCATE(self%cofs(self%ncofs))
+CALL hdf5_read(self%cofs,filename,path//'/COFS',success=success)
+IF(.NOT.success)RETURN
+CALL hdf5_read(self%zero_grad,filename,path//'/ZERO_GRAD',success=success)
+IF(.NOT.success)RETURN
+end subroutine poly_load_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine poly_load_txt(self,io_unit)
+class(poly_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+logical :: zero_grad
+integer(i4) :: ncofs
+real(r8), allocatable :: cofs(:)
+READ(io_unit,*)ncofs,zero_grad
+ALLOCATE(cofs(ncofs))
+READ(io_unit,*)cofs
+CALL create_poly_ff(self,ncofs,cofs,zero_grad)
+DEALLOCATE(cofs)
+end subroutine poly_load_txt
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-SUBROUTINE create_poly_ff(func,ncofs,cofs,zero_fp)
-CLASS(flux_func), POINTER, INTENT(out) :: func
+SUBROUTINE create_poly_ff(func,ncofs,cofs,zero_grad)
+CLASS(flux_func), POINTER, INTENT(inout) :: func
 INTEGER(4), INTENT(in) :: ncofs
-REAL(8), OPTIONAL, INTENT(in) :: cofs(:)
-LOGICAL, OPTIONAL, INTENT(in) :: zero_fp
+REAL(8), INTENT(in) :: cofs(:)
+LOGICAL, INTENT(in) :: zero_grad
 INTEGER(4) :: i,offset
 
-ALLOCATE(poly_flux_func::func)
+IF(.NOT.ASSOCIATED(func))ALLOCATE(poly_flux_func::func)
 select type(self=>func)
   type is(poly_flux_func)
   !---
   self%deg=ncofs
   self%ncofs=ncofs
-  IF(PRESENT(zero_fp))self%zero_grad=zero_fp
+  self%zero_grad=zero_grad
   offset=0
   IF(self%zero_grad)THEN
     offset=1
@@ -436,11 +464,9 @@ select type(self=>func)
   ALLOCATE(self%cofs(self%ncofs))
   self%cofs=0.d0
   !---
-  IF(PRESENT(cofs))THEN
-    DO i=1,self%ncofs
-      self%cofs(i)=cofs(offset+i)
-    END DO
-  END IF
+  DO i=1,self%ncofs
+    self%cofs(i)=cofs(offset+i)
+  END DO
   self%c0=1.d0
   IF(.NOT.self%zero_grad)THEN
     self%c0=0.d0
@@ -449,6 +475,8 @@ select type(self=>func)
     END DO
     self%c0=1.d0-self%c0
   END IF
+class default
+  CALL oft_error('Invalid flux function type in create_poly_ff')
 end select
 END SUBROUTINE create_poly_ff
 !------------------------------------------------------------------------------
@@ -584,18 +612,73 @@ DO i=1,self%ncofs
 END DO
 end subroutine poly_cofs_get
 !------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine spline_save_hdf5(self,filename,path)
+class(spline_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+CALL hdf5_write(self%npsi,filename,path//'/NPSI')
+CALL hdf5_write(self%func%xs(0:self%npsi-1),filename,path//'/XVALS')
+CALL hdf5_write(self%func%fs(0:self%npsi-1,1),filename,path//'/YVALS')
+end subroutine spline_save_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine spline_save_txt(self,io_unit)
+class(spline_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+WRITE(io_unit,*)'spline'
+WRITE(io_unit,*)self%npsi
+WRITE(io_unit,*)self%func%xs(0:self%npsi-1)
+WRITE(io_unit,*)self%func%fs(0:self%npsi-1,1)
+end subroutine spline_save_txt
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine spline_load_hdf5(self,filename,path,success)
+class(spline_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+logical, intent(out) :: success
+integer(i4) :: npsi
+real(r8), allocatable :: xvals(:),yvals(:)
+CALL hdf5_read(npsi,filename,path//'/NPSI',success=success)
+IF(.NOT.success)RETURN
+ALLOCATE(xvals(npsi),yvals(npsi))
+CALL hdf5_read(xvals,filename,path//'/XVALS',success=success)
+IF(.NOT.success)RETURN
+CALL hdf5_read(yvals,filename,path//'/YVALS',success=success)
+IF(.NOT.success)RETURN
+CALL create_spline_ff(self,npsi,xvals,yvals)
+DEALLOCATE(xvals,yvals)
+end subroutine spline_load_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine spline_load_txt(self,io_unit)
+class(spline_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+integer(i4) :: npsi
+real(r8), allocatable :: xvals(:),yvals(:)
+READ(io_unit,*)npsi
+ALLOCATE(xvals(npsi),yvals(npsi))
+READ(io_unit,*)xvals
+READ(io_unit,*)yvals
+CALL create_spline_ff(self,npsi,xvals,yvals)
+DEALLOCATE(xvals,yvals)
+end subroutine spline_load_txt
+!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-SUBROUTINE create_spline_ff(func,npsi,psimin,psimax,psivals)
-CLASS(flux_func), POINTER, INTENT(out) :: func
+SUBROUTINE create_spline_ff(func,npsi,psivals,yvals)
+CLASS(flux_func), POINTER, INTENT(inout) :: func
 INTEGER(4), INTENT(in) :: npsi
-REAL(8), OPTIONAL, INTENT(in) :: psimin
-REAL(8), OPTIONAL, INTENT(in) :: psimax
-REAL(8), OPTIONAL, INTENT(in) :: psivals(npsi)
+REAL(8), INTENT(in) :: psivals(npsi),yvals(npsi)
 REAL(8) :: psi1,psi2
 REAL(8), ALLOCATABLE :: c(:)
 INTEGER(4) :: i,ierr
-ALLOCATE(spline_flux_func::func)
+IF(.NOT.ASSOCIATED(func))ALLOCATE(spline_flux_func::func)
 select type(self=>func)
   type is(spline_flux_func)
   !---
@@ -606,28 +689,15 @@ select type(self=>func)
   DO i=1,omp_get_max_threads()
     CALL spline_alloc(self%fun_loc(i),self%npsi-1,1)
   END DO
-  IF(PRESENT(psivals))THEN
-    !---
-    DO i=1,self%npsi
-      self%func%xs(i-1)=psivals(i)
-      self%func%fs(i-1,1)=1.d0*psivals(i)
-    END DO
-  ELSE
-    !---
-    psi1=0.d0
-    psi2=1.d0
-    IF(PRESENT(psimin))psi1=psimin
-    IF(PRESENT(psimax))psi2=psimax
-    !---
-    DO i=1,self%npsi
-      self%func%xs(i-1)=(psi2-psi1)*i/(self%npsi+1) + psi1
-      self%func%fs(i-1,1)=1.d0*self%func%xs(i-1)
-    END DO
-  END IF
+  !---
+  DO i=1,self%npsi
+    self%func%xs(i-1)=psivals(i)
+    self%func%fs(i-1,1)=yvals(i)
+  END DO
   self%xmin=self%func%xs(0)
   self%xmax=self%func%xs(self%npsi-1)
   !---
-  WRITE(*,*)'Fitting',self%func%xs
+  ! WRITE(*,*)'Fitting',self%func%xs
   !CALL spline_fit(self%func,"extrap")
   CALL spline_fit(self%func,"not-a-knot")
   DO i=1,omp_get_max_threads()
@@ -637,7 +707,7 @@ select type(self=>func)
   CALL self%get_cofs(c)
   ierr=self%set_cofs(c)
   DEALLOCATE(c)
-  WRITE(*,*)'Spline Created',self%ncofs,self%func%xs
+  ! WRITE(*,*)'Spline Created',self%ncofs,self%func%xs
 end select
 
 END SUBROUTINE create_spline_ff
@@ -776,16 +846,78 @@ DO i=0,self%npsi-1
 END DO
 end subroutine spline_cofs_get
 !------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine linterp_save_hdf5(self,filename,path)
+class(linterp_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+CALL hdf5_write(self%npsi,filename,path//'/NPSI')
+CALL hdf5_write(self%x,filename,path//'/XVALS')
+CALL hdf5_write(self%yp,filename,path//'/YVALS')
+CALL hdf5_write(self%y0,filename,path//'/Y0')
+end subroutine linterp_save_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine linterp_save_txt(self,io_unit)
+class(linterp_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+WRITE(io_unit,*)'linterp'
+WRITE(io_unit,*)self%npsi,self%y0
+WRITE(io_unit,*)self%x
+WRITE(io_unit,*)self%yp
+end subroutine linterp_save_txt
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine linterp_load_hdf5(self,filename,path,success)
+class(linterp_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+logical, intent(out) :: success
+integer(i4) :: npsi
+real(r8) :: y0
+real(r8), allocatable :: xvals(:),yvals(:)
+CALL hdf5_read(npsi,filename,path//'/NPSI',success=success)
+IF(.NOT.success)RETURN
+ALLOCATE(xvals(npsi),yvals(npsi))
+CALL hdf5_read(xvals,filename,path//'/XVALS',success=success)
+IF(.NOT.success)RETURN
+CALL hdf5_read(yvals,filename,path//'/YVALS',success=success)
+IF(.NOT.success)RETURN
+CALL hdf5_read(y0,filename,path//'/Y0',success=success)
+IF(.NOT.success)RETURN
+CALL create_linterp_ff(self,npsi,xvals,yvals,y0)
+DEALLOCATE(xvals,yvals)
+end subroutine linterp_load_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine linterp_load_txt(self,io_unit)
+class(linterp_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+integer(i4) :: npsi
+real(r8) :: y0
+real(r8), allocatable :: xvals(:),yvals(:)
+READ(io_unit,*)npsi,y0
+ALLOCATE(xvals(npsi),yvals(npsi))
+READ(io_unit,*)xvals
+READ(io_unit,*)yvals
+CALL create_linterp_ff(self,npsi,xvals,yvals,y0)
+DEALLOCATE(xvals,yvals)
+end subroutine linterp_load_txt
+!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_linterp_ff(func,npsi,psivals,yvals,y0)
-CLASS(flux_func), POINTER, INTENT(out) :: func
+CLASS(flux_func), POINTER, INTENT(inout) :: func
 INTEGER(4), INTENT(in) :: npsi
 REAL(8), INTENT(in) :: psivals(npsi)
 REAL(8), INTENT(in) :: yvals(npsi)
 REAL(8), INTENT(in) :: y0
 INTEGER(4) :: i,ierr
-ALLOCATE(linterp_flux_func::func)
+IF(.NOT.ASSOCIATED(func))ALLOCATE(linterp_flux_func::func)
 SELECT TYPE(self=>func)
   TYPE IS(linterp_flux_func)
   !---
@@ -796,17 +928,13 @@ SELECT TYPE(self=>func)
   ALLOCATE(self%yp(self%npsi))
   ALLOCATE(self%y(self%npsi))
   !---
+  IF(y0<1.d-8)CALL oft_abort("Support for y0 = 0 has been removed","create_linterp_ff",__FILE__)
   self%y0=y0
   DO i=1,self%npsi
     self%x(i)=psivals(i)
     self%yp(i)=yvals(i)
   END DO
-  IF(self%y0<1.d-8)THEN
-    self%ncofs=self%ncofs-1
-    ierr=self%set_cofs(yvals(2:self%npsi))
-  ELSE
-    ierr=self%set_cofs(yvals)
-  END IF
+  ierr=self%set_cofs(yvals)
   IF(oft_debug_print(1))WRITE(*,*)'Linear interpolator Created',self%ncofs,self%x,self%y0
 END SELECT
 
@@ -985,158 +1113,57 @@ DO i=1,self%ncofs
   c(i)=self%yp(i+offset)
 END DO
 end subroutine linterp_cofs_get
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! SUBROUTINE create_twolam_ff(func,sep,alpha)
-! CLASS(flux_func), POINTER, INTENT(out) :: func
-! REAL(8), INTENT(in) :: sep
-! REAL(8), INTENT(in) :: alpha
-
-! ALLOCATE(twolam_flux_func::func)
-! select type(self=>func)
-!   type is(twolam_flux_func)
-!   !---
-!   self%ncofs=2
-!   self%sep=sep
-!   self%alpha=alpha
-! end select
-
-! END SUBROUTINE create_twolam_ff
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! function twolam_f(self,psi) result(b)
-! class(twolam_flux_func), intent(inout) :: self
-! real(8), intent(in) :: psi
-! real(8) :: b
-! b=(1.d0+self%alpha/2.d0)*psi + self%alpha*LOG(COSH(self%width*(psi-self%sep)))/2.d0/self%width &
-! - self%alpha*LOG(COSH(-self%width*self%sep))/2.d0/self%width
-! end function twolam_f
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! function twolam_fp(self,psi) result(b)
-! class(twolam_flux_func), intent(inout) :: self
-! real(8), intent(in) :: psi
-! real(8) :: b
-! b=1.d0 + self%alpha*(1.d0 + TANH(self%width*(psi-self%sep)))/2.d0
-! end function twolam_fp
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! subroutine twolam_update(self,gseq)
-! class(twolam_flux_func), intent(inout) :: self
-! class(gs_equil), intent(inout) :: gseq
-! self%plasma_bounds=gseq%plasma_bounds
-! end subroutine twolam_update
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! function twolam_cofs_update(self,c) result(ierr)
-! class(twolam_flux_func), intent(inout) :: self
-! real(8), intent(in) :: c(:)
-! integer(4) :: ierr
-! ierr=0
-! IF(c(1)<0.d0.OR.c(1)>1.d0)ierr=-1
-! IF(ABS(c(2))>1.d0)ierr=-1
-! self%sep=c(1)
-! self%alpha=c(2)
-! end function twolam_cofs_update
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! subroutine twolam_cofs_get(self,c)
-! class(twolam_flux_func), intent(inout) :: self
-! real(8), intent(out) :: c(:)
-! c(1)=self%sep
-! c(2)=self%alpha
-! end subroutine twolam_cofs_get
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! SUBROUTINE create_stepslant_ff(func,sep,alpha,beta)
-! CLASS(flux_func), POINTER, INTENT(out) :: func
-! REAL(8), INTENT(in) :: sep
-! REAL(8), INTENT(in) :: alpha
-! REAL(8), INTENT(in) :: beta
-
-! ALLOCATE(stepslant_flux_func::func)
-! select type(self=>func)
-!   type is(stepslant_flux_func)
-!   !---
-!   self%ncofs=2
-!   self%sep=sep
-!   self%alpha=alpha
-!   self%beta=beta
-! end select
-
-! END SUBROUTINE create_stepslant_ff
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! function stepslant_f(self,psi) result(b)
-! class(stepslant_flux_func), intent(inout) :: self
-! real(8), intent(in) :: psi
-! real(8) :: b
-! if(psi<self%sep)then
-!   b=psi
-! else
-!   b=self%sep + (1.d0+self%alpha)*(self%sep-psi)*((self%beta-2)*self%sep-self%beta*psi)/(2*self%sep)
-! end if
-! end function stepslant_f
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! function stepslant_fp(self,psi) result(b)
-! class(stepslant_flux_func), intent(inout) :: self
-! real(8), intent(in) :: psi
-! real(8) :: b
-! if(psi<self%sep) then
-!   b=1.d0
-! else
-!   b=(1.d0+self%alpha)*(1.d0+self%beta*(psi-self%sep)/self%sep)
-! end if
-! end function stepslant_fp
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! subroutine stepslant_update(self,gseq)
-! class(stepslant_flux_func), intent(inout) :: self
-! class(gs_equil), intent(inout) :: gseq
-! self%plasma_bounds=gseq%plasma_bounds
-! end subroutine stepslant_update
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! function stepslant_cofs_update(self,c) result(ierr)
-! class(stepslant_flux_func), intent(inout) :: self
-! real(8), intent(in) :: c(:)
-! integer(4) :: ierr
-! self%sep=c(1)
-! self%alpha=c(2)
-! self%beta=c(3)
-! ierr=0
-! end function stepslant_cofs_update
-! !------------------------------------------------------------------------------
-! !> Needs docs
-! !------------------------------------------------------------------------------
-! subroutine stepslant_cofs_get(self,c)
-! class(stepslant_flux_func), intent(inout) :: self
-! real(8), intent(out) :: c(:)
-! c(1)=self%sep
-! c(2)=self%alpha
-! c(3)=self%beta
-! end subroutine stepslant_cofs_get
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine wesson_save_hdf5(self,filename,path)
+class(wesson_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+CALL hdf5_write(self%ncofs,filename,path//'/NCOFS')
+CALL hdf5_write(self%gamma,filename,path//'/GAMMA')
+end subroutine wesson_save_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine wesson_save_txt(self,io_unit)
+class(wesson_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+WRITE(io_unit,*)'wesson'
+WRITE(io_unit,*)self%ncofs
+WRITE(io_unit,*)self%gamma
+end subroutine wesson_save_txt
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine wesson_load_hdf5(self,filename,path,success)
+class(wesson_flux_func), intent(inout) :: self
+character(LEN=*), intent(in) :: filename
+character(LEN=*), intent(in) :: path
+logical, intent(out) :: success
+CALL hdf5_read(self%ncofs,filename,path//'/NCOFS',success=success)
+IF(.NOT.success)RETURN
+CALL hdf5_read(self%gamma,filename,path//'/GAMMA',success=success)
+IF(.NOT.success)RETURN
+end subroutine wesson_load_hdf5
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine wesson_load_txt(self,io_unit)
+class(wesson_flux_func), intent(inout) :: self
+integer, intent(in) :: io_unit
+READ(io_unit,*)self%ncofs
+READ(io_unit,*)self%gamma
+end subroutine wesson_load_txt
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_wesson_ff(func,ncofs,gamma)
-CLASS(flux_func), POINTER, INTENT(out) :: func
+CLASS(flux_func), POINTER, INTENT(inout) :: func
 INTEGER(4), INTENT(in) :: ncofs
 REAL(8), INTENT(in) :: gamma
 
-ALLOCATE(wesson_flux_func::func)
+IF(.NOT.ASSOCIATED(func))ALLOCATE(wesson_flux_func::func)
 select type(self=>func)
   type is(wesson_flux_func)
   !---

--- a/src/physics/grad_shaf_profiles.F90
+++ b/src/physics/grad_shaf_profiles.F90
@@ -23,6 +23,8 @@ implicit none
 !------------------------------------------------------------------------------
 type, extends(flux_func) :: zero_flux_func
 contains
+  !> Delete profile
+  procedure :: delete => zero_delete
   !> Needs docs
   procedure :: copy => zero_copy
   !> Needs docs
@@ -47,6 +49,8 @@ end type zero_flux_func
 !------------------------------------------------------------------------------
 type, extends(flux_func) :: flat_flux_func
 contains
+  !> Delete profile
+  procedure :: delete => flat_delete
   !> Needs docs
   procedure :: copy => flat_copy
   !> Needs docs
@@ -75,6 +79,8 @@ type, extends(flux_func) :: poly_flux_func
   real(8), pointer, dimension(:) :: cofs => NULL() !< Coefficients [deg]
   logical :: zero_grad = .FALSE. !< Force zero gradient at boundary
 contains
+  !> Delete profile
+  procedure :: delete => poly_delete
   !> Needs docs
   procedure :: copy => poly_copy
   !> Needs docs
@@ -108,6 +114,8 @@ type, extends(flux_func) :: spline_flux_func
   TYPE(spline_type) :: func !< Needs docs
   TYPE(spline_type), POINTER, DIMENSION(:) :: fun_loc => NULL() !< Needs docs
 contains
+  !> Delete profile
+  procedure :: delete => spline_func_delete
   !> Needs docs
   procedure :: copy => spline_func_copy
   !> Needs docs
@@ -137,6 +145,8 @@ type, extends(flux_func) :: linterp_flux_func
   real(8), pointer, dimension(:) :: yp => NULL() !< Needs docs
   real(8), pointer, dimension(:) :: y => NULL() !< Needs docs
 contains
+  !> Delete profile
+  procedure :: delete => linterp_delete
   !> Needs docs
   procedure :: copy => linterp_copy
   !> Needs docs
@@ -164,16 +174,15 @@ end type linterp_flux_func
 type, extends(flux_func) :: wesson_flux_func
   real(8) :: gamma = 0.d0
 contains
+  procedure :: delete => wesson_delete
   procedure :: copy => wesson_copy
   procedure :: f => wesson_f
   procedure :: fp => wesson_fp
   procedure :: update => wesson_update
   procedure :: set_cofs => wesson_cofs_update
   procedure :: get_cofs => wesson_cofs_get
-  !> Needs docs
   procedure :: save_hdf5 => wesson_save_hdf5
   procedure :: save_txt => wesson_save_txt
-  !> Needs docs
   procedure :: load_hdf5 => wesson_load_hdf5
   procedure :: load_txt => wesson_load_txt
 end type wesson_flux_func
@@ -225,6 +234,13 @@ new%plasma_bounds=self%plasma_bounds
 new%f_offset=self%f_offset
 new%ncofs=0
 end subroutine zero_copy
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine zero_delete(self)
+class(zero_flux_func), intent(inout) :: self
+!--- No internal memory to free
+end subroutine zero_delete
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -325,6 +341,13 @@ new%plasma_bounds=self%plasma_bounds
 new%f_offset=self%f_offset
 new%ncofs=0
 end subroutine flat_copy
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine flat_delete(self)
+class(flat_flux_func), intent(inout) :: self
+!--- No internal memory to free
+end subroutine flat_delete
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -504,6 +527,15 @@ SELECT TYPE(new)
     new%cofs=self%cofs
 END SELECT
 end subroutine poly_copy
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine poly_delete(self)
+class(poly_flux_func), intent(inout) :: self
+IF(ASSOCIATED(self%cofs))DEALLOCATE(self%cofs)
+self%ncofs=0
+self%deg=0
+end subroutine poly_delete
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -748,6 +780,21 @@ SELECT TYPE(new)
 END SELECT
 end subroutine spline_func_copy
 !------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine spline_func_delete(self)
+class(spline_flux_func), intent(inout) :: self
+integer(i4) :: i
+self%npsi=0
+self%ncofs=0
+IF(ASSOCIATED(self%fun_loc))THEN
+  CALL spline_dealloc(self%func)
+  DO i=1,omp_get_max_threads()
+    CALL spline_dealloc(self%fun_loc(i))
+  END DO
+END IF
+end subroutine spline_func_delete
+!------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
 function spline_f(self,psi) result(b)
@@ -974,6 +1021,17 @@ SELECT TYPE(new)
     new%y=self%y
 END SELECT
 end subroutine linterp_copy
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine linterp_delete(self)
+class(linterp_flux_func), intent(inout) :: self
+self%npsi=0
+self%ncofs=0
+IF(ASSOCIATED(self%x))DEALLOCATE(self%x)
+IF(ASSOCIATED(self%yp))DEALLOCATE(self%yp)
+IF(ASSOCIATED(self%y))DEALLOCATE(self%y)
+end subroutine linterp_delete
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
@@ -1203,6 +1261,14 @@ SELECT TYPE(new)
     new%gamma=self%gamma
 END SELECT
 end subroutine wesson_copy
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine wesson_delete(self)
+class(wesson_flux_func), intent(inout) :: self
+self%ncofs=0
+self%gamma=0.d0
+end subroutine wesson_delete
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------

--- a/src/physics/grad_shaf_profiles.F90
+++ b/src/physics/grad_shaf_profiles.F90
@@ -12,6 +12,7 @@
 !! @ingroup doxy_oft_physics
 !------------------------------------------------------------------------------
 module oft_gs_profiles
+USE oft_io, ONLY: hdf5_read, hdf5_write, hdf5_field_exist
 USE oft_base
 USE spline_mod
 USE oft_gs, ONLY: flux_func, gs_equil, oft_indent, oft_increase_indent, &
@@ -184,6 +185,7 @@ subroutine zero_save_hdf5(self,filename,path)
 class(zero_flux_func), intent(inout) :: self
 character(LEN=*), intent(in) :: filename
 character(LEN=*), intent(in) :: path
+IF(.NOT.hdf5_field_exist(filename,path//'/TYPE'))CALL hdf5_write('zero',filename,path//'/TYPE')
 end subroutine zero_save_hdf5
 !------------------------------------------------------------------------------
 !> Needs Docs
@@ -270,6 +272,7 @@ subroutine flat_save_hdf5(self,filename,path)
 class(flat_flux_func), intent(inout) :: self
 character(LEN=*), intent(in) :: filename
 character(LEN=*), intent(in) :: path
+IF(.NOT.hdf5_field_exist(filename,path//'/TYPE'))CALL hdf5_write('flat',filename,path//'/TYPE')
 end subroutine flat_save_hdf5
 !------------------------------------------------------------------------------
 !> Needs Docs
@@ -301,11 +304,12 @@ end subroutine flat_load_txt
 !> Needs docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_flat_f(func)
-CLASS(flux_func), POINTER, INTENT(inout) :: func
-IF(.NOT.ASSOCIATED(func))ALLOCATE(flat_flux_func::func)
+CLASS(flux_func), INTENT(inout) :: func
 select type(self=>func)
   type is(flat_flux_func)
     self%ncofs=0
+class default
+  CALL oft_abort('Invalid flux function type in create_flat_f','create_flat_f',__FILE__)
 end select
 END SUBROUTINE create_flat_f
 !------------------------------------------------------------------------------
@@ -388,6 +392,7 @@ subroutine poly_save_hdf5(self,filename,path)
 class(poly_flux_func), intent(inout) :: self
 character(LEN=*), intent(in) :: filename
 character(LEN=*), intent(in) :: path
+IF(.NOT.hdf5_field_exist(filename,path//'/TYPE'))CALL hdf5_write('poly',filename,path//'/TYPE')
 CALL hdf5_write(self%ncofs,filename,path//'/NCOFS')
 CALL hdf5_write(self%cofs,filename,path//'/COFS')
 CALL hdf5_write(self%zero_grad,filename,path//'/ZERO_GRAD')
@@ -401,10 +406,10 @@ integer, intent(in) :: io_unit
 WRITE(io_unit,*)'poly'
 IF(self%zero_grad)THEN
   WRITE(io_unit,*)self%ncofs+1,self%zero_grad
-  WRITE(io_unit,*)0.d0,cofs
+  WRITE(io_unit,*)0.d0,self%cofs
 ELSE
   WRITE(io_unit,*)self%ncofs,self%zero_grad
-  WRITE(io_unit,*)cofs
+  WRITE(io_unit,*)self%cofs
 END IF
 end subroutine poly_save_txt
 !------------------------------------------------------------------------------
@@ -442,13 +447,12 @@ end subroutine poly_load_txt
 !> Needs docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_poly_ff(func,ncofs,cofs,zero_grad)
-CLASS(flux_func), POINTER, INTENT(inout) :: func
+CLASS(flux_func), INTENT(inout) :: func
 INTEGER(4), INTENT(in) :: ncofs
 REAL(8), INTENT(in) :: cofs(:)
 LOGICAL, INTENT(in) :: zero_grad
 INTEGER(4) :: i,offset
 
-IF(.NOT.ASSOCIATED(func))ALLOCATE(poly_flux_func::func)
 select type(self=>func)
   type is(poly_flux_func)
   !---
@@ -476,7 +480,7 @@ select type(self=>func)
     self%c0=1.d0-self%c0
   END IF
 class default
-  CALL oft_error('Invalid flux function type in create_poly_ff')
+  CALL oft_abort('Invalid flux function type in create_poly_ff','create_poly_ff',__FILE__)
 end select
 END SUBROUTINE create_poly_ff
 !------------------------------------------------------------------------------
@@ -618,6 +622,7 @@ subroutine spline_save_hdf5(self,filename,path)
 class(spline_flux_func), intent(inout) :: self
 character(LEN=*), intent(in) :: filename
 character(LEN=*), intent(in) :: path
+IF(.NOT.hdf5_field_exist(filename,path//'/TYPE'))CALL hdf5_write('spline',filename,path//'/TYPE')
 CALL hdf5_write(self%npsi,filename,path//'/NPSI')
 CALL hdf5_write(self%func%xs(0:self%npsi-1),filename,path//'/XVALS')
 CALL hdf5_write(self%func%fs(0:self%npsi-1,1),filename,path//'/YVALS')
@@ -672,13 +677,12 @@ end subroutine spline_load_txt
 !> Needs docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_spline_ff(func,npsi,psivals,yvals)
-CLASS(flux_func), POINTER, INTENT(inout) :: func
+CLASS(flux_func), INTENT(inout) :: func
 INTEGER(4), INTENT(in) :: npsi
 REAL(8), INTENT(in) :: psivals(npsi),yvals(npsi)
 REAL(8) :: psi1,psi2
 REAL(8), ALLOCATABLE :: c(:)
 INTEGER(4) :: i,ierr
-IF(.NOT.ASSOCIATED(func))ALLOCATE(spline_flux_func::func)
 select type(self=>func)
   type is(spline_flux_func)
   !---
@@ -708,6 +712,8 @@ select type(self=>func)
   ierr=self%set_cofs(c)
   DEALLOCATE(c)
   ! WRITE(*,*)'Spline Created',self%ncofs,self%func%xs
+class default
+  CALL oft_abort('Invalid flux function type in create_spline_ff','create_spline_ff',__FILE__)
 end select
 
 END SUBROUTINE create_spline_ff
@@ -852,6 +858,7 @@ subroutine linterp_save_hdf5(self,filename,path)
 class(linterp_flux_func), intent(inout) :: self
 character(LEN=*), intent(in) :: filename
 character(LEN=*), intent(in) :: path
+IF(.NOT.hdf5_field_exist(filename,path//'/TYPE'))CALL hdf5_write('linterp',filename,path//'/TYPE')
 CALL hdf5_write(self%npsi,filename,path//'/NPSI')
 CALL hdf5_write(self%x,filename,path//'/XVALS')
 CALL hdf5_write(self%yp,filename,path//'/YVALS')
@@ -911,13 +918,12 @@ end subroutine linterp_load_txt
 !> Needs docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_linterp_ff(func,npsi,psivals,yvals,y0)
-CLASS(flux_func), POINTER, INTENT(inout) :: func
+CLASS(flux_func), INTENT(inout) :: func
 INTEGER(4), INTENT(in) :: npsi
 REAL(8), INTENT(in) :: psivals(npsi)
 REAL(8), INTENT(in) :: yvals(npsi)
 REAL(8), INTENT(in) :: y0
 INTEGER(4) :: i,ierr
-IF(.NOT.ASSOCIATED(func))ALLOCATE(linterp_flux_func::func)
 SELECT TYPE(self=>func)
   TYPE IS(linterp_flux_func)
   !---
@@ -928,14 +934,21 @@ SELECT TYPE(self=>func)
   ALLOCATE(self%yp(self%npsi))
   ALLOCATE(self%y(self%npsi))
   !---
-  IF(y0<1.d-8)CALL oft_abort("Support for y0 = 0 has been removed","create_linterp_ff",__FILE__)
+  ! IF(y0<1.d-8)CALL oft_abort("Support for y0 = 0 has been removed","create_linterp_ff",__FILE__)
   self%y0=y0
   DO i=1,self%npsi
     self%x(i)=psivals(i)
     self%yp(i)=yvals(i)
   END DO
-  ierr=self%set_cofs(yvals)
+  IF(self%y0<1.d-8)THEN
+    self%ncofs=self%ncofs-1
+    ierr=self%set_cofs(yvals(2:self%npsi))
+  ELSE
+    ierr=self%set_cofs(yvals)
+  END IF
   IF(oft_debug_print(1))WRITE(*,*)'Linear interpolator Created',self%ncofs,self%x,self%y0
+class default
+  CALL oft_abort('Invalid flux function type in create_linterp_ff','create_linterp_ff',__FILE__)
 END SELECT
 
 END SUBROUTINE create_linterp_ff
@@ -1120,6 +1133,7 @@ subroutine wesson_save_hdf5(self,filename,path)
 class(wesson_flux_func), intent(inout) :: self
 character(LEN=*), intent(in) :: filename
 character(LEN=*), intent(in) :: path
+IF(.NOT.hdf5_field_exist(filename,path//'/TYPE'))CALL hdf5_write('wesson',filename,path//'/TYPE')
 CALL hdf5_write(self%ncofs,filename,path//'/NCOFS')
 CALL hdf5_write(self%gamma,filename,path//'/GAMMA')
 end subroutine wesson_save_hdf5
@@ -1159,16 +1173,16 @@ end subroutine wesson_load_txt
 !> Needs docs
 !------------------------------------------------------------------------------
 SUBROUTINE create_wesson_ff(func,ncofs,gamma)
-CLASS(flux_func), POINTER, INTENT(inout) :: func
+CLASS(flux_func), INTENT(inout) :: func
 INTEGER(4), INTENT(in) :: ncofs
 REAL(8), INTENT(in) :: gamma
-
-IF(.NOT.ASSOCIATED(func))ALLOCATE(wesson_flux_func::func)
 select type(self=>func)
   type is(wesson_flux_func)
   !---
   self%ncofs=ncofs
   self%gamma=gamma
+class default
+  CALL oft_abort('Invalid flux function type in create_wesson_ff','create_wesson_ff',__FILE__)
 end select
 
 END SUBROUTINE create_wesson_ff

--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -416,23 +416,39 @@ CHARACTER(LEN=:), ALLOCATABLE :: profType
 ! CALL hdf5_write(self%device%fe_rep%mesh%lc,filename,'mesh/LC')
 !---Check compatibility of mesh and FE representation
 CALL hdf5_read(int_tmp,filename,'tokamaker/FE_ORDER',success=success)
+IF(.NOT.success)THEN
+  error_string='Failed to read FE order.'
+  RETURN
+END IF
 IF(int_tmp/=self%device%fe_rep%order)THEN
   error_string='FE order of equilibrium does not match current device.'
   RETURN
 END IF
 hash_tmp = oft_simple_hash(C_LOC(self%device%mesh%lc),INT(4*3*self%device%mesh%nc,8))
 CALL hdf5_read(hash_in,filename,'tokamaker/LC_HASH',success=success)
+IF(.NOT.success)THEN
+  error_string='Failed to read cell list hash.'
+  RETURN
+END IF
 IF(hash_tmp/=hash_in)THEN
   error_string='Cell list hash for equilibrium does not match current device.'
   RETURN
 END IF
 hash_tmp = oft_simple_hash(C_LOC(self%device%mesh%reg),INT(4*self%device%mesh%nc,8))
 CALL hdf5_read(hash_in,filename,'tokamaker/REG_HASH',success=success)
+IF(.NOT.success)THEN
+  error_string='Failed to read region hash.'
+  RETURN
+END IF
 IF(hash_tmp/=hash_in)THEN
   error_string='Region hash for equilibrium does not match current device.'
   RETURN
 END IF
 CALL hdf5_read(int_tmp,filename,'tokamaker/NCOILS',success=success)
+IF(.NOT.success)THEN
+  error_string='Failed to read number of coils.'
+  RETURN
+END IF
 IF(int_tmp/=self%device%ncoils)THEN
   error_string='Number of coils for equilibrium does not match current device.'
   RETURN
@@ -463,12 +479,12 @@ IF(.NOT.success)THEN
   error_string="Failed to read F*F' profile type."
   RETURN
 END IF
-CALL gs_profile_alloc(profType,self%I)
-DEALLOCATE(profType)
 IF(ASSOCIATED(self%I))THEN
   CALL self%I%delete()
   DEALLOCATE(self%I)
 END IF
+CALL gs_profile_alloc(profType,self%I)
+DEALLOCATE(profType)
 CALL self%I%load(filename,'tokamaker/FFP_PROFILE',success=success)
 CALL self%I%update(self)
 IF(.NOT.success)THEN

--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -12,6 +12,7 @@
 !! @ingroup doxy_oft_physics
 !------------------------------------------------------------------------------
 MODULE oft_gs_util
+USE, INTRINSIC :: iso_c_binding, ONLY: C_LOC
 USE oft_base
 USE spline_mod
 USE oft_io, ONLY: hdf5_create_file, hdf5_create_group, hdf5_write, hdf5_read, &

--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -48,79 +48,92 @@ CLASS(flux_func), POINTER :: ff_fit => NULL()
 REAL(8), POINTER, DIMENSION(:,:) :: tmpprof => NULL()
 CONTAINS
 !---------------------------------------------------------------------------------
-!> Create flux function object from definition file
-!!
-!! @param[in] filename File storing function definition
-!! @param[out] f Flux function object
+!> Create flux function object from profile name
 !---------------------------------------------------------------------------------
-SUBROUTINE gs_profile_load(filename,F)
-CHARACTER(LEN=*), INTENT(in) :: filename
-CLASS(flux_func), POINTER, INTENT(out) :: F
-!---
-REAL(8) :: alpha,beta,sep
-REAL(8), ALLOCATABLE, DIMENSION(:) :: cofs,yvals
-INTEGER(4) :: ncofs,npsi,io_unit
-LOGICAL :: zero_grad
-CHARACTER(LEN=15) :: profType
-!---
-OPEN(NEWUNIT=io_unit,FILE=TRIM(filename))
-READ(io_unit,*)profType
+SUBROUTINE gs_profile_alloc(profType,F)
+CHARACTER(LEN=*), INTENT(in) :: profType !< Profile type
+CLASS(flux_func), POINTER, INTENT(out) :: F !< Flux function object
 !---
 SELECT CASE(TRIM(profType))
   CASE("zero")
     ALLOCATE(zero_flux_func::F)
   CASE("flat")
-    CALL create_flat_f(F)
-  CASE("linear")
-    CALL oft_abort('"linear" profile no longer supported.','gs_profile_load',__FILE__)
-  !   READ(io_unit,*)ncofs
-  !   READ(io_unit,*)alpha
-  !   CALL create_linear_ff(F,alpha)
-  !   F%ncofs=ncofs
+    ALLOCATE(flat_flux_func::F)
   CASE("poly")
-    READ(io_unit,*)ncofs,zero_grad
-    ALLOCATE(cofs(ncofs))
-    READ(io_unit,*)cofs
-    CALL create_poly_ff(F,ncofs,cofs,zero_grad)
-    DEALLOCATE(cofs)
+    ALLOCATE(poly_flux_func::F)
   CASE("linterp")
-    READ(io_unit,*)ncofs,alpha
-    ALLOCATE(cofs(ncofs),yvals(ncofs))
-    READ(io_unit,*)cofs
-    READ(io_unit,*)yvals
-    CALL create_linterp_ff(F,ncofs,cofs,yvals,alpha)
-    DEALLOCATE(cofs,yvals)
+    ALLOCATE(linterp_flux_func::F)
   CASE("jphi-linterp")
-    READ(io_unit,*)ncofs,alpha
-    ALLOCATE(cofs(ncofs),yvals(ncofs))
-    READ(io_unit,*)cofs
-    READ(io_unit,*)yvals
-    CALL create_jphi_ff(F,ncofs,cofs,yvals,alpha)
-    DEALLOCATE(cofs,yvals)
-  CASE("idcd")
-    CALL oft_abort('"idcd" profile no longer supported.','gs_profile_load',__FILE__)
-  !   READ(io_unit,*)ncofs
-  !   READ(io_unit,*)sep,alpha
-  !   CALL create_twolam_ff(F,sep,alpha)
-  !   F%ncofs=ncofs
-  CASE("step-slant")
-    CALL oft_abort('"step-slant" profile no longer supported.','gs_profile_load',__FILE__)
-  !   READ(io_unit,*)ncofs
-  !   READ(io_unit,*)sep,alpha,beta
-  !   CALL create_stepslant_ff(F,sep,alpha,beta)
-  !   F%ncofs=ncofs
-  ! CASE("mercier")
-  !   READ(io_unit,*)npsi
-  !   CALL create_mercier_ff(F,npsi)
-  !   F%ncofs=0
+    ALLOCATE(jphi_flux_func::F)
   CASE("wesson")
-    READ(io_unit,*)ncofs
-    READ(io_unit,*)beta
-    CALL create_wesson_ff(F,ncofs,beta)
+    ALLOCATE(wesson_flux_func::F)
   CASE DEFAULT
     CALL oft_abort('Invalid profile type.','gs_profile_load',__FILE__)
 END SELECT
+END SUBROUTINE gs_profile_alloc
+!---------------------------------------------------------------------------------
+!> Create flux function object from definition file
+!---------------------------------------------------------------------------------
+SUBROUTINE gs_profile_load(filename,F)
+CHARACTER(LEN=*), INTENT(in) :: filename !< File storing function definition
+CLASS(flux_func), POINTER, INTENT(out) :: F !< Flux function object
+! !---
+! REAL(8) :: alpha,beta,sep
+! REAL(8), ALLOCATABLE, DIMENSION(:) :: cofs,yvals
+! INTEGER(4) :: ncofs,npsi,io_unit
+! LOGICAL :: zero_grad
+CHARACTER(LEN=15) :: profType
+!---
+OPEN(NEWUNIT=io_unit,FILE=TRIM(filename))
+READ(io_unit,*)profType
+CALL gs_profile_alloc(profType,F)
+CALL F%load(io_unit)
 CLOSE(io_unit)
+! !---
+! SELECT CASE(TRIM(profType))
+!   CASE("zero")
+!     ALLOCATE(zero_flux_func::F)
+!   CASE("flat")
+!     ALLOCATE(flat_flux_func::F)
+!     ! CALL create_flat_f(F)
+!   CASE("linear")
+!     CALL oft_abort('"linear" profile no longer supported.','gs_profile_load',__FILE__)
+!   CASE("poly")
+!     ALLOCATE(poly_flux_func::F)
+!     ! READ(io_unit,*)ncofs,zero_grad
+!     ! ALLOCATE(cofs(ncofs))
+!     ! READ(io_unit,*)cofs
+!     ! CALL create_poly_ff(F,ncofs,cofs,zero_grad)
+!     ! DEALLOCATE(cofs)
+!   CASE("linterp")
+!     ALLOCATE(linterp_flux_func::F)
+!     ! READ(io_unit,*)ncofs,alpha
+!     ! ALLOCATE(cofs(ncofs),yvals(ncofs))
+!     ! READ(io_unit,*)cofs
+!     ! READ(io_unit,*)yvals
+!     ! CALL create_linterp_ff(F,ncofs,cofs,yvals,alpha)
+!     ! DEALLOCATE(cofs,yvals)
+!   CASE("jphi-linterp")
+!     ALLOCATE(jphi_flux_func::F)
+!     ! READ(io_unit,*)ncofs,alpha
+!     ! ALLOCATE(cofs(ncofs),yvals(ncofs))
+!     ! READ(io_unit,*)cofs
+!     ! READ(io_unit,*)yvals
+!     ! CALL create_jphi_ff(F,ncofs,cofs,yvals,alpha)
+!     ! DEALLOCATE(cofs,yvals)
+!   CASE("idcd")
+!     CALL oft_abort('"idcd" profile no longer supported.','gs_profile_load',__FILE__)
+!   CASE("step-slant")
+!     CALL oft_abort('"step-slant" profile no longer supported.','gs_profile_load',__FILE__)
+!   CASE("wesson")
+!     ALLOCATE(wesson_flux_func::F)
+!     ! READ(io_unit,*)ncofs
+!     ! READ(io_unit,*)beta
+!     ! CALL create_wesson_ff(F,ncofs,beta)
+!   CASE DEFAULT
+!     CALL oft_abort('Invalid profile type.','gs_profile_load',__FILE__)
+! END SELECT
+! CLOSE(io_unit)
 END SUBROUTINE gs_profile_load
 !---------------------------------------------------------------------------------
 !> Save flux function object to definition file
@@ -129,59 +142,45 @@ END SUBROUTINE gs_profile_load
 !! @param[in] f Flux function object
 !---------------------------------------------------------------------------------
 SUBROUTINE gs_profile_save(filename,F)
-CHARACTER(LEN=*), INTENT(in) :: filename
-CLASS(flux_func), POINTER, INTENT(in) :: F
+CHARACTER(LEN=*), INTENT(in) :: filename !< File to store function definition
+CLASS(flux_func), POINTER, INTENT(in) :: F !< Flux function object
 !---
 INTEGER(4) :: io_unit
 !---
 OPEN(NEWUNIT=io_unit,FILE=TRIM(filename))
-!---
-SELECT TYPE(this=>F)
-  TYPE IS(zero_flux_func)
-    WRITE(io_unit,*)"zero"
-  TYPE IS(flat_flux_func)
-    WRITE(io_unit,*)"flat"
-  ! TYPE IS(linear_flux_func)
-  !   WRITE(io_unit,*)"linear"
-  !   WRITE(io_unit,*)this%ncofs
-  !   WRITE(io_unit,*)this%alpha
-  TYPE IS(poly_flux_func)
-    WRITE(io_unit,*)"poly"
-    IF(this%zero_grad)THEN
-      WRITE(io_unit,*)this%deg+1,this%zero_grad
-      WRITE(io_unit,*)1.d0,this%cofs
-    ELSE
-      WRITE(io_unit,*)this%deg,this%zero_grad
-      WRITE(io_unit,*)this%cofs
-    END IF
-  TYPE IS(linterp_flux_func)
-    WRITE(io_unit,*)"linterp"
-    WRITE(io_unit,*)this%npsi,this%y0
-    WRITE(io_unit,*)this%x
-    WRITE(io_unit,*)this%yp
-  TYPE IS(jphi_flux_func)
-    WRITE(io_unit,*)"jphi-linterp"
-    WRITE(io_unit,*)this%npsi,this%y0
-    WRITE(io_unit,*)this%x
-    WRITE(io_unit,*)this%jphi
-  ! TYPE IS(twolam_flux_func)
-  !   WRITE(io_unit,*)"idcd"
-  !   WRITE(io_unit,*)this%ncofs
-  !   WRITE(io_unit,*)this%sep,this%alpha
-  ! TYPE IS(stepslant_flux_func)
-  !   WRITE(io_unit,*)"step-slant"
-  !   WRITE(io_unit,*)this%ncofs
-  !   WRITE(io_unit,*)this%sep,this%alpha,this%beta
-  ! TYPE IS(mercier_flux_func)
-  !   WRITE(io_unit,*)"mercier"
-  !   WRITE(io_unit,*)this%npsi
-  TYPE IS(wesson_flux_func)
-    WRITE(io_unit,*)"wesson"
-    WRITE(io_unit,*)this%ncofs
-    WRITE(io_unit,*)this%gamma
-  CLASS DEFAULT
-    CALL oft_abort('Invalid profile type.','gs_profile_save',__FILE__)
-END SELECT
+! !---
+! SELECT TYPE(this=>F)
+!   TYPE IS(zero_flux_func)
+!     WRITE(io_unit,*)"zero"
+!   TYPE IS(flat_flux_func)
+!     WRITE(io_unit,*)"flat"
+!   TYPE IS(poly_flux_func)
+!     WRITE(io_unit,*)"poly"
+!     ! IF(this%zero_grad)THEN
+!     !   WRITE(io_unit,*)this%deg+1,this%zero_grad
+!     !   WRITE(io_unit,*)1.d0,this%cofs
+!     ! ELSE
+!     !   WRITE(io_unit,*)this%deg,this%zero_grad
+!     !   WRITE(io_unit,*)this%cofs
+!     ! END IF
+!   TYPE IS(linterp_flux_func)
+!     WRITE(io_unit,*)"linterp"
+!     ! WRITE(io_unit,*)this%npsi,this%y0
+!     ! WRITE(io_unit,*)this%x
+!     ! WRITE(io_unit,*)this%yp
+!   TYPE IS(jphi_flux_func)
+!     WRITE(io_unit,*)"jphi-linterp"
+!     ! WRITE(io_unit,*)this%npsi,this%y0
+!     ! WRITE(io_unit,*)this%x
+!     ! WRITE(io_unit,*)this%jphi
+!   TYPE IS(wesson_flux_func)
+!     WRITE(io_unit,*)"wesson"
+!     ! WRITE(io_unit,*)this%ncofs
+!     ! WRITE(io_unit,*)this%gamma
+!   CLASS DEFAULT
+!     CALL oft_abort('Invalid profile type.','gs_profile_save',__FILE__)
+! END SELECT
+CALL F%save(io_unit)
 CLOSE(io_unit)
 END SUBROUTINE gs_profile_save
 !------------------------------------------------------------------------------
@@ -337,6 +336,139 @@ vloop=self%psiscale*(eta_jsq/itor)
 CALL psi_eval%delete
 CALL psi_geval%delete
 end subroutine gs_calc_vloop
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine gs_save_tokamaker(self,filename)
+class(gs_equil), intent(inout) :: self
+character(LEN=*), optional, intent(in) :: filename
+real(r8), pointer :: vals_tmp(:)
+integer(4) :: hash_tmp,io_unit
+logical :: pm_save
+CALL hdf5_create_file(filename)
+! CALL hdf5_create_group(filename,'mesh')
+! CALL hdf5_write(self%device%fe_rep%mesh%r,filename,'mesh/R')
+! CALL hdf5_write(self%device%fe_rep%mesh%lc,filename,'mesh/LC')
+CALL hdf5_create_group(filename,'tokamaker')
+CALL hdf5_write(self%device%fe_rep%order,filename,'tokamaker/FE_ORDER')
+hash_tmp = oft_simple_hash(C_LOC(self%device%mesh%lc),INT(4*3*self%device%mesh%nc,8))
+CALL hdf5_write(hash_tmp,filename,'tokamaker/LC_HASH')
+hash_tmp = oft_simple_hash(C_LOC(self%device%mesh%reg),INT(4*self%device%mesh%nc,8))
+CALL hdf5_write(hash_tmp,filename,'tokamaker/REG_HASH')
+CALL hdf5_write(self%device%ncoils,filename,'tokamaker/NCOILS')
+!---
+NULLIFY(vals_tmp)
+CALL self%psi%get_local(vals_tmp)
+CALL hdf5_write(vals_tmp,filename,'tokamaker/PSI')
+CALL hdf5_write(self%coil_currs,filename,'tokamaker/COIL_CURRENTS')
+!---
+CALL hdf5_write(self%ffp_scale,filename,'tokamaker/FFP_SCALE')
+CALL hdf5_write(self%I%f_offset,'tokamaker/F0')
+CALL hdf5_create_group(filename,'tokamaker/FFP_PROFILE')
+CALL self%I%save(filename,'tokamaker/FFP_PROFILE')
+CALL hdf5_write(self%p_scale,filename,'tokamaker/P_SCALE')
+CALL hdf5_create_group(filename,'tokamaker/PP_PROFILE')
+CALL self%P%save(filename,'tokamaker/PP_PROFILE')
+!---
+CALL hdf5_write(self%plasma_bounds,filename,'tokamaker/PSI_BOUNDS')
+CALL hdf5_write(self%o_point,filename,'tokamaker/O_POINT')
+CALL hdf5_write(self%lim_point,filename,'tokamaker/LIM_POINT')
+CALL hdf5_write(self%diverted,filename,'tokamaker/DIVERTED')
+!---
+IF(self%isoflux_ntargets>0)CALL hdf5_write(self%isoflux_targets,filename,'tokamaker/ISOFLUX_TARGETS')
+IF(self%flux_ntargets>0)CALL hdf5_write(self%flux_targets,filename,'tokamaker/FLUX_TARGETS')
+IF(self%saddle_ntargets>0)CALL hdf5_write(self%saddle_targets,filename,'tokamaker/SADDLE_TARGETS')
+end subroutine gs_save_tokamaker
+!------------------------------------------------------------------------------
+!> Needs Docs
+!------------------------------------------------------------------------------
+subroutine gs_load_tokamaker(self,filename)
+class(gs_equil), intent(inout) :: self
+character(LEN=*), optional, intent(in) :: filename
+integer(4) :: hash_tmp,hash_in,io_unit,int_tmp
+REAL(r8) :: pt_tmp(2),scale_tmp,diff_val
+real(r8), pointer :: vals_tmp(:)
+logical :: success,pm_save,logical_tmp
+! CALL hdf5_write(self%device%fe_rep%mesh%r,filename,'mesh/R')
+! CALL hdf5_write(self%device%fe_rep%mesh%lc,filename,'mesh/LC')
+!---Check compatibility of mesh and FE representation
+CALL hdf5_read(int_tmp,filename,'tokamaker/FE_ORDER',success=success)
+IF(int_tmp/=self%device%fe_rep%order)THEN
+  CALL oft_abort('FE order of equilibrium does not match current device.','gs_load_tokamaker',__FILE__)
+END IF
+hash_tmp = oft_simple_hash(C_LOC(self%device%mesh%lc),INT(4*3*self%device%mesh%nc,8))
+CALL hdf5_read(hash_in,filename,'tokamaker/LC_HASH',success=success)
+IF(hash_tmp/=hash_in)THEN
+  CALL oft_abort('Cell list hash for equilibrium does not match current device.','gs_load_tokamaker',__FILE__)
+END IF
+hash_tmp = oft_simple_hash(C_LOC(self%device%mesh%reg),INT(4*self%device%mesh%nc,8))
+CALL hdf5_read(hash_in,filename,'tokamaker/REG_HASH',success=success)
+IF(hash_tmp/=hash_in)THEN
+  CALL oft_abort('Region hash for equilibrium does not match current device.','gs_load_tokamaker',__FILE__)
+END IF
+CALL hdf5_read(int_tmp,filename,'tokamaker/NCOILS',success=success)
+IF(int_tmp/=self%device%ncoils)THEN
+  CALL oft_abort('Number of coils for equilibrium does not match current device.','gs_load_tokamaker',__FILE__)
+END IF
+!---Load psi and update bounds
+NULLIFY(vals_tmp)
+CALL self%psi%get_local(vals_tmp)
+CALL hdf5_read(vals_tmp,filename,'tokamaker/PSI',success=success)
+IF(.NOT.success)GOTO 100
+CALL hdf5_read(self%coil_currs,filename,'tokamaker/COIL_CURRENTS',success=success)
+IF(.NOT.success)GOTO 100
+CALL gs_update_bounds(self)
+!---Load flux functions
+CALL hdf5_read(self%ffp_scale,filename,'tokamaker/FFP_SCALE',success=success)
+IF(.NOT.success)GOTO 100
+CALL self%I%load(filename,'tokamaker/FFP_PROFILE',success=success)
+IF(.NOT.success)GOTO 100
+CALL hdf5_read(self%I%f_offset,filename,'tokamaker/F0',success=success)
+IF(.NOT.success)GOTO 100
+CALL hdf5_read(self%p_scale,filename,'tokamaker/P_SCALE',success=success)
+IF(.NOT.success)GOTO 100
+CALL self%P%load(filename,'tokamaker/PP_PROFILE',success=success)
+IF(.NOT.success)GOTO 100
+!---Check consistency of values and warn if they differ beyond expected numerical differences
+CALL hdf5_read(pt_tmp,filename,'tokamaker/PSI_BOUNDS',success=success)
+IF(.NOT.success)GOTO 100
+diff_val=ABS(pt_tmp(2)-pt_tmp(1))*1.d-2
+IF(ANY(ABS(pt_tmp-self%plasma_bounds)>diff_val))THEN
+  CALL oft_warn('Plasma bounds in equilibrium file do not match recomputed values.')
+END IF
+CALL hdf5_read(pt_tmp,filename,'tokamaker/O_POINT',success=success)
+IF(.NOT.success)GOTO 100
+diff_val=self%device%mesh%hrms
+IF(SQRT(SUM((pt_tmp-self%o_point)**2))>diff_val)THEN
+  CALL oft_warn('O-point in equilibrium file does not match recomputed location.')
+END IF
+CALL hdf5_read(pt_tmp,filename,'tokamaker/LIM_POINT',success=success)
+IF(.NOT.success)GOTO 100
+diff_val=self%device%mesh%hrms
+IF(SQRT(SUM((pt_tmp-self%lim_point)**2))>diff_val)THEN
+  CALL oft_warn('Limiting point in equilibrium file does not match recomputed location.')
+END IF
+CALL hdf5_read(logical_tmp,filename,'tokamaker/DIVERTED',success=success)
+IF(.NOT.success)GOTO 100
+IF(logical_tmp.NEQV.self%diverted)THEN
+  CALL oft_warn('Diverted status in equilibrium file does not match recomputed value.')
+END IF
+!---Load targets and coil currents
+IF(hdf5_field_exist(filename,'tokamaker/ISOFLUX_TARGETS'))THEN
+  CALL hdf5_read(self%isoflux_targets,filename,'tokamaker/ISOFLUX_TARGETS',success=success)
+  IF(.NOT.success)GOTO 100
+END IF
+IF(hdf5_field_exist(filename,'tokamaker/FLUX_TARGETS'))THEN
+  CALL hdf5_read(self%flux_targets,filename,'tokamaker/FLUX_TARGETS',success=success)
+  IF(.NOT.success)GOTO 100
+END IF
+IF(hdf5_field_exist(filename,'tokamaker/SADDLE_TARGETS'))THEN
+  CALL hdf5_read(self%saddle_targets,filename,'tokamaker/SADDLE_TARGETS',success=success)
+  IF(.NOT.success)GOTO 100
+END IF
+RETURN
+100 CALL oft_abort('Error loading equilibrium file.','gs_load_tokamaker',__FILE__)
+end subroutine gs_load_tokamaker
 !---------------------------------------------------------------------------
 !> Needs docs
 !---------------------------------------------------------------------------

--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -616,7 +616,8 @@ IF(hdf5_field_exist(filename,'tokamaker/ISOFLUX_TARGETS'))THEN
   CALL hdf5_field_get_sizes(filename,'tokamaker/ISOFLUX_TARGETS',ndims,dim_sizes)
   IF(dim_sizes(1)/=5)CALL oft_abort('Invalid first dimension for isoflux targets', 'gs_load_tokamaker', __FILE__)
   self%isoflux_ntargets=dim_sizes(2)
-  ALLOCATE(self%isoflux_targets(dim_sizes(1),dim_sizes(2)))
+  IF(ASSOCIATED(self%isoflux_targets))DEALLOCATE(self%isoflux_targets)
+  ALLOCATE(self%isoflux_targets(5,self%isoflux_ntargets))
   DEALLOCATE(dim_sizes)
   CALL hdf5_read(self%isoflux_targets,filename,'tokamaker/ISOFLUX_TARGETS',success=success)
   IF(.NOT.success)THEN
@@ -627,8 +628,9 @@ END IF
 IF(hdf5_field_exist(filename,'tokamaker/FLUX_TARGETS'))THEN
   CALL hdf5_field_get_sizes(filename,'tokamaker/FLUX_TARGETS',ndims,dim_sizes)
   IF(dim_sizes(1)/=4)CALL oft_abort('Invalid first dimension for flux targets', 'gs_load_tokamaker', __FILE__)
-  ALLOCATE(self%flux_targets(dim_sizes(1),dim_sizes(2)))
   self%flux_ntargets=dim_sizes(2)
+  IF(ASSOCIATED(self%flux_targets))DEALLOCATE(self%flux_targets)
+  ALLOCATE(self%flux_targets(4,self%flux_ntargets))
   DEALLOCATE(dim_sizes)
   CALL hdf5_read(self%flux_targets,filename,'tokamaker/FLUX_TARGETS',success=success)
   IF(.NOT.success)THEN
@@ -639,8 +641,9 @@ END IF
 IF(hdf5_field_exist(filename,'tokamaker/SADDLE_TARGETS'))THEN
   CALL hdf5_field_get_sizes(filename,'tokamaker/SADDLE_TARGETS',ndims,dim_sizes)
   IF(dim_sizes(1)/=3)CALL oft_abort('Invalid first dimension for saddle targets', 'gs_load_tokamaker', __FILE__)
-  ALLOCATE(self%saddle_targets(dim_sizes(1),dim_sizes(2)))
   self%saddle_ntargets=dim_sizes(2)
+  IF(ASSOCIATED(self%saddle_targets))DEALLOCATE(self%saddle_targets)
+  ALLOCATE(self%saddle_targets(3,self%saddle_ntargets))
   DEALLOCATE(dim_sizes)
   CALL hdf5_read(self%saddle_targets,filename,'tokamaker/SADDLE_TARGETS',success=success)
   IF(.NOT.success)THEN

--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -14,7 +14,8 @@
 MODULE oft_gs_util
 USE oft_base
 USE spline_mod
-USE oft_io, ONLY: hdf5_create_file, hdf5_create_group, hdf5_write, hdf5_read
+USE oft_io, ONLY: hdf5_create_file, hdf5_create_group, hdf5_write, hdf5_read, &
+  hdf5_field_get_sizes, hdf5_field_exist
 USE oft_mesh_type, ONLY: oft_bmesh, bmesh_findcell
 USE oft_la_base, ONLY: oft_vector
 USE oft_solver_base, ONLY: oft_solver
@@ -25,7 +26,7 @@ USE oft_blag_operators, ONLY: oft_blag_project, oft_lag_brinterp, oft_lag_bginte
 USE tracing_2d, ONLY: active_tracer, tracinginv_fs, set_tracer
 USE mhd_utils, ONLY: mu0
 USE oft_gs, ONLY: gs_factory, flux_func, gs_dflux, gs_itor_nl, gs_test_bounds, gs_b_interp, &
-  gs_get_qprof, gsinv_interp, gs_psi2r, gs_psi2pt, gs_epsilon
+  gs_get_qprof, gsinv_interp, gs_psi2r, gs_psi2pt, gs_epsilon, gs_update_bounds
 USE oft_gs_profiles
 USE grad_shaf_prof_phys, ONLY: create_jphi_ff, jphi_flux_func
 IMPLICIT NONE
@@ -77,6 +78,7 @@ END SUBROUTINE gs_profile_alloc
 SUBROUTINE gs_profile_load(filename,F)
 CHARACTER(LEN=*), INTENT(in) :: filename !< File storing function definition
 CLASS(flux_func), POINTER, INTENT(out) :: F !< Flux function object
+INTEGER(4) :: io_unit
 ! !---
 ! REAL(8) :: alpha,beta,sep
 ! REAL(8), ALLOCATABLE, DIMENSION(:) :: cofs,yvals
@@ -144,9 +146,7 @@ END SUBROUTINE gs_profile_load
 SUBROUTINE gs_profile_save(filename,F)
 CHARACTER(LEN=*), INTENT(in) :: filename !< File to store function definition
 CLASS(flux_func), POINTER, INTENT(in) :: F !< Flux function object
-!---
 INTEGER(4) :: io_unit
-!---
 OPEN(NEWUNIT=io_unit,FILE=TRIM(filename))
 ! !---
 ! SELECT TYPE(this=>F)
@@ -345,6 +345,7 @@ character(LEN=*), optional, intent(in) :: filename
 real(r8), pointer :: vals_tmp(:)
 integer(4) :: hash_tmp,io_unit
 logical :: pm_save
+IF(ASSOCIATED(self%P_ani))CALL oft_abort('Anisotropic pressure profiles not currently supported in tokamaker save.','gs_save_tokamaker',__FILE__)
 CALL hdf5_create_file(filename)
 ! CALL hdf5_create_group(filename,'mesh')
 ! CALL hdf5_write(self%device%fe_rep%mesh%r,filename,'mesh/R')
@@ -363,18 +364,36 @@ CALL hdf5_write(vals_tmp,filename,'tokamaker/PSI')
 CALL hdf5_write(self%coil_currs,filename,'tokamaker/COIL_CURRENTS')
 !---
 CALL hdf5_write(self%ffp_scale,filename,'tokamaker/FFP_SCALE')
-CALL hdf5_write(self%I%f_offset,'tokamaker/F0')
+CALL hdf5_write(self%I%f_offset,filename,'tokamaker/F0')
 CALL hdf5_create_group(filename,'tokamaker/FFP_PROFILE')
 CALL self%I%save(filename,'tokamaker/FFP_PROFILE')
 CALL hdf5_write(self%p_scale,filename,'tokamaker/P_SCALE')
 CALL hdf5_create_group(filename,'tokamaker/PP_PROFILE')
 CALL self%P%save(filename,'tokamaker/PP_PROFILE')
+IF(ASSOCIATED(self%I_NI))THEN
+  CALL hdf5_create_group(filename,'tokamaker/NI_PROFILE')
+  CALL self%I_NI%save(filename,'tokamaker/NI_PROFILE')
+END IF
+IF(ASSOCIATED(self%eta))THEN
+  CALL hdf5_create_group(filename,'tokamaker/ETA_PROFILE')
+  CALL self%eta%save(filename,'tokamaker/ETA_PROFILE')
+END IF
+! IF(ASSOCIATED(self%P_ani))THEN
+!   CALL hdf5_create_group(filename,'tokamaker/P_ANI')
+!   CALL self%P_ani%save(filename,'tokamaker/P_ANI')
+! END IF
 !---
 CALL hdf5_write(self%plasma_bounds,filename,'tokamaker/PSI_BOUNDS')
 CALL hdf5_write(self%o_point,filename,'tokamaker/O_POINT')
 CALL hdf5_write(self%lim_point,filename,'tokamaker/LIM_POINT')
 CALL hdf5_write(self%diverted,filename,'tokamaker/DIVERTED')
 !---
+IF(self%Itor_target>0.d0)CALL hdf5_write(self%Itor_target,filename,'tokamaker/IP_TARGET')
+IF(self%Ip_ratio_target>-1.d98)CALL hdf5_write(self%Ip_ratio_target,filename,'tokamaker/IP_RATIO_TARGET')
+IF(self%R0_target>0.d0)CALL hdf5_write(self%R0_target,filename,'tokamaker/R0_TARGET')
+IF(self%V0_target>-1.d98)CALL hdf5_write(self%V0_target,filename,'tokamaker/V0_TARGET')
+IF(self%pax_target>0.d0)CALL hdf5_write(self%pax_target,filename,'tokamaker/PAX_TARGET')
+IF(self%estore_target>0.d0)CALL hdf5_write(self%estore_target,filename,'tokamaker/ESTORE_TARGET')
 IF(self%isoflux_ntargets>0)CALL hdf5_write(self%isoflux_targets,filename,'tokamaker/ISOFLUX_TARGETS')
 IF(self%flux_ntargets>0)CALL hdf5_write(self%flux_targets,filename,'tokamaker/FLUX_TARGETS')
 IF(self%saddle_ntargets>0)CALL hdf5_write(self%saddle_targets,filename,'tokamaker/SADDLE_TARGETS')
@@ -385,10 +404,12 @@ end subroutine gs_save_tokamaker
 subroutine gs_load_tokamaker(self,filename)
 class(gs_equil), intent(inout) :: self
 character(LEN=*), optional, intent(in) :: filename
-integer(4) :: hash_tmp,hash_in,io_unit,int_tmp
+integer(4) :: hash_tmp,hash_in,io_unit,int_tmp,ndims
+integer(i4), allocatable :: dim_sizes(:)
 REAL(r8) :: pt_tmp(2),scale_tmp,diff_val
 real(r8), pointer :: vals_tmp(:)
 logical :: success,pm_save,logical_tmp
+CHARACTER(LEN=:), ALLOCATABLE :: profType
 ! CALL hdf5_write(self%device%fe_rep%mesh%r,filename,'mesh/R')
 ! CALL hdf5_write(self%device%fe_rep%mesh%lc,filename,'mesh/LC')
 !---Check compatibility of mesh and FE representation
@@ -415,25 +436,64 @@ NULLIFY(vals_tmp)
 CALL self%psi%get_local(vals_tmp)
 CALL hdf5_read(vals_tmp,filename,'tokamaker/PSI',success=success)
 IF(.NOT.success)GOTO 100
+CALL self%psi%restore_local(vals_tmp)
 CALL hdf5_read(self%coil_currs,filename,'tokamaker/COIL_CURRENTS',success=success)
 IF(.NOT.success)GOTO 100
 CALL gs_update_bounds(self)
 !---Load flux functions
 CALL hdf5_read(self%ffp_scale,filename,'tokamaker/FFP_SCALE',success=success)
 IF(.NOT.success)GOTO 100
+CALL hdf5_read(profType,filename,'tokamaker/FFP_PROFILE/TYPE',success=success)
+IF(.NOT.success)GOTO 100
+CALL gs_profile_alloc(profType,self%I)
+DEALLOCATE(profType)
 CALL self%I%load(filename,'tokamaker/FFP_PROFILE',success=success)
+CALL self%I%update(self)
 IF(.NOT.success)GOTO 100
 CALL hdf5_read(self%I%f_offset,filename,'tokamaker/F0',success=success)
 IF(.NOT.success)GOTO 100
 CALL hdf5_read(self%p_scale,filename,'tokamaker/P_SCALE',success=success)
 IF(.NOT.success)GOTO 100
-CALL self%P%load(filename,'tokamaker/PP_PROFILE',success=success)
+CALL hdf5_read(profType,filename,'tokamaker/PP_PROFILE/TYPE',success=success)
 IF(.NOT.success)GOTO 100
+CALL gs_profile_alloc(profType,self%P)
+DEALLOCATE(profType)
+CALL self%P%load(filename,'tokamaker/PP_PROFILE',success=success)
+CALL self%P%update(self)
+IF(.NOT.success)GOTO 100
+IF(hdf5_field_exist(filename,'tokamaker/NI_PROFILE'))THEN
+  CALL hdf5_read(profType,filename,'tokamaker/NI_PROFILE/TYPE',success=success)
+  IF(.NOT.success)GOTO 100
+  CALL gs_profile_alloc(profType,self%I_NI)
+  DEALLOCATE(profType)
+  CALL self%I_NI%load(filename,'tokamaker/NI_PROFILE',success=success)
+  IF(.NOT.success)GOTO 100
+  CALL self%I_NI%update(self)
+END IF
+IF(hdf5_field_exist(filename,'tokamaker/ETA_PROFILE'))THEN
+  CALL hdf5_read(profType,filename,'tokamaker/ETA_PROFILE/TYPE',success=success)
+  IF(.NOT.success)GOTO 100
+  CALL gs_profile_alloc(profType,self%eta)
+  DEALLOCATE(profType)
+  CALL self%eta%load(filename,'tokamaker/ETA_PROFILE',success=success)
+  IF(.NOT.success)GOTO 100
+  CALL self%eta%update(self)
+END IF
+! IF(hdf5_field_exist(filename,'tokamaker/P_ANI'))THEN
+!   CALL hdf5_read(profType,filename,'tokamaker/P_ANI/TYPE',success=success)
+!   IF(.NOT.success)GOTO 100
+!   CALL gs_ani_alloc(profType,self%P_ani)
+!   DEALLOCATE(profType)
+!   CALL self%P_ani%load(filename,'tokamaker/P_ANI',success=success)
+!   IF(.NOT.success)GOTO 100
+!   CALL self%P_ani%update(self)
+! END IF
 !---Check consistency of values and warn if they differ beyond expected numerical differences
 CALL hdf5_read(pt_tmp,filename,'tokamaker/PSI_BOUNDS',success=success)
 IF(.NOT.success)GOTO 100
 diff_val=ABS(pt_tmp(2)-pt_tmp(1))*1.d-2
 IF(ANY(ABS(pt_tmp-self%plasma_bounds)>diff_val))THEN
+  WRITE(*,*)pt_tmp,self%plasma_bounds
   CALL oft_warn('Plasma bounds in equilibrium file do not match recomputed values.')
 END IF
 CALL hdf5_read(pt_tmp,filename,'tokamaker/O_POINT',success=success)
@@ -454,15 +514,54 @@ IF(logical_tmp.NEQV.self%diverted)THEN
   CALL oft_warn('Diverted status in equilibrium file does not match recomputed value.')
 END IF
 !---Load targets and coil currents
+IF(hdf5_field_exist(filename,'tokamaker/IP_TARGET'))THEN
+  CALL hdf5_read(self%Itor_target,filename,'tokamaker/IP_TARGET',success=success)
+  IF(.NOT.success)GOTO 100
+END IF
+IF(hdf5_field_exist(filename,'tokamaker/IP_RATIO_TARGET'))THEN
+  CALL hdf5_read(self%Ip_ratio_target,filename,'tokamaker/IP_RATIO_TARGET',success=success)
+  IF(.NOT.success)GOTO 100
+END IF
+IF(hdf5_field_exist(filename,'tokamaker/R0_TARGET'))THEN
+  CALL hdf5_read(self%R0_target,filename,'tokamaker/R0_TARGET',success=success)
+  IF(.NOT.success)GOTO 100
+END IF
+IF(hdf5_field_exist(filename,'tokamaker/V0_TARGET'))THEN
+  CALL hdf5_read(self%V0_target,filename,'tokamaker/V0_TARGET',success=success)
+  IF(.NOT.success)GOTO 100
+END IF
+IF(hdf5_field_exist(filename,'tokamaker/PAX_TARGET'))THEN
+  CALL hdf5_read(self%pax_target,filename,'tokamaker/PAX_TARGET',success=success)
+  IF(.NOT.success)GOTO 100
+END IF
+IF(hdf5_field_exist(filename,'tokamaker/ESTORE_TARGET'))THEN
+  CALL hdf5_read(self%estore_target,filename,'tokamaker/ESTORE_TARGET',success=success)
+  IF(.NOT.success)GOTO 100
+END IF
 IF(hdf5_field_exist(filename,'tokamaker/ISOFLUX_TARGETS'))THEN
+  CALL hdf5_field_get_sizes(filename,'tokamaker/ISOFLUX_TARGETS',ndims,dim_sizes)
+  IF(dim_sizes(1)/=5)CALL oft_abort('Invalid first dimension for isoflux targets', 'gs_load_tokamaker', __FILE__)
+  self%isoflux_ntargets=dim_sizes(2)
+  ALLOCATE(self%isoflux_targets(dim_sizes(1),dim_sizes(2)))
+  DEALLOCATE(dim_sizes)
   CALL hdf5_read(self%isoflux_targets,filename,'tokamaker/ISOFLUX_TARGETS',success=success)
   IF(.NOT.success)GOTO 100
 END IF
 IF(hdf5_field_exist(filename,'tokamaker/FLUX_TARGETS'))THEN
+  CALL hdf5_field_get_sizes(filename,'tokamaker/FLUX_TARGETS',ndims,dim_sizes)
+  IF(dim_sizes(1)/=4)CALL oft_abort('Invalid first dimension for flux targets', 'gs_load_tokamaker', __FILE__)
+  ALLOCATE(self%flux_targets(dim_sizes(1),dim_sizes(2)))
+  self%flux_ntargets=dim_sizes(2)
+  DEALLOCATE(dim_sizes)
   CALL hdf5_read(self%flux_targets,filename,'tokamaker/FLUX_TARGETS',success=success)
   IF(.NOT.success)GOTO 100
 END IF
 IF(hdf5_field_exist(filename,'tokamaker/SADDLE_TARGETS'))THEN
+  CALL hdf5_field_get_sizes(filename,'tokamaker/SADDLE_TARGETS',ndims,dim_sizes)
+  IF(dim_sizes(1)/=3)CALL oft_abort('Invalid first dimension for saddle targets', 'gs_load_tokamaker', __FILE__)
+  ALLOCATE(self%saddle_targets(dim_sizes(1),dim_sizes(2)))
+  self%saddle_ntargets=dim_sizes(2)
+  DEALLOCATE(dim_sizes)
   CALL hdf5_read(self%saddle_targets,filename,'tokamaker/SADDLE_TARGETS',success=success)
   IF(.NOT.success)GOTO 100
 END IF

--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -341,7 +341,7 @@ end subroutine gs_calc_vloop
 !------------------------------------------------------------------------------
 subroutine gs_save_tokamaker(self,filename)
 class(gs_equil), intent(inout) :: self
-character(LEN=*), optional, intent(in) :: filename
+character(LEN=*), intent(in) :: filename
 real(r8), pointer :: vals_tmp(:)
 integer(4) :: hash_tmp,io_unit
 logical :: pm_save
@@ -391,7 +391,7 @@ CALL hdf5_write(self%diverted,filename,'tokamaker/DIVERTED')
 IF(self%Itor_target>0.d0)CALL hdf5_write(self%Itor_target,filename,'tokamaker/IP_TARGET')
 IF(self%Ip_ratio_target>-1.d98)CALL hdf5_write(self%Ip_ratio_target,filename,'tokamaker/IP_RATIO_TARGET')
 IF(self%R0_target>0.d0)CALL hdf5_write(self%R0_target,filename,'tokamaker/R0_TARGET')
-IF(self%V0_target>-1.d98)CALL hdf5_write(self%V0_target,filename,'tokamaker/V0_TARGET')
+IF(self%Z0_target>-1.d98)CALL hdf5_write(self%Z0_target,filename,'tokamaker/Z0_TARGET')
 IF(self%pax_target>0.d0)CALL hdf5_write(self%pax_target,filename,'tokamaker/PAX_TARGET')
 IF(self%estore_target>0.d0)CALL hdf5_write(self%estore_target,filename,'tokamaker/ESTORE_TARGET')
 IF(self%isoflux_ntargets>0)CALL hdf5_write(self%isoflux_targets,filename,'tokamaker/ISOFLUX_TARGETS')
@@ -401,9 +401,10 @@ end subroutine gs_save_tokamaker
 !------------------------------------------------------------------------------
 !> Needs Docs
 !------------------------------------------------------------------------------
-subroutine gs_load_tokamaker(self,filename)
+subroutine gs_load_tokamaker(self,filename,error_string)
 class(gs_equil), intent(inout) :: self
-character(LEN=*), optional, intent(in) :: filename
+character(LEN=*), intent(in) :: filename
+CHARACTER(LEN=OFT_ERROR_SLEN), intent(out) :: error_string
 integer(4) :: hash_tmp,hash_in,io_unit,int_tmp,ndims
 integer(i4), allocatable :: dim_sizes(:)
 REAL(r8) :: pt_tmp(2),scale_tmp,diff_val
@@ -415,68 +416,111 @@ CHARACTER(LEN=:), ALLOCATABLE :: profType
 !---Check compatibility of mesh and FE representation
 CALL hdf5_read(int_tmp,filename,'tokamaker/FE_ORDER',success=success)
 IF(int_tmp/=self%device%fe_rep%order)THEN
-  CALL oft_abort('FE order of equilibrium does not match current device.','gs_load_tokamaker',__FILE__)
+  error_string='FE order of equilibrium does not match current device.'
+  RETURN
 END IF
 hash_tmp = oft_simple_hash(C_LOC(self%device%mesh%lc),INT(4*3*self%device%mesh%nc,8))
 CALL hdf5_read(hash_in,filename,'tokamaker/LC_HASH',success=success)
 IF(hash_tmp/=hash_in)THEN
-  CALL oft_abort('Cell list hash for equilibrium does not match current device.','gs_load_tokamaker',__FILE__)
+  error_string='Cell list hash for equilibrium does not match current device.'
+  RETURN
 END IF
 hash_tmp = oft_simple_hash(C_LOC(self%device%mesh%reg),INT(4*self%device%mesh%nc,8))
 CALL hdf5_read(hash_in,filename,'tokamaker/REG_HASH',success=success)
 IF(hash_tmp/=hash_in)THEN
-  CALL oft_abort('Region hash for equilibrium does not match current device.','gs_load_tokamaker',__FILE__)
+  error_string='Region hash for equilibrium does not match current device.'
+  RETURN
 END IF
 CALL hdf5_read(int_tmp,filename,'tokamaker/NCOILS',success=success)
 IF(int_tmp/=self%device%ncoils)THEN
-  CALL oft_abort('Number of coils for equilibrium does not match current device.','gs_load_tokamaker',__FILE__)
+  error_string='Number of coils for equilibrium does not match current device.'
+  RETURN
 END IF
 !---Load psi and update bounds
 NULLIFY(vals_tmp)
 CALL self%psi%get_local(vals_tmp)
 CALL hdf5_read(vals_tmp,filename,'tokamaker/PSI',success=success)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string='Failed to read PSI values.'
+  RETURN
+END IF
 CALL self%psi%restore_local(vals_tmp)
 CALL hdf5_read(self%coil_currs,filename,'tokamaker/COIL_CURRENTS',success=success)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string='Failed to read coil currents.'
+  RETURN
+END IF
 CALL gs_update_bounds(self)
 !---Load flux functions
 CALL hdf5_read(self%ffp_scale,filename,'tokamaker/FFP_SCALE',success=success)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string="Failed to read F*F' scale."
+  RETURN
+END IF
 CALL hdf5_read(profType,filename,'tokamaker/FFP_PROFILE/TYPE',success=success)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string="Failed to read F*F' profile type."
+  RETURN
+END IF
 CALL gs_profile_alloc(profType,self%I)
 DEALLOCATE(profType)
 CALL self%I%load(filename,'tokamaker/FFP_PROFILE',success=success)
 CALL self%I%update(self)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string="Failed to load F*F' profile."
+  RETURN
+END IF
 CALL hdf5_read(self%I%f_offset,filename,'tokamaker/F0',success=success)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string='Failed to read F0 values.'
+  RETURN
+END IF
 CALL hdf5_read(self%p_scale,filename,'tokamaker/P_SCALE',success=success)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string='Failed to read P scale.'
+  RETURN
+END IF
 CALL hdf5_read(profType,filename,'tokamaker/PP_PROFILE/TYPE',success=success)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string="Failed to read P' profile type."
+  RETURN
+END IF
 CALL gs_profile_alloc(profType,self%P)
 DEALLOCATE(profType)
 CALL self%P%load(filename,'tokamaker/PP_PROFILE',success=success)
 CALL self%P%update(self)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string="Failed to load P' profile."
+  RETURN
+END IF
 IF(hdf5_field_exist(filename,'tokamaker/NI_PROFILE'))THEN
   CALL hdf5_read(profType,filename,'tokamaker/NI_PROFILE/TYPE',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to read non-inductive current profile type.'
+    RETURN
+  END IF
   CALL gs_profile_alloc(profType,self%I_NI)
   DEALLOCATE(profType)
   CALL self%I_NI%load(filename,'tokamaker/NI_PROFILE',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to load non-inductive current profile.'
+    RETURN
+  END IF
   CALL self%I_NI%update(self)
 END IF
 IF(hdf5_field_exist(filename,'tokamaker/ETA_PROFILE'))THEN
   CALL hdf5_read(profType,filename,'tokamaker/ETA_PROFILE/TYPE',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to read ETA profile type.'
+    RETURN
+  END IF
   CALL gs_profile_alloc(profType,self%eta)
   DEALLOCATE(profType)
   CALL self%eta%load(filename,'tokamaker/ETA_PROFILE',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to load ETA profile.'
+    RETURN
+  END IF
   CALL self%eta%update(self)
 END IF
 ! IF(hdf5_field_exist(filename,'tokamaker/P_ANI'))THEN
@@ -490,53 +534,82 @@ END IF
 ! END IF
 !---Check consistency of values and warn if they differ beyond expected numerical differences
 CALL hdf5_read(pt_tmp,filename,'tokamaker/PSI_BOUNDS',success=success)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string='Failed to read PSI bounds.'
+  RETURN
+END IF
 diff_val=ABS(pt_tmp(2)-pt_tmp(1))*1.d-2
 IF(ANY(ABS(pt_tmp-self%plasma_bounds)>diff_val))THEN
-  WRITE(*,*)pt_tmp,self%plasma_bounds
   CALL oft_warn('Plasma bounds in equilibrium file do not match recomputed values.')
 END IF
 CALL hdf5_read(pt_tmp,filename,'tokamaker/O_POINT',success=success)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string='Failed to read O-point.'
+  RETURN
+END IF
 diff_val=self%device%mesh%hrms
 IF(SQRT(SUM((pt_tmp-self%o_point)**2))>diff_val)THEN
   CALL oft_warn('O-point in equilibrium file does not match recomputed location.')
 END IF
 CALL hdf5_read(pt_tmp,filename,'tokamaker/LIM_POINT',success=success)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string='Failed to read Limiting point.'
+  RETURN
+END IF
 diff_val=self%device%mesh%hrms
 IF(SQRT(SUM((pt_tmp-self%lim_point)**2))>diff_val)THEN
   CALL oft_warn('Limiting point in equilibrium file does not match recomputed location.')
 END IF
 CALL hdf5_read(logical_tmp,filename,'tokamaker/DIVERTED',success=success)
-IF(.NOT.success)GOTO 100
+IF(.NOT.success)THEN
+  error_string='Failed to read Diverted status.'
+  RETURN
+END IF
 IF(logical_tmp.NEQV.self%diverted)THEN
   CALL oft_warn('Diverted status in equilibrium file does not match recomputed value.')
 END IF
 !---Load targets and coil currents
 IF(hdf5_field_exist(filename,'tokamaker/IP_TARGET'))THEN
   CALL hdf5_read(self%Itor_target,filename,'tokamaker/IP_TARGET',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to read Ip target.'
+    RETURN
+  END IF
 END IF
 IF(hdf5_field_exist(filename,'tokamaker/IP_RATIO_TARGET'))THEN
   CALL hdf5_read(self%Ip_ratio_target,filename,'tokamaker/IP_RATIO_TARGET',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to read Ip ratio target.'
+    RETURN
+  END IF
 END IF
 IF(hdf5_field_exist(filename,'tokamaker/R0_TARGET'))THEN
   CALL hdf5_read(self%R0_target,filename,'tokamaker/R0_TARGET',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to read R0 target.'
+    RETURN
+  END IF
 END IF
-IF(hdf5_field_exist(filename,'tokamaker/V0_TARGET'))THEN
-  CALL hdf5_read(self%V0_target,filename,'tokamaker/V0_TARGET',success=success)
-  IF(.NOT.success)GOTO 100
+IF(hdf5_field_exist(filename,'tokamaker/Z0_TARGET'))THEN
+  CALL hdf5_read(self%Z0_target,filename,'tokamaker/Z0_TARGET',success=success)
+  IF(.NOT.success)THEN
+    error_string='Failed to read Z0 target.'
+    RETURN
+  END IF
 END IF
 IF(hdf5_field_exist(filename,'tokamaker/PAX_TARGET'))THEN
   CALL hdf5_read(self%pax_target,filename,'tokamaker/PAX_TARGET',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to read P axis target.'
+    RETURN
+  END IF
 END IF
 IF(hdf5_field_exist(filename,'tokamaker/ESTORE_TARGET'))THEN
   CALL hdf5_read(self%estore_target,filename,'tokamaker/ESTORE_TARGET',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to read stored energy target.'
+    RETURN
+  END IF
 END IF
 IF(hdf5_field_exist(filename,'tokamaker/ISOFLUX_TARGETS'))THEN
   CALL hdf5_field_get_sizes(filename,'tokamaker/ISOFLUX_TARGETS',ndims,dim_sizes)
@@ -545,7 +618,10 @@ IF(hdf5_field_exist(filename,'tokamaker/ISOFLUX_TARGETS'))THEN
   ALLOCATE(self%isoflux_targets(dim_sizes(1),dim_sizes(2)))
   DEALLOCATE(dim_sizes)
   CALL hdf5_read(self%isoflux_targets,filename,'tokamaker/ISOFLUX_TARGETS',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to read isoflux targets.'
+    RETURN
+  END IF
 END IF
 IF(hdf5_field_exist(filename,'tokamaker/FLUX_TARGETS'))THEN
   CALL hdf5_field_get_sizes(filename,'tokamaker/FLUX_TARGETS',ndims,dim_sizes)
@@ -554,7 +630,10 @@ IF(hdf5_field_exist(filename,'tokamaker/FLUX_TARGETS'))THEN
   self%flux_ntargets=dim_sizes(2)
   DEALLOCATE(dim_sizes)
   CALL hdf5_read(self%flux_targets,filename,'tokamaker/FLUX_TARGETS',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to read flux targets.'
+    RETURN
+  END IF
 END IF
 IF(hdf5_field_exist(filename,'tokamaker/SADDLE_TARGETS'))THEN
   CALL hdf5_field_get_sizes(filename,'tokamaker/SADDLE_TARGETS',ndims,dim_sizes)
@@ -563,10 +642,11 @@ IF(hdf5_field_exist(filename,'tokamaker/SADDLE_TARGETS'))THEN
   self%saddle_ntargets=dim_sizes(2)
   DEALLOCATE(dim_sizes)
   CALL hdf5_read(self%saddle_targets,filename,'tokamaker/SADDLE_TARGETS',success=success)
-  IF(.NOT.success)GOTO 100
+  IF(.NOT.success)THEN
+    error_string='Failed to read saddle targets.'
+    RETURN
+  END IF
 END IF
-RETURN
-100 CALL oft_abort('Error loading equilibrium file.','gs_load_tokamaker',__FILE__)
 end subroutine gs_load_tokamaker
 !---------------------------------------------------------------------------
 !> Needs docs

--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -465,6 +465,10 @@ IF(.NOT.success)THEN
 END IF
 CALL gs_profile_alloc(profType,self%I)
 DEALLOCATE(profType)
+IF(ASSOCIATED(self%I))THEN
+  CALL self%I%delete()
+  DEALLOCATE(self%I)
+END IF
 CALL self%I%load(filename,'tokamaker/FFP_PROFILE',success=success)
 CALL self%I%update(self)
 IF(.NOT.success)THEN
@@ -486,6 +490,10 @@ IF(.NOT.success)THEN
   error_string="Failed to read P' profile type."
   RETURN
 END IF
+IF(ASSOCIATED(self%P))THEN
+  CALL self%P%delete()
+  DEALLOCATE(self%P)
+END IF
 CALL gs_profile_alloc(profType,self%P)
 DEALLOCATE(profType)
 CALL self%P%load(filename,'tokamaker/PP_PROFILE',success=success)
@@ -499,6 +507,10 @@ IF(hdf5_field_exist(filename,'tokamaker/NI_PROFILE'))THEN
   IF(.NOT.success)THEN
     error_string='Failed to read non-inductive current profile type.'
     RETURN
+  END IF
+  IF(ASSOCIATED(self%I_NI))THEN
+    CALL self%I_NI%delete()
+    DEALLOCATE(self%I_NI)
   END IF
   CALL gs_profile_alloc(profType,self%I_NI)
   DEALLOCATE(profType)
@@ -515,6 +527,10 @@ IF(hdf5_field_exist(filename,'tokamaker/ETA_PROFILE'))THEN
     error_string='Failed to read ETA profile type.'
     RETURN
   END IF
+  IF(ASSOCIATED(self%eta))THEN
+    CALL self%eta%delete()
+    DEALLOCATE(self%eta)
+  END IF
   CALL gs_profile_alloc(profType,self%eta)
   DEALLOCATE(profType)
   CALL self%eta%load(filename,'tokamaker/ETA_PROFILE',success=success)
@@ -527,6 +543,10 @@ END IF
 ! IF(hdf5_field_exist(filename,'tokamaker/P_ANI'))THEN
 !   CALL hdf5_read(profType,filename,'tokamaker/P_ANI/TYPE',success=success)
 !   IF(.NOT.success)GOTO 100
+!   IF(ASSOCIATED(self%P_ani))THEN
+!     CALL self%P_ani%delete()
+!     DEALLOCATE(self%P_ani)
+!   END IF
 !   CALL gs_ani_alloc(profType,self%P_ani)
 !   DEALLOCATE(profType)
 !   CALL self%P_ani%load(filename,'tokamaker/P_ANI',success=success)

--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -412,6 +412,7 @@ REAL(r8) :: pt_tmp(2),scale_tmp,diff_val
 real(r8), pointer :: vals_tmp(:)
 logical :: success,pm_save,logical_tmp
 CHARACTER(LEN=:), ALLOCATABLE :: profType
+error_string=''
 ! CALL hdf5_write(self%device%fe_rep%mesh%r,filename,'mesh/R')
 ! CALL hdf5_write(self%device%fe_rep%mesh%lc,filename,'mesh/LC')
 !---Check compatibility of mesh and FE representation

--- a/src/python/OpenFUSIONToolkit/TokaMaker/__init__.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/__init__.py
@@ -9,6 +9,6 @@
 @date May 2023
 @ingroup doxy_oft_python
 '''
-from ._core import TokaMaker, tokamaker_default_settings
+from ._core import TokaMaker
 
-__all__ = ["TokaMaker", "tokamaker_default_settings"]
+__all__ = ["TokaMaker"]

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1833,9 +1833,9 @@ class TokaMaker():
 
 
 class TokaMaker_equilibrium():
-    '''! TokaMaker G-S solver class'''
+    '''! TokaMaker G-S equilibrium class'''
     def __init__(self,TokaMaker_obj=None,source_eq=None,skip_targets=False,skip_constraints=False):
-        '''! Initialize TokaMaker object
+        '''! Initialize TokaMaker equilibrium object
 
         @param TokaMaker_obj TokaMaker object (See @ref OpenFUSIONToolkit.TokaMaker._core.TokaMaker "TokaMaker")
         @param source_eq Existing equilibrium object to copy

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1111,6 +1111,8 @@ class TokaMaker():
             if error_string.value != b'':
                 raise Exception(error_string.value)
             self._tMaker_equil = tmp_eq
+        else:
+            raise ValueError("Must specify either `source_eq` or `source_file`")
 
     def get_psi(self,normalized=True):
         r'''! Get poloidal flux values on node points
@@ -2754,7 +2756,7 @@ class TokaMaker_equilibrium():
             raise Exception(error_string.value)
     
     def save_TokaMaker(self,filename):
-        r'''! Save current equilibrium to an HDF5 file for latter use with TokaMaker
+        r'''! Save current equilibrium to an HDF5 file for later use with TokaMaker
 
         @param filename Filename to save equilibrium to
         '''

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1084,6 +1084,28 @@ class TokaMaker():
             raise ValueError("Equilibrium object is `None`")
         return TokaMaker_equilibrium(source_eq=self._tMaker_equil,skip_targets=skip_targets,skip_constraints=skip_constraints)
 
+    def replace_eq(self,source_eq=None,source_file=None,skip_targets=False,skip_constraints=False):
+        '''! Replace the current equilibrium object with a copy of another equilibrium object or one loaded from file
+        
+        @param source_eq `TokaMaker_equilibrium` object to copy from
+        @param source_file Path to a file containing a TokaMaker equilibrium
+        @param skip_targets When copying, skip copying target values
+        @param skip_constraints When copying, skip copying constraint values
+        @result New `TokaMaker_equilibrium` object with copied values
+        '''
+        if self._tMaker_equil is None:
+            raise ValueError("Equilibrium object is `None`")
+        if source_eq is not None:
+            if source_file is not None:
+                raise ValueError("Cannot specify both `source_eq` and `source_file`")
+            self._tMaker_equil = TokaMaker_equilibrium(source_eq=source_eq,skip_targets=skip_targets,skip_constraints=skip_constraints)
+        elif source_file is not None:
+            cfilename = self._oft_env.path2c(source_file)
+            error_string = self._oft_env.get_c_errorbuff()
+            tokamaker_load_tokamaker(self._tMaker_equil.c_ptr,cfilename,error_string)
+            if error_string.value != b'':
+                raise Exception(error_string.value)
+
     def get_psi(self,normalized=True):
         r'''! Get poloidal flux values on node points
 
@@ -2722,5 +2744,16 @@ class TokaMaker_equilibrium():
         cfilename = self._oft_env.path2c(filename)
         error_string = self._oft_env.get_c_errorbuff()
         tokamaker_save_mug(self._equil_ptr,cfilename,error_string)
+        if error_string.value != b'':
+            raise Exception(error_string.value)
+    
+    def save_TokaMaker(self,filename):
+        r'''! Save current equilibrium to an HDF5 file for latter use with TokaMaker
+
+        @param filename Filename to save equilibrium to
+        '''
+        cfilename = self._oft_env.path2c(filename)
+        error_string = self._oft_env.get_c_errorbuff()
+        tokamaker_save_tokamaker(self._equil_ptr,cfilename,error_string)
         if error_string.value != b'':
             raise Exception(error_string.value)

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -987,6 +987,11 @@ class TokaMaker():
                 raise ValueError("`R0` must be positive or set to `OFT_env.float_disable_flag` to disable")
             self._tMaker_equil._R0_target = copy.copy(R0)
         if V0 is not None:
+            warn(
+                "`V0` is deprecated, use `Z0` instead. This argument will be removed in a future version.",
+                DeprecationWarning,
+                stacklevel=2
+            )
             Z0 = V0
         if Z0 is not None:
             self._tMaker_equil._Z0_target = copy.copy(Z0)
@@ -1091,7 +1096,6 @@ class TokaMaker():
         @param source_file Path to a file containing a TokaMaker equilibrium
         @param skip_targets When copying, skip copying target values
         @param skip_constraints When copying, skip copying constraint values
-        @result New `TokaMaker_equilibrium` object with copied values
         '''
         if self._tMaker_equil is None:
             raise ValueError("Equilibrium object is `None`")
@@ -1100,11 +1104,13 @@ class TokaMaker():
                 raise ValueError("Cannot specify both `source_eq` and `source_file`")
             self._tMaker_equil = TokaMaker_equilibrium(source_eq=source_eq,skip_targets=skip_targets,skip_constraints=skip_constraints)
         elif source_file is not None:
+            tmp_eq = TokaMaker_equilibrium(source_eq=self._tMaker_equil,skip_targets=skip_targets,skip_constraints=skip_constraints)
             cfilename = self._oft_env.path2c(source_file)
             error_string = self._oft_env.get_c_errorbuff()
-            tokamaker_load_tokamaker(self._tMaker_equil.c_ptr,cfilename,error_string)
+            tokamaker_load_tokamaker(tmp_eq.c_ptr,cfilename,error_string)
             if error_string.value != b'':
                 raise Exception(error_string.value)
+            self._tMaker_equil = tmp_eq
 
     def get_psi(self,normalized=True):
         r'''! Get poloidal flux values on node points

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -16,27 +16,6 @@ from warnings import warn
 import numpy
 from ._interface import *
 
-def tokamaker_default_settings(oft_env):
-    '''! Initialize settings object with default values
-
-    @param oft_env Current runtime environment
-    @result tokamaker_settings_struct object
-    '''
-    settings = tokamaker_settings_struct()
-    settings.pm = True
-    settings.free_boundary = True
-    settings.limited_only = False
-    settings.dipole_mode = False
-    settings.mirror_mode = False
-    settings.maxits = 40
-    settings.mode = 1
-    settings.urf = 0.2
-    settings.nl_tol = 1.E-6
-    settings.rmin = 0.0
-    settings.lim_zmax = 1.E99
-    settings.limiter_file = oft_env.path2c('none')
-    return settings
-
 
 def create_prof_file(self, filename, profile_dict, name):
     '''! Create profile input file to be read by load_profiles()
@@ -84,6 +63,60 @@ def create_prof_file(self, filename, profile_dict, name):
         fid.write("\n".join(file_lines))
 
 
+class tokamaker_settings:
+    r'''! TokaMaker settings class'''
+    def __init__(self):
+        ## Print 'performance' information (eg. iteration count) during run?
+        self.pm = True
+        ## Perform free-boundary calculation?
+        self.free_boundary = True
+        ## Do not search for X-points when determining LCFS?
+        self.limited_only = False
+        ## Use dipole mode (only toroidal current, no pressure gradient)
+        self.dipole_mode = False
+        ## Use mirror mode (symmetry about z=0 plane, only upper half of mesh used)
+        self.mirror_mode = False
+        ## Maximum NL iteration count for G-S solver
+        self.maxits = 40
+        ## Parallel current source formulation used (0 -> define \f$F'\f$, 1 -> define \f$F*F'\f$)
+        self.mode = 1
+        ## Under-relaxation factor for NL fixed-point iteration
+        self.urf = 0.2
+        ## Convergence tolerance for NL solver
+        self.nl_tol = 1.E-6
+        ## Minimum magnetic axis major radius, used to catch 'lost' equilibria
+        self.rmin = 0.0
+        ## Maximum vertical range for limiter points, can be used to exclude complex diverter regions
+        self.lim_zmax = 1.E99
+        ## File containing additional limiter points not included in mesh (default: 'none')
+        self.limiter_file = None
+        # Must be added last
+        self._initialized = True
+
+    def __setattr__(self, name, value):
+        # Check if the attribute is being created for the first time after initialization
+        if (name not in self.__dict__) and hasattr(self, '_initialized'):
+            raise AttributeError(f"Cannot add new attribute '{name}' to tokamaker_settings")
+        super().__setattr__(name, value)
+    
+    def get_c_struct(self,oft_env):
+        r'''! Get C struct representation of settings for passing to TokaMaker Fortran API'''
+        c_struct_instance = tokamaker_settings_cstruct()
+        c_struct_instance.pm = self.pm
+        c_struct_instance.free_boundary = self.free_boundary
+        c_struct_instance.limited_only = self.limited_only
+        c_struct_instance.dipole_mode = self.dipole_mode
+        c_struct_instance.mirror_mode = self.mirror_mode
+        c_struct_instance.maxits = self.maxits
+        c_struct_instance.mode = self.mode
+        c_struct_instance.urf = self.urf
+        c_struct_instance.nl_tol = self.nl_tol
+        c_struct_instance.rmin = self.rmin
+        c_struct_instance.lim_zmax = self.lim_zmax
+        c_struct_instance.limiter_file = oft_env.path2c(self.limiter_file) if self.limiter_file else None
+        return c_struct_instance
+
+
 class TokaMaker():
     '''! TokaMaker G-S solver class'''
     def __init__(self,OFT_env):
@@ -100,7 +133,7 @@ class TokaMaker():
         ## Internal mesh object
         self._mesh_ptr = c_void_p()
         ## General settings object
-        self.settings = tokamaker_default_settings(self._oft_env)
+        self.settings = tokamaker_settings()
         ## Conductor definition dictionary
         self._cond_dict = {}
         ## Vacuum definition dictionary
@@ -164,7 +197,7 @@ class TokaMaker():
         self._tMaker_ptr = c_void_p()
         self._tMaker_equil = None
         self._mesh_ptr = c_void_p()
-        self.settings = tokamaker_default_settings(self._oft_env)
+        self.settings = tokamaker_settings()
         self._cond_dict = {}
         self._vac_dict = {}
         self._coil_dict = {}
@@ -1287,7 +1320,7 @@ class TokaMaker():
     def update_settings(self):
         '''! Update settings after changes to values in python'''
         error_string = self._oft_env.get_c_errorbuff()
-        tokamaker_set_settings(self._tMaker_ptr,ctypes.byref(self.settings),error_string)
+        tokamaker_set_settings(self._tMaker_ptr,self.settings.get_c_struct(self._oft_env),error_string)
         if error_string.value != b'':
             raise Exception(error_string.value)
     

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -745,17 +745,22 @@ class TokaMaker():
             raise ValueError("Equilibrium object is `None`")
         return self._tMaker_equil.set_resistivity(eta_prof)
 
-    def solve(self, vacuum=False):
+    def solve(self, vacuum=False, return_its=False):
         '''! Solve G-S equation with specified constraints, profiles, etc.
         
         @param vacuum Perform vacuum solve? Plasma-related targets (eg. `Ip`) will be ignored.
+        @param return_its Return the number of nonlinear iterations?
         @result Equilibrium object
         '''
+        nl_its = c_int()
         error_string = self._oft_env.get_c_errorbuff()
-        tokamaker_solve(self._tMaker_ptr,c_bool(vacuum),error_string)
+        tokamaker_solve(self._tMaker_ptr,c_bool(vacuum),ctypes.byref(nl_its),error_string)
         if error_string.value != b'':
             raise ValueError("Error in solve: {0}".format(error_string.value.decode()))
-        return self.copy_eq()
+        if return_its:
+            return self.copy_eq(), nl_its.value
+        else:
+            return self.copy_eq()
     
     def vac_solve(self,psi=None,rhs_source=None):
         '''! Solve for vacuum solution (no plasma), with present coil currents
@@ -1135,7 +1140,7 @@ class TokaMaker():
         if source_eq is not None:
             if source_file is not None:
                 raise ValueError("Cannot specify both `source_eq` and `source_file`")
-            self._tMaker_equil = TokaMaker_equilibrium(source_eq=source_eq,skip_targets=skip_targets,skip_constraints=skip_constraints)
+            tmp_eq = TokaMaker_equilibrium(source_eq=source_eq,skip_targets=skip_targets,skip_constraints=skip_constraints)
         elif source_file is not None:
             tmp_eq = TokaMaker_equilibrium(source_eq=self._tMaker_equil,skip_targets=skip_targets,skip_constraints=skip_constraints)
             cfilename = self._oft_env.path2c(source_file)
@@ -1143,9 +1148,13 @@ class TokaMaker():
             tokamaker_load_tokamaker(tmp_eq.c_ptr,cfilename,error_string)
             if error_string.value != b'':
                 raise Exception(error_string.value)
-            self._tMaker_equil = tmp_eq
         else:
             raise ValueError("Must specify either `source_eq` or `source_file`")
+        error_string = self._oft_env.get_c_errorbuff()
+        tokamaker_equil_set(self._tMaker_ptr,tmp_eq.c_ptr,error_string)
+        if error_string.value != b'':
+            raise Exception(error_string.value)
+        self._tMaker_equil = tmp_eq
 
     def get_psi(self,normalized=True):
         r'''! Get poloidal flux values on node points

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1752,7 +1752,7 @@ class TokaMaker():
 
         @param filename Filename to save equilibrium to
         @param npsi Number of radial sampling points
-        @param ntheta Number of vertical sampling points
+        @param ntheta Number of poloidal sampling points
         @param lcfs_pad Padding in normalized flux at LCFS
         @param lcfs_pressure Plasma pressure on the LCFS (zero by default)
         @param pack_lcfs Pack toward LCFS with quadraturic sampling?

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1924,17 +1924,28 @@ class TokaMaker_equilibrium():
             self._saddle_targets = None
         else:
             self._F0 = copy.copy(source_eq._F0)
-            if not skip_targets:
+            if skip_targets:
+                self._Ip_target = None
+                self._Ip_ratio_target = None
+                self._pax_target = None
+                self._estored_target = None
+                self._R0_target = None
+                self._Z0_target = None
+            else:
                 self._Ip_target = source_eq._Ip_target
                 self._Ip_ratio_target = source_eq._Ip_ratio_target
                 self._pax_target = source_eq._pax_target
                 self._estored_target = source_eq._estored_target
                 self._R0_target = source_eq._R0_target
                 self._Z0_target = source_eq._Z0_target
-            if not skip_constraints:
+            if skip_constraints:
+                self._isoflux_constraints = None
+                self._saddle_targets = None
+                self._psi_constraints = None
+            else:
                 self._isoflux_constraints = source_eq._isoflux_constraints.copy() if source_eq._isoflux_constraints is not None else None
                 self._saddle_targets = source_eq._saddle_targets.copy() if source_eq._saddle_targets is not None else None
-            self._psi_constraints = (source_eq._psi_constraints[0].copy(), source_eq._psi_constraints[1].copy()) if source_eq._psi_constraints is not None else None
+                self._psi_constraints = (source_eq._psi_constraints[0].copy(), source_eq._psi_constraints[1].copy()) if source_eq._psi_constraints is not None else None
         ## Normalized flux convention (0 -> tokamak, 1 -> spheromak)
         self.psi_convention = self._tMaker.psi_convention
         ## Free or fixed boundary flag

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -251,6 +251,14 @@ tokamaker_save_ifile = ctypes_subroutine(oftpy_lib.tokamaker_save_ifile,
 tokamaker_save_mug = ctypes_subroutine(oftpy_lib.tokamaker_save_mug,
     [c_void_p, c_char_p, c_char_p])
 
+# tokamaker_save_tokamaker(tMaker_equil_ptr,filename,error_str)
+tokamaker_save_tokamaker = ctypes_subroutine(oftpy_lib.tokamaker_save_tokamaker,
+    [c_void_p, c_char_p, c_char_p])
+
+# tokamaker_load_tokamaker(tMaker_equil_ptr,filename,error_str)
+tokamaker_load_tokamaker = ctypes_subroutine(oftpy_lib.tokamaker_load_tokamaker,
+    [c_void_p, c_char_p, c_char_p])
+
 # tokamaker_set_coil_current_dist(tMaker_ptr,iCoil,curr_dist,dist_pointer,normalize,error_str)
 tokamaker_set_coil_current_dist = ctypes_subroutine(oftpy_lib.tokamaker_set_coil_current_dist,
     [c_void_p, c_int, ctypes_numpy_array(numpy.float64,1), c_double_ptr_ptr, c_bool, c_char_p])

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -202,7 +202,7 @@ tokamaker_set_dipole_a = ctypes_subroutine(oftpy_lib.tokamaker_set_dipole_a,
 tokamaker_set_mirror_slosh = ctypes_subroutine(oftpy_lib.tokamaker_set_mirror_slosh,
     [c_void_p, c_double, c_double, c_double, c_char_p])
 
-# tokamaker_set_targets(tMaker_ptr,ip_target,ip_ratio_target,pax_target,estore_target,R0_target,V0_target,error_str)
+# tokamaker_set_targets(tMaker_ptr,ip_target,ip_ratio_target,pax_target,estore_target,R0_target,Z0_target,error_str)
 tokamaker_set_targets = ctypes_subroutine(oftpy_lib.tokamaker_set_targets,
     [c_void_p, c_double, c_double, c_double, c_double, c_double, c_double, c_char_p])
 

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -11,21 +11,8 @@
 '''
 from .._interface import *
 
-
-class tokamaker_settings_struct(c_struct):
-    r'''! TokaMaker settings structure
-
-     - `pm` Print 'performance' information (eg. iteration count) during run?
-     - `free_boundary` Perform free-boundary calculation?
-     - `limited_only` Do not search for X-points when determining LCFS?
-     - `maxits` Maximum NL iteration count for G-S solver
-     - `mode` Parallel current source formulation used (0 -> define \f$F'\f$, 1 -> define \f$F*F'\f$)
-     - `urf` Under-relaxation factor for NL fixed-point iteration
-     - `nl_tol` Convergence tolerance for NL solver
-     - `rmin` Minimum magnetic axis major radius, used to catch 'lost' equilibria
-     - `lim_zmax` Maximum vertical range for limiter points, can be used to exclude complex diverter regions
-     - `limiter_file` File containing additional limiter points not included in mesh (default: 'none')
-    '''
+## @cond
+class tokamaker_settings_cstruct(c_struct):
     _fields_ = [("pm", c_bool),
                 ("free_boundary", c_bool),
                 ("limited_only", c_bool),
@@ -39,8 +26,6 @@ class tokamaker_settings_struct(c_struct):
                 ("lim_zmax", c_double),
                 ("limiter_file", ctypes.c_char_p)]
 
-
-## @cond
 # tokamaker_alloc(tMaker_ptr,mesh_ptr,error_str)
 tokamaker_alloc = ctypes_subroutine(oftpy_lib.tokamaker_alloc,
     [c_void_ptr_ptr, c_void_p, c_char_p])
@@ -192,7 +177,7 @@ tokamaker_set_psi_dt = ctypes_subroutine(oftpy_lib.tokamaker_set_psi_dt,
 
 # tokamaker_set_settings(tMaker_ptr,settings,error_str)
 tokamaker_set_settings = ctypes_subroutine(oftpy_lib.tokamaker_set_settings,
-    [c_void_p, ctypes.POINTER(tokamaker_settings_struct), c_char_p])
+    [c_void_p, tokamaker_settings_cstruct, c_char_p])
 
 # tokamaker_set_dipole_a(tMaker_ptr,dipole_a,error_str)
 tokamaker_set_dipole_a = ctypes_subroutine(oftpy_lib.tokamaker_set_dipole_a,

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -62,9 +62,9 @@ tokamaker_load_profiles = ctypes_subroutine(oftpy_lib.tokamaker_load_profiles,
 tokamaker_init_psi = ctypes_subroutine(oftpy_lib.tokamaker_init_psi,
     [c_void_p, c_double, c_double, c_double, c_double, c_double, c_double_ptr, c_char_p])
 
-# tokamaker_solve(tMaker_ptr,vacuum,error_str)
+# tokamaker_solve(tMaker_ptr,vacuum,nl_its,error_str)
 tokamaker_solve = ctypes_subroutine(oftpy_lib.tokamaker_solve, 
-    [c_void_p, c_bool, c_char_p])
+    [c_void_p, c_bool, c_int_ptr, c_char_p])
 
 # tokamaker_vac_solve(tMaker_ptr,psi_in,rhs_source,error_str)
 tokamaker_vac_solve = ctypes_subroutine(oftpy_lib.tokamaker_vac_solve, 

--- a/src/python/OpenFUSIONToolkit/TokaMaker/reconstruction.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/reconstruction.py
@@ -9,31 +9,18 @@
 @date April 2024
 @ingroup doxy_oft_python
 '''
+from warnings import warn
 from .._interface import *
 from ..util import oft_warning
 
-class tokamaker_recon_settings_struct(c_struct):
-    r'''! TokaMaker reconstruction settings structure
-
-     - `fitI` Adjust \f$ F*F' \f$ parameterization coefficients?
-     - `fitP` Adjust \f$ P' \f$ parameterization coefficients?
-     - `fit_Pscale` Adjust \f$ P' \f$ scale factor?
-     - `fit_FFPscale` Adjust \f$ F*F' \f$ scale factor?
-     - `fitR0` Utilize and adjust \f$ R_0 \f$ constraint?
-     - `fitV0` Utilize and adjust \f$ Z_0 \f$ constraint?
-     - `fitCoils` Allow adjustment of PF coil currents?
-     - `fitF0` Allow adjustment of TF coil current?
-     - `fixedCentering` Do not update centering (initial guess for NL solve) as solve progresses
-     - `pm` Show detailed progress output?
-     - `infile` File containing constraint definitions
-     - `outfile` File to write output information to
-    '''
+## @cond
+class tokamaker_recon_settings_cstruct(c_struct):
     _fields_ = [("fitI", c_bool),
                 ("fitP", c_bool),
                 ("fit_Pscale", c_bool),
                 ("fit_FFPscale", c_bool),
                 ("fitR0", c_bool),
-                ("fitV0", c_bool),
+                ("fitZ0", c_bool),
                 ("fitCoils", c_bool),
                 ("fitF0", c_bool),
                 ("fixedCentering", c_bool),
@@ -41,32 +28,9 @@ class tokamaker_recon_settings_struct(c_struct):
                 ("infile", ctypes.c_char_p),
                 ("outfile", ctypes.c_char_p)]
 
-
-def tokamaker_recon_default_settings(oft_env):
-    '''! Initialize reconstruction settings object with default values
-
-    @param oft_env OFT runtime environment 
-    @result tokamaker_recon_settings_struct object
-    '''
-    settings = tokamaker_recon_settings_struct()
-    settings.fitI = False
-    settings.fitP = False
-    settings.fit_Pscale = True
-    settings.fit_FFPscale = True
-    settings.fitR0 = False
-    settings.fitV0 = False
-    settings.fitCoils = False
-    settings.fitF0 = False
-    settings.fixedCentering = False
-    settings.pm = False
-    settings.infile = oft_env.path2c('fit.in')
-    settings.outfile = oft_env.path2c('fit.out')
-    return settings
-
-## @cond
 # tokamaker_recon_run(tMaker_ptr,vacuum,settings,error_flag)
 tokamaker_recon_run = ctypes_subroutine(oftpy_lib.tokamaker_recon_run,
-    [c_void_p, c_bool, ctypes.POINTER(tokamaker_recon_settings_struct), c_int_ptr])
+    [c_void_p, c_bool, tokamaker_recon_settings_cstruct, c_int_ptr])
 ## @endcond
 
 Mirnov_con_id = 1
@@ -349,6 +313,78 @@ con_map = {
 }
 
 
+class tokamaker_recon_settings:
+    r'''! TokaMaker reconstruction settings class'''
+    def __init__(self):
+        ## Adjust \f$ F*F' \f$ parameterization coefficients?
+        self.fitI = False
+        ## Adjust \f$ P' \f$ parameterization coefficients?
+        self.fitP = False
+        ## Adjust \f$ P' \f$ scale factor?
+        self.fit_Pscale = True
+        ## Adjust \f$ F*F' \f$ scale factor?
+        self.fit_FFPscale = True
+        ## Utilize and adjust \f$ R_0 \f$ constraint?
+        self.fitR0 = False
+        ## Utilize and adjust \f$ Z_0 \f$ constraint?
+        self.fitZ0 = False
+        ## Allow adjustment of PF coil currents?
+        self.fitCoils = False
+        ## Allow adjustment of TF coil current?
+        self.fitF0 = False
+        ## Do not update centering (initial guess for NL solve) as solve progresses
+        self.fixedCentering = False
+        ## Show detailed progress output?
+        self.pm = False
+        ## File containing constraint definitions
+        self.infile = 'fit.in'
+        ## File to write output information to
+        self.outfile = 'fit.out'
+        # Must be added last
+        self._initialized = True
+
+    def __setattr__(self, name, value):
+        # Check if the attribute is being created for the first time after initialization
+        if (name not in self.__dict__) and hasattr(self, '_initialized'):
+            raise AttributeError(f"Cannot add new attribute '{name}' to tokamaker_recon_settings")
+        super().__setattr__(name, value)
+    
+    @property
+    def fitV0(self):
+        warn(
+            "`fitV0` is deprecated, use `fitZ0` instead. This function will be removed in a future version.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        return self.fitZ0
+    
+    @fitV0.setter
+    def fitV0(self, value):
+        warn(
+            "`fitV0` is deprecated, use `fitZ0` instead. This function will be removed in a future version.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        self.fitZ0 = value
+    
+    def get_c_struct(self,oft_env):
+        r'''! Get C struct representation of settings for passing to TokaMaker Fortran API'''
+        c_struct_instance = tokamaker_recon_settings_cstruct()
+        c_struct_instance.fitI = self.fitI
+        c_struct_instance.fitP = self.fitP
+        c_struct_instance.fit_Pscale = self.fit_Pscale
+        c_struct_instance.fit_FFPscale = self.fit_FFPscale
+        c_struct_instance.fitR0 = self.fitR0
+        c_struct_instance.fitZ0 = self.fitZ0
+        c_struct_instance.fitCoils = self.fitCoils
+        c_struct_instance.fitF0 = self.fitF0
+        c_struct_instance.fixedCentering = self.fixedCentering
+        c_struct_instance.pm = self.pm
+        c_struct_instance.infile = oft_env.path2c(self.infile)
+        c_struct_instance.outfile = oft_env.path2c(self.outfile)
+        return c_struct_instance
+
+
 class reconstruction():
     '''! TokaMaker equilibrium reconstruction class'''
     def __init__(self,tMaker_obj,in_filename='fit.in',out_filename='fit.out'):
@@ -361,7 +397,7 @@ class reconstruction():
         ## Grad-Shafranov object for reconstruction
         self._tMaker_obj = tMaker_obj
         ## Reconstruction specific settings object
-        self.settings = tokamaker_recon_default_settings(self._tMaker_obj._oft_env)
+        self.settings = tokamaker_recon_settings()
         ## Plasma current constraint
         self._Ip_con = None
         ## Diamagnetic flux constraint 
@@ -379,8 +415,8 @@ class reconstruction():
         ## Name of reconstruction output file
         self.out_file = out_filename
         # Update settings
-        self.settings.infile = self._tMaker_obj._oft_env.path2c(self.con_file)
-        self.settings.outfile = self._tMaker_obj._oft_env.path2c(self.out_file)
+        self.settings.infile = self.con_file
+        self.settings.outfile = self.out_file
         # Fit-specific input file settings
         self._tMaker_obj._oft_env.oft_in_groups['gs_fit_options'] = {
             'ftol': '1.E-3',
@@ -541,5 +577,5 @@ class reconstruction():
         self._tMaker_obj._oft_env.update_oft_in()
         # Run reconstruction
         error_flag = c_int()
-        tokamaker_recon_run(self._tMaker_obj._tMaker_ptr,c_bool(vacuum),self.settings,ctypes.byref(error_flag))
+        tokamaker_recon_run(self._tMaker_obj._tMaker_ptr,c_bool(vacuum),self.settings.get_c_struct(self._tMaker_obj._oft_env),ctypes.byref(error_flag))
         return error_flag.value

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -34,7 +34,7 @@ USE oft_gs, ONLY: gs_factory, gs_equil, gs_save_fields, gs_setup_walls, build_de
   gs_plasma_mutual, gs_source, gs_err_reason, gs_coil_source, gs_coil_source_distributed, gs_vacuum_solve, &
   gs_coil_mutual, gs_coil_mutual_distributed, gs_project_b, gs_save_mug, gs_update_bounds
 USE oft_gs_util, ONLY: gs_comp_globals, gs_save_eqdsk, gs_save_ifile, gs_profile_load, gs_profile_save, &
-  sauter_fc, gs_calc_vloop
+  sauter_fc, gs_calc_vloop, gs_save_tokamaker, gs_load_tokamaker
 USE oft_gs_fit, ONLY: fit_gs, fit_pm
 USE oft_gs_td, ONLY: oft_tmaker_td, eig_gs_td
 USE grad_shaf_prof_phys, ONLY: create_dipole_b0_prof, dipole_ani_press, mirror_ani_slosh

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -1649,6 +1649,36 @@ CALL copy_string_rev(filename,filename_tmp)
 CALL gs_save_mug(tMaker_equil_obj,filename_tmp)
 CALL copy_string(TRIM(error_flag),error_str)
 END SUBROUTINE tokamaker_save_mug
+!------------------------------------------------------------------------------
+!> Needs docs
+!------------------------------------------------------------------------------
+SUBROUTINE tokamaker_save_tokamaker(tMaker_equil_ptr,filename,error_str) BIND(C,NAME="tokamaker_save_tokamaker")
+TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< TokaMaker equilibrium instance
+CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Needs docs
+CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Needs docs
+CHARACTER(LEN=OFT_PATH_SLEN) :: filename_tmp
+CHARACTER(LEN=OFT_ERROR_SLEN) :: error_flag
+TYPE(gs_equil), POINTER :: tMaker_equil_obj
+IF(.NOT.tokamaker_equil_ccast(tMaker_equil_ptr,tMaker_equil_obj,error_str))RETURN
+CALL copy_string_rev(filename,filename_tmp)
+CALL gs_save_tokamaker(tMaker_equil_obj,filename_tmp)
+CALL copy_string(TRIM(error_flag),error_str)
+END SUBROUTINE tokamaker_save_tokamaker
+!------------------------------------------------------------------------------
+!> Needs docs
+!------------------------------------------------------------------------------
+SUBROUTINE tokamaker_load_tokamaker(tMaker_equil_ptr,filename,error_str) BIND(C,NAME="tokamaker_load_tokamaker")
+TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< TokaMaker equilibrium instance
+CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Needs docs
+CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Needs docs
+CHARACTER(LEN=OFT_PATH_SLEN) :: filename_tmp
+CHARACTER(LEN=OFT_ERROR_SLEN) :: error_flag
+TYPE(gs_equil), POINTER :: tMaker_equil_obj
+IF(.NOT.tokamaker_equil_ccast(tMaker_equil_ptr,tMaker_equil_obj,error_str))RETURN
+CALL copy_string_rev(filename,filename_tmp)
+CALL gs_load_tokamaker(tMaker_equil_obj,filename_tmp)
+CALL copy_string(TRIM(error_flag),error_str)
+END SUBROUTINE tokamaker_load_tokamaker
 !---------------------------------------------------------------------------
 !> Overwrites default coil flux contribution to non-uniform current distribution
 !------------------------------------------------------------------------------

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -1391,20 +1391,20 @@ END SUBROUTINE tokamaker_set_mirror_slosh
 !---------------------------------------------------------------------------------
 !> Needs docs
 !---------------------------------------------------------------------------------
-SUBROUTINE tokamaker_set_targets(tMaker_ptr,ip_target,ip_ratio_target,pax_target,estore_target,R0_target,V0_target,error_str) BIND(C,NAME="tokamaker_set_targets")
+SUBROUTINE tokamaker_set_targets(tMaker_ptr,ip_target,ip_ratio_target,pax_target,estore_target,R0_target,Z0_target,error_str) BIND(C,NAME="tokamaker_set_targets")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
 REAL(c_double), VALUE, INTENT(in) :: ip_target !< Needs docs
 REAL(c_double), VALUE, INTENT(in) :: ip_ratio_target !< Needs docs
 REAL(c_double), VALUE, INTENT(in) :: pax_target !< Needs docs
 REAL(c_double), VALUE, INTENT(in) :: estore_target !< Needs docs
 REAL(c_double), VALUE, INTENT(in) :: R0_target !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: V0_target !< Needs docs
+REAL(c_double), VALUE, INTENT(in) :: Z0_target !< Needs docs
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 TYPE(tokamaker_instance), POINTER :: tMaker_obj
 IF(.NOT.tokamaker_ccast(tMaker_ptr,tMaker_obj,error_str))RETURN
 IF(.NOT.tokamaker_require_equil(tMaker_obj,error_str))RETURN
 tMaker_obj%gs_equil%R0_target=R0_target
-tMaker_obj%gs_equil%V0_target=V0_target
+tMaker_obj%gs_equil%Z0_target=Z0_target
 tMaker_obj%gs_equil%pax_target=pax_target*mu0
 tMaker_obj%gs_equil%estore_target=estore_target*mu0
 tMaker_obj%gs_equil%itor_target=ip_target*mu0
@@ -1657,12 +1657,10 @@ TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< TokaMaker equilibrium inst
 CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Needs docs
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Needs docs
 CHARACTER(LEN=OFT_PATH_SLEN) :: filename_tmp
-CHARACTER(LEN=OFT_ERROR_SLEN) :: error_flag
 TYPE(gs_equil), POINTER :: tMaker_equil_obj
 IF(.NOT.tokamaker_equil_ccast(tMaker_equil_ptr,tMaker_equil_obj,error_str))RETURN
 CALL copy_string_rev(filename,filename_tmp)
 CALL gs_save_tokamaker(tMaker_equil_obj,filename_tmp)
-CALL copy_string(TRIM(error_flag),error_str)
 END SUBROUTINE tokamaker_save_tokamaker
 !------------------------------------------------------------------------------
 !> Needs docs
@@ -1676,7 +1674,7 @@ CHARACTER(LEN=OFT_ERROR_SLEN) :: error_flag
 TYPE(gs_equil), POINTER :: tMaker_equil_obj
 IF(.NOT.tokamaker_equil_ccast(tMaker_equil_ptr,tMaker_equil_obj,error_str))RETURN
 CALL copy_string_rev(filename,filename_tmp)
-CALL gs_load_tokamaker(tMaker_equil_obj,filename_tmp)
+CALL gs_load_tokamaker(tMaker_equil_obj,filename_tmp,error_flag)
 CALL copy_string(TRIM(error_flag),error_str)
 END SUBROUTINE tokamaker_load_tokamaker
 !---------------------------------------------------------------------------

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -219,7 +219,7 @@ DO i=1,n
 END DO
 END SUBROUTINE tokamaker_eval_green
 !---------------------------------------------------------------------------------
-!> Setup TokaMaker region representations based on coil, conductor, and other inforamtion
+!> Setup TokaMaker region representations based on coil, conductor, and other information
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_setup_regions(tMaker_ptr,coil_file,reg_eta,contig_flag,xpoint_mask,coil_nturns,ncoils,error_str) BIND(C,NAME="tokamaker_setup_regions")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -68,7 +68,7 @@ TYPE, BIND(C) :: tokamaker_recon_settings_type
   LOGICAL(KIND=c_bool) :: fit_Pscale = .FALSE. !< Needs docs
   LOGICAL(KIND=c_bool) :: fit_FFPscale = .FALSE. !< Needs docs
   LOGICAL(KIND=c_bool) :: fitR0 = .TRUE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: fitV0 = .FALSE. !< Needs docs
+  LOGICAL(KIND=c_bool) :: fitZ0 = .FALSE. !< Needs docs
   LOGICAL(KIND=c_bool) :: fitCoils = .FALSE. !< Needs docs
   LOGICAL(KIND=c_bool) :: fitF0 = .FALSE. !< Needs docs
   LOGICAL(KIND=c_bool) :: fixedCentering = .FALSE. !< Needs docs
@@ -521,9 +521,9 @@ END SUBROUTINE tokamaker_vac_solve
 SUBROUTINE tokamaker_recon_run(tMaker_ptr,vacuum,settings,error_flag) BIND(C,NAME="tokamaker_recon_run")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
 LOGICAL(c_bool), VALUE, INTENT(in) :: vacuum !< Needs docs
-TYPE(tokamaker_recon_settings_type), INTENT(in) :: settings !< Needs docs
+TYPE(tokamaker_recon_settings_type), VALUE, INTENT(in) :: settings !< Needs docs
 INTEGER(c_int), INTENT(out) :: error_flag !< Needs docs
-LOGICAL :: fitI,fitP,fit_Pscale,fit_FFPscale,fitR0,fitV0,fitCoils,fitF0,fixedCentering
+LOGICAL :: fitI,fitP,fit_Pscale,fit_FFPscale,fitR0,fitZ0,fitCoils,fitF0,fixedCentering
 CHARACTER(KIND=c_char), POINTER, DIMENSION(:) :: infile_c,outfile_c
 CHARACTER(LEN=OFT_PATH_SLEN) :: infile,outfile
 TYPE(tokamaker_instance), POINTER :: tMaker_obj
@@ -542,7 +542,7 @@ fitP=settings%fitP
 fit_Pscale=settings%fit_Pscale
 fit_FFPscale=settings%fit_FFPscale
 fitR0=settings%fitR0
-fitV0=settings%fitV0
+fitZ0=settings%fitZ0
 fitCoils=settings%fitCoils
 fitF0=settings%fitF0
 fixedCentering=settings%fixedCentering
@@ -553,7 +553,7 @@ CALL copy_string_rev(infile_c,infile)
 CALL copy_string_rev(outfile_c,outfile)
 tMaker_obj%device%timing=0.d0
 CALL fit_gs(tMaker_obj%gs_equil,infile,outfile,fitI,fitP,fit_Pscale,&
-            fit_FFPscale,fitR0,fitV0,fitCoils,fitF0, &
+            fit_FFPscale,fitR0,fitZ0,fitCoils,fitF0, &
             fixedCentering)
 CALL gs_profile_save(TRIM(outfile)//'_fprof',tMaker_obj%gs_equil%I)
 CALL gs_profile_save(TRIM(outfile)//'_pprof',tMaker_obj%gs_equil%P)
@@ -1297,7 +1297,7 @@ END SUBROUTINE tokamaker_set_psi_dt
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_settings(tMaker_ptr,settings,error_str) BIND(C,NAME="tokamaker_set_settings")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
-TYPE(tokamaker_settings_type), INTENT(in) :: settings !< Settings object
+TYPE(tokamaker_settings_type), VALUE, INTENT(in) :: settings !< Settings object
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 CHARACTER(KIND=c_char), POINTER, DIMENSION(:) :: limfile_c
 TYPE(tokamaker_instance), POINTER :: tMaker_obj
@@ -1315,8 +1315,12 @@ IF((.NOT.tMaker_obj%device%dipole_mode).AND.settings%dipole_mode)CALL oft_warn("
 tMaker_obj%device%dipole_mode=settings%dipole_mode
 IF((.NOT.tMaker_obj%device%mirror_mode).AND.settings%mirror_mode)CALL oft_warn("TokaMaker's mirror functionality is experimental, use with caution and report bugs")
 tMaker_obj%device%mirror_mode=settings%mirror_mode
-CALL c_f_pointer(settings%limiter_file,limfile_c,[OFT_PATH_SLEN])
-CALL copy_string_rev(limfile_c,tMaker_obj%device%limiter_file)
+IF(c_associated(settings%limiter_file))THEN
+  CALL c_f_pointer(settings%limiter_file,limfile_c,[OFT_PATH_SLEN])
+  CALL copy_string_rev(limfile_c,tMaker_obj%device%limiter_file)
+ELSE
+  tMaker_obj%device%limiter_file="none"
+END IF
 END SUBROUTINE tokamaker_set_settings
 !---------------------------------------------------------------------------------
 !> Needs docs

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -43,56 +43,56 @@ USE oft_base_f, ONLY: copy_string, copy_string_rev, oftpy_init
 IMPLICIT NONE
 #include "local.h"
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> TokaMaker settings structure for passing settings between Python to Fortran
 !---------------------------------------------------------------------------------
 TYPE, BIND(C) :: tokamaker_settings_type
-  LOGICAL(KIND=c_bool) :: pm = .FALSE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: free_boundary = .FALSE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: limited_only = .FALSE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: dipole_mode = .FALSE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: mirror_mode = .FALSE. !< Needs docs
-  INTEGER(KIND=c_int) :: maxits = 40 !< Needs docs
-  INTEGER(KIND=c_int) :: mode = 1 !< Needs docs
-  REAL(KIND=c_double) :: urf = 0.3d0 !< Needs docs
-  REAL(KIND=c_double) :: nl_tol = 1.d-6 !< Needs docs
-  REAL(KIND=c_double) :: rmin = 0.d0 !< Needs docs
-  REAL(KIND=c_double) :: lim_zmax = 1.d99 !< Needs docs
-  TYPE(c_ptr) :: limiter_file !< Needs docs
+  LOGICAL(KIND=c_bool) :: pm = .FALSE. !< Print 'performance' information (eg. iteration count) during run?
+  LOGICAL(KIND=c_bool) :: free_boundary = .FALSE. !< Perform free-boundary calculation?
+  LOGICAL(KIND=c_bool) :: limited_only = .FALSE. !< Do not search for X-points when determining LCFS?
+  LOGICAL(KIND=c_bool) :: dipole_mode = .FALSE. !< Use dipole mode (only toroidal current, no pressure gradient)
+  LOGICAL(KIND=c_bool) :: mirror_mode = .FALSE. !< Use mirror mode (symmetry about z=0 plane, only upper half of mesh used)
+  INTEGER(KIND=c_int) :: maxits = 40 !< Maximum NL iteration count for G-S solver
+  INTEGER(KIND=c_int) :: mode = 1 !< Parallel current source formulation used (0 -> define \f$F'\f$, 1 -> define \f$F*F'\f$)
+  REAL(KIND=c_double) :: urf = 0.3d0 !< Under-relaxation factor for NL fixed-point iteration
+  REAL(KIND=c_double) :: nl_tol = 1.d-6 !< Convergence tolerance for NL solver
+  REAL(KIND=c_double) :: rmin = 0.d0 !< Minimum magnetic axis major radius, used to catch 'lost' equilibria
+  REAL(KIND=c_double) :: lim_zmax = 1.d99 !< Maximum vertical range for limiter points, can be used to exclude complex diverter regions
+  TYPE(c_ptr) :: limiter_file !< File containing additional limiter points not included in mesh (default: 'none')
 END TYPE tokamaker_settings_type
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> TokaMaker reconstruction settings structure for passing settings between Python to Fortran
 !---------------------------------------------------------------------------------
 TYPE, BIND(C) :: tokamaker_recon_settings_type
-  LOGICAL(KIND=c_bool) :: fitI = .TRUE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: fitP = .TRUE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: fit_Pscale = .FALSE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: fit_FFPscale = .FALSE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: fitR0 = .TRUE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: fitZ0 = .FALSE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: fitCoils = .FALSE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: fitF0 = .FALSE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: fixedCentering = .FALSE. !< Needs docs
-  LOGICAL(KIND=c_bool) :: pm = .FALSE. !< Needs docs
-  TYPE(c_ptr) :: infile !< Needs docs
-  TYPE(c_ptr) :: outfile !< Needs docs
+  LOGICAL(KIND=c_bool) :: fitI = .TRUE. !< Adjust \f$ F*F' \f$ parameterization coefficients?
+  LOGICAL(KIND=c_bool) :: fitP = .TRUE. !< Adjust \f$ P' \f$ parameterization coefficients?
+  LOGICAL(KIND=c_bool) :: fit_Pscale = .FALSE. !< Adjust \f$ P' \f$ scale factor?
+  LOGICAL(KIND=c_bool) :: fit_FFPscale = .FALSE. !< Adjust \f$ F*F' \f$ scale factor?
+  LOGICAL(KIND=c_bool) :: fitR0 = .TRUE. !< Utilize and adjust \f$ R_0 \f$ constraint?
+  LOGICAL(KIND=c_bool) :: fitZ0 = .FALSE. !< Utilize and adjust \f$ Z_0 \f$ constraint?
+  LOGICAL(KIND=c_bool) :: fitCoils = .FALSE. !< Allow adjustment of PF coil currents?
+  LOGICAL(KIND=c_bool) :: fitF0 = .FALSE. !< Allow adjustment of TF coil current?
+  LOGICAL(KIND=c_bool) :: fixedCentering = .FALSE. !< Do not update centering (initial guess for NL solve) as solve progresses
+  LOGICAL(KIND=c_bool) :: pm = .FALSE. !< Show detailed progress output?
+  TYPE(c_ptr) :: infile !< File containing constraint definitions
+  TYPE(c_ptr) :: outfile !< File to write output information to
 END TYPE tokamaker_recon_settings_type
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> TokaMaker wrapper object for Python API
 !---------------------------------------------------------------------------------
 TYPE :: tokamaker_instance
-  INTEGER(i4) :: mode = 1 !< Needs docs
-  INTEGER(i4), POINTER, DIMENSION(:) :: reg_plot => NULL() !< Needs docs
-  INTEGER(i4), POINTER, DIMENSION(:,:) :: lc_plot => NULL() !< Needs docs
-  REAL(r8), POINTER, DIMENSION(:,:) :: r_plot => NULL() !< Needs docs
-  TYPE(multigrid_mesh), POINTER :: ml_mesh => NULL() !< Mesh container
+  INTEGER(i4) :: mode = 1 !< Parallel current source formulation used (0 -> define \f$F'\f$, 1 -> define \f$F*F'\f$)
+  INTEGER(i4), POINTER, DIMENSION(:) :: reg_plot => NULL() !< Region index on tesselated plotting mesh
+  INTEGER(i4), POINTER, DIMENSION(:,:) :: lc_plot => NULL() !< Cell list for tesselated plotting mesh
+  REAL(r8), POINTER, DIMENSION(:,:) :: r_plot => NULL() !< Point list for tesselated plotting mesh
+  TYPE(multigrid_mesh), POINTER :: ml_mesh => NULL() !< ML mesh container
   TYPE(oft_ml_fem_type), POINTER :: ML_oft_blagrange => NULL() !< Finite element container
-  TYPE(gs_factory), POINTER :: device => NULL() !< G-S object
-  TYPE(gs_equil), POINTER :: gs_equil => NULL() !< G-S object
+  TYPE(gs_factory), POINTER :: device => NULL() !< G-S device object
+  TYPE(gs_equil), POINTER :: gs_equil => NULL() !< Active G-S equilibrium object
   TYPE(oft_tmaker_td), POINTER :: gs_td => NULL() !< Time-dependent G-S object
 END TYPE tokamaker_instance
 CONTAINS
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Allocate TokaMaker wrapper object and initialize with mesh information
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_alloc(tMaker_ptr,mesh_ptr,error_str) BIND(C,NAME="tokamaker_alloc")
 TYPE(c_ptr), INTENT(out) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -110,7 +110,7 @@ tMaker_ptr=C_LOC(tMaker_obj)
 CALL c_f_pointer(mesh_ptr,tMaker_obj%ml_mesh)
 END SUBROUTINE tokamaker_alloc
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Copy TokaMaker equilibrium object
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_equil_copy(tMaker_ptr,old_equil_ptr,new_equil_ptr,error_str) BIND(C,NAME="tokamaker_equil_copy")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -134,7 +134,7 @@ END IF
 new_equil_ptr=C_LOC(new_equil)
 END SUBROUTINE tokamaker_equil_copy
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Set TokaMaker equilibrium object for use in TokaMaker wrapper object
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_equil_set(tMaker_ptr,new_equil_ptr,error_str) BIND(C,NAME="tokamaker_equil_set")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -147,7 +147,7 @@ IF(.NOT.tokamaker_equil_ccast(new_equil_ptr,new_equil,error_str))RETURN
 tMaker_obj%gs_equil=>new_equil
 END SUBROUTINE tokamaker_equil_set
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Cast C pointer to TokaMaker wrapper object
 !---------------------------------------------------------------------------------
 FUNCTION tokamaker_ccast(tMaker_cptr,tMaker_obj,error_str) RESULT(success)
 TYPE(c_ptr), INTENT(in) :: tMaker_cptr !< C pointer to TokaMaker object
@@ -165,7 +165,7 @@ CALL c_f_pointer(tMaker_cptr,tMaker_obj)
 success=.TRUE.
 END FUNCTION tokamaker_ccast
 !---------------------------------------------------------------------------------
-!> Evaluate Green's function for axisymmetric toroidal current loop
+!> Cast C pointer to TokaMaker equilibrium object
 !---------------------------------------------------------------------------------
 FUNCTION tokamaker_equil_ccast(tMaker_equil_cptr,tMaker_equil_obj,error_str) RESULT(success)
 TYPE(c_ptr), INTENT(in) :: tMaker_equil_cptr !< C pointer to TokaMaker equilibrium object
@@ -183,7 +183,7 @@ CALL c_f_pointer(tMaker_equil_cptr,tMaker_equil_obj)
 success=.TRUE.
 END FUNCTION tokamaker_equil_ccast
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Require TokaMaker wrapper object to have TokaMaker equilibrium object allocated
 !---------------------------------------------------------------------------------
 FUNCTION tokamaker_require_equil(tMaker_obj,error_str) RESULT(success)
 TYPE(tokamaker_instance), INTENT(in) :: tMaker_obj
@@ -199,7 +199,7 @@ END IF
 success=.TRUE.
 END FUNCTION tokamaker_require_equil
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Evaluate Green's function for axisymmetric toroidal current loop
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_eval_green(n,r,z,rc,zc,vals) BIND(C,NAME="tokamaker_eval_green")
 INTEGER(c_int), VALUE, INTENT(in) :: n !< Number of evaluation points
@@ -219,16 +219,16 @@ DO i=1,n
 END DO
 END SUBROUTINE tokamaker_eval_green
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Setup TokaMaker region representations based on coil, conductor, and other inforamtion
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_setup_regions(tMaker_ptr,coil_file,reg_eta,contig_flag,xpoint_mask,coil_nturns,ncoils,error_str) BIND(C,NAME="tokamaker_setup_regions")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
-CHARACTER(KIND=c_char), INTENT(in) :: coil_file(OFT_PATH_SLEN) !< Needs docs
-TYPE(c_ptr), VALUE, INTENT(in) :: reg_eta !< Needs docs
-TYPE(c_ptr), VALUE, INTENT(in) :: contig_flag !< Needs docs
-TYPE(c_ptr), VALUE, INTENT(in) :: xpoint_mask !< Needs docs
-TYPE(c_ptr), VALUE, INTENT(in) :: coil_nturns !< Needs docs
-INTEGER(c_int), VALUE, INTENT(in) :: ncoils !< Needs docs
+CHARACTER(KIND=c_char), INTENT(in) :: coil_file(OFT_PATH_SLEN) !< Path to file containing coil information (for legacy region loading)
+TYPE(c_ptr), VALUE, INTENT(in) :: reg_eta !< Resistivity values for each region
+TYPE(c_ptr), VALUE, INTENT(in) :: contig_flag !< Toroidal contiguity/inner limiter flag for each region (1 if toroidally contiguous, 0 if not, -1 if inner limiter region)
+TYPE(c_ptr), VALUE, INTENT(in) :: xpoint_mask !< Region mask for X-point search (1 if region can contain X-points, 0 otherwise)
+TYPE(c_ptr), VALUE, INTENT(in) :: coil_nturns !< Number of turns for each coil
+INTEGER(c_int), VALUE, INTENT(in) :: ncoils !< Number of coils
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 real(r8), POINTER :: eta_tmp(:),nturns_tmp(:,:)
 INTEGER(i4), POINTER :: contig_tmp(:)
@@ -288,7 +288,7 @@ ELSE
 END IF
 END SUBROUTINE tokamaker_setup_regions
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Destroy TokaMaker wrapper object and associated device object
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_destroy(tMaker_ptr,error_str) BIND(C,NAME="tokamaker_destroy")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -317,7 +317,7 @@ END IF
 DEALLOCATE(tMaker_obj)
 END SUBROUTINE tokamaker_destroy
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Destroy TokaMaker equilibrium object
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_equil_destroy(tMaker_equil_ptr,error_str) BIND(C,NAME="tokamaker_equil_destroy")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< Pointer to TokaMaker equilibrium object
@@ -328,14 +328,14 @@ CALL tMaker_equil_obj%delete()
 DEALLOCATE(tMaker_equil_obj)
 END SUBROUTINE tokamaker_equil_destroy
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Complete setup of TokaMaker device/wrapper object and build FE representation
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_setup(tMaker_ptr,order,full_domain,ncoils,coil_Lmat,error_str) BIND(C,NAME="tokamaker_setup")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
 INTEGER(KIND=c_int), VALUE, INTENT(in) :: order !< FE order for Lagrange elements
-LOGICAL(KIND=c_bool), VALUE, INTENT(in) :: full_domain !< Needs docs
-INTEGER(KIND=c_int), INTENT(out) :: ncoils !< Needs docs
-TYPE(c_ptr), INTENT(out) :: coil_Lmat !< Needs docs
+LOGICAL(KIND=c_bool), VALUE, INTENT(in) :: full_domain !< Plasma covers full domain (eg. fixed-boundary solves)?
+INTEGER(KIND=c_int), INTENT(out) :: ncoils !< Number of coils in model
+TYPE(c_ptr), INTENT(out) :: coil_Lmat !< Pointer to coil inductance matrix
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 INTEGER(4) :: i,ierr,io_unit,npts,iostat
 REAL(8) :: theta
@@ -424,7 +424,7 @@ CALL copy_string_rev(f_NI_file,tmp_str)
 IF(TRIM(tmp_str)/='none')CALL gs_profile_load(tmp_str,tMaker_equil_obj%I_NI)
 END SUBROUTINE tokamaker_load_profiles
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Initialize \f$ \psi \f$ using a uniform or specified current source
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_init_psi(tMaker_ptr,r0,z0,a,kappa,delta,rhs_source,error_str) BIND(C,NAME="tokamaker_init_psi")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -449,7 +449,7 @@ END IF
 IF(ierr/=0)CALL copy_string(gs_err_reason(ierr),error_str)
 END SUBROUTINE tokamaker_init_psi
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Perform nonlinear solve to find equilibrium solution for given profiles, targets, etc.
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_solve(tMaker_ptr,vacuum,nl_its,error_str) BIND(C,NAME="tokamaker_solve")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -479,7 +479,7 @@ IF(ierr/=0)CALL copy_string(gs_err_reason(ierr),error_str)
 nl_its=tMaker_obj%device%nl_its
 END SUBROUTINE tokamaker_solve
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Perform linear solve to find vacuum solution for given BCs and current sources
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_vac_solve(tMaker_ptr,psi_in,rhs_source,error_str) BIND(C,NAME="tokamaker_vac_solve")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -518,13 +518,13 @@ CALL psi_tmp%delete()
 DEALLOCATE(psi_tmp)
 END SUBROUTINE tokamaker_vac_solve
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Perform an equilibrium reconstruction using TokaMaker
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_recon_run(tMaker_ptr,vacuum,settings,error_flag) BIND(C,NAME="tokamaker_recon_run")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
-LOGICAL(c_bool), VALUE, INTENT(in) :: vacuum !< Needs docs
-TYPE(tokamaker_recon_settings_type), VALUE, INTENT(in) :: settings !< Needs docs
-INTEGER(c_int), INTENT(out) :: error_flag !< Needs docs
+LOGICAL(c_bool), VALUE, INTENT(in) :: vacuum !< Reconstruct vacuum equilibrium (no plasma)?
+TYPE(tokamaker_recon_settings_type), VALUE, INTENT(in) :: settings !< Reconstruction settings struct
+INTEGER(c_int), INTENT(out) :: error_flag !< Error flag (0 if no error)
 LOGICAL :: fitI,fitP,fit_Pscale,fit_FFPscale,fitR0,fitZ0,fitCoils,fitF0,fixedCentering
 CHARACTER(KIND=c_char), POINTER, DIMENSION(:) :: infile_c,outfile_c
 CHARACTER(LEN=OFT_PATH_SLEN) :: infile,outfile
@@ -562,27 +562,7 @@ CALL gs_profile_save(TRIM(outfile)//'_pprof',tMaker_obj%gs_equil%P)
 tMaker_obj%gs_equil%has_plasma=.TRUE.
 END SUBROUTINE tokamaker_recon_run
 !---------------------------------------------------------------------------------
-!> Needs docs
-!---------------------------------------------------------------------------------
-SUBROUTINE tokamaker_setup_td(tMaker_ptr,dt,lin_tol,nl_tol,pre_plasma,error_str) BIND(C,NAME="tokamaker_setup_td")
-TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
-REAL(c_double), VALUE, INTENT(in) :: dt !< Time step size
-REAL(c_double), VALUE, INTENT(in) :: lin_tol !< Linear solver tolerance
-REAL(c_double), VALUE, INTENT(in) :: nl_tol !< Nonlinear solver tolerance
-LOGICAL(c_bool), VALUE, INTENT(in) :: pre_plasma !< Include plasma contributions in preconditioner?
-CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
-TYPE(tokamaker_instance), POINTER :: tMaker_obj
-IF(.NOT.tokamaker_ccast(tMaker_ptr,tMaker_obj,error_str))RETURN
-IF(.NOT.tokamaker_require_equil(tMaker_obj,error_str))RETURN
-IF(ASSOCIATED(tMaker_obj%gs_td))THEN
-  CALL tMaker_obj%gs_td%delete()
-  DEALLOCATE(tMaker_obj%gs_td)
-END IF
-ALLOCATE(tMaker_obj%gs_td)
-CALL tMaker_obj%gs_td%setup(tMaker_obj%gs_equil,dt,lin_tol,nl_tol,LOGICAL(pre_plasma))
-END SUBROUTINE tokamaker_setup_td
-!---------------------------------------------------------------------------------
-!> Needs docs
+!> Compute eigenvalues/eigenvectors of linearized plasma-conductor system
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_eig_td(tMaker_ptr,omega,neigs,eigs,eig_vecs,include_bounds,eta_plasma,pm,error_str) BIND(C,NAME="tokamaker_eig_td")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -615,7 +595,7 @@ CALL copy_string('Eigenvalue solve requires ARPACK',error_str)
 #endif
 END SUBROUTINE tokamaker_eig_td
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Compute eigenvalues/eigenvectors of conductor (wall) system
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_eig_wall(tMaker_ptr,neigs,eigs,eig_vecs,pm,error_str) BIND(C,NAME="tokamaker_eig_wall")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -650,7 +630,27 @@ CALL copy_string('Eigenvalue solve requires ARPACK',error_str)
 #endif
 END SUBROUTINE tokamaker_eig_wall
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Setup nonlinear time-dependent solver
+!---------------------------------------------------------------------------------
+SUBROUTINE tokamaker_setup_td(tMaker_ptr,dt,lin_tol,nl_tol,pre_plasma,error_str) BIND(C,NAME="tokamaker_setup_td")
+TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
+REAL(c_double), VALUE, INTENT(in) :: dt !< Time step size
+REAL(c_double), VALUE, INTENT(in) :: lin_tol !< Linear solver tolerance
+REAL(c_double), VALUE, INTENT(in) :: nl_tol !< Nonlinear solver tolerance
+LOGICAL(c_bool), VALUE, INTENT(in) :: pre_plasma !< Include plasma contributions in preconditioner?
+CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
+TYPE(tokamaker_instance), POINTER :: tMaker_obj
+IF(.NOT.tokamaker_ccast(tMaker_ptr,tMaker_obj,error_str))RETURN
+IF(.NOT.tokamaker_require_equil(tMaker_obj,error_str))RETURN
+IF(ASSOCIATED(tMaker_obj%gs_td))THEN
+  CALL tMaker_obj%gs_td%delete()
+  DEALLOCATE(tMaker_obj%gs_td)
+END IF
+ALLOCATE(tMaker_obj%gs_td)
+CALL tMaker_obj%gs_td%setup(tMaker_obj%gs_equil,dt,lin_tol,nl_tol,LOGICAL(pre_plasma))
+END SUBROUTINE tokamaker_setup_td
+!---------------------------------------------------------------------------------
+!> Advance the time-dependent solver by one time step
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_step_td(tMaker_ptr,curr_ptr,volt_ptr,time,dt,nl_its,lin_its,nretry,error_str) BIND(C,NAME="tokamaker_step_td")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -675,7 +675,7 @@ CALL tMaker_obj%gs_td%step(coil_currents,coil_voltages,time,dt,nl_its,lin_its,nr
 DEALLOCATE(coil_currents,coil_voltages)
 END SUBROUTINE tokamaker_step_td
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Build tessellated plotting mesh and return pointers to mesh information
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_get_mesh(tMaker_ptr,np,r_loc,nc,lc_loc,reg_loc,error_str) BIND(C,NAME="tokamaker_get_mesh")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -710,7 +710,7 @@ END IF
 reg_loc=c_loc(tMaker_obj%reg_plot)
 END SUBROUTINE tokamaker_get_mesh
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Get limiter geometry information
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_get_limiter(tMaker_ptr,np,r_loc,nloops,loop_ptr,error_str) BIND(C,NAME="tokamaker_get_limiter")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
@@ -733,7 +733,7 @@ nloops=tMaker_obj%device%lim_nloops
 loop_ptr=C_LOC(tMaker_obj%device%lim_ptr)
 END SUBROUTINE tokamaker_get_limiter
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Get \f$ \psi \f$ values for equilibrium
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_get_psi(tMaker_equil_ptr,psi_vals,psi_lim,psi_max,error_str) BIND(C,NAME="tokamaker_get_psi")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< Pointer to TokaMaker equilibrium object
@@ -750,7 +750,7 @@ psi_lim = tMaker_equil_obj%plasma_bounds(1)
 psi_max = tMaker_equil_obj%plasma_bounds(2)
 END SUBROUTINE tokamaker_get_psi
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Compute current density from \f$ \psi \f$ using \f$ \Delta^* \psi \f$ operator
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_get_dels_curr(tMaker_equil_ptr,psi_vals,error_str) BIND(C,NAME="tokamaker_get_dels_curr")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< Pointer to TokaMaker equilibrium object
@@ -786,7 +786,7 @@ CALL minv%delete()
 DEALLOCATE(u,v,minv)
 END SUBROUTINE tokamaker_get_dels_curr
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Compute plasma toroidal current density using G-S RHS source
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_get_jtor(tMaker_equil_ptr,jtor,error_str) BIND(C,NAME="tokamaker_get_jtor")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< Pointer to TokaMaker equilibrium object
@@ -979,13 +979,13 @@ p_scale=c_loc(tMaker_equil_obj%p_scale)
 has_plasma=c_loc(tMaker_equil_obj%has_plasma)
 END SUBROUTINE tokamaker_get_refs
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Trace a flux surface at specified \f$ \psi \f$ value and return points defining the surface
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_trace_surf(tMaker_equil_ptr,psi_surf,points,npoints,error_str) BIND(C,NAME="tokamaker_trace_surf")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< Pointer to TokaMaker equilibrium object
-REAL(c_double), VALUE, INTENT(in) :: psi_surf !< Needs docs
-TYPE(c_ptr), INTENT(out) ::  points !< Needs docs
-INTEGER(c_int), INTENT(out) :: npoints !< Needs docs
+REAL(c_double), VALUE, INTENT(in) :: psi_surf !< Location in normalized flux coordinates to trace surface (eg. 0 for LCFS)
+TYPE(c_ptr), INTENT(out) ::  points !< Points defining surface
+INTEGER(c_int), INTENT(out) :: npoints !< Number of points in contour
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 REAL(8), POINTER, DIMENSION(:,:) :: pts_tmp
 TYPE(gs_equil), POINTER :: tMaker_equil_obj
@@ -1241,11 +1241,11 @@ ELSE IF(int_type>=5)THEN
 END IF
 END SUBROUTINE tokamaker_apply_field_eval
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Set \f$ \psi \f$ values in TokaMaker equilibrium object
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_psi(tMaker_equil_ptr,psi_vals,update_bounds,error_str) BIND(C,NAME="tokamaker_set_psi")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< TokaMaker equilibrium instance
-TYPE(c_ptr), VALUE, INTENT(in) :: psi_vals !< Needs docs
+TYPE(c_ptr), VALUE, INTENT(in) :: psi_vals !< New \f$ \psi \f$ values to set in TokaMaker equilibrium object
 LOGICAL(c_bool), VALUE, INTENT(in) :: update_bounds !< Update bounds by determining new limiting points
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 REAL(8), POINTER, DIMENSION(:) :: vals_tmp
@@ -1325,7 +1325,7 @@ ELSE
 END IF
 END SUBROUTINE tokamaker_set_settings
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Set parameters for dipole anisotropic pressure profile
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_dipole_a(tMaker_ptr,dipole_a,error_str) BIND(C,NAME="tokamaker_set_dipole_a")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
@@ -1357,7 +1357,7 @@ ELSE
 END IF
 END SUBROUTINE tokamaker_set_dipole_a
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Set parameters for mirror anisotropic pressure profile
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_mirror_slosh(tMaker_ptr,mirror_n,mirror_bturn,mirror_zthroat,error_str) BIND(C,NAME="tokamaker_set_mirror_slosh")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
@@ -1395,16 +1395,16 @@ ELSE
 END IF
 END SUBROUTINE tokamaker_set_mirror_slosh
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Set global target values for equilibrium solve
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_targets(tMaker_ptr,ip_target,ip_ratio_target,pax_target,estore_target,R0_target,Z0_target,error_str) BIND(C,NAME="tokamaker_set_targets")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
-REAL(c_double), VALUE, INTENT(in) :: ip_target !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: ip_ratio_target !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: pax_target !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: estore_target !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: R0_target !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: Z0_target !< Needs docs
+REAL(c_double), VALUE, INTENT(in) :: ip_target !< Target plasma current [A]
+REAL(c_double), VALUE, INTENT(in) :: ip_ratio_target !< Ratio of net plasma current contribution from \f$F F'\f$ compared to \f$ P' \f$
+REAL(c_double), VALUE, INTENT(in) :: pax_target !< Target axis pressure [Pa]
+REAL(c_double), VALUE, INTENT(in) :: estore_target !< Target sotred energy [J]
+REAL(c_double), VALUE, INTENT(in) :: R0_target !< Target major radius for magnetic axis
+REAL(c_double), VALUE, INTENT(in) :: Z0_target !< Target vertical position for magnetic axis
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 TYPE(tokamaker_instance), POINTER :: tMaker_obj
 IF(.NOT.tokamaker_ccast(tMaker_ptr,tMaker_obj,error_str))RETURN
@@ -1417,15 +1417,15 @@ tMaker_obj%gs_equil%itor_target=ip_target*mu0
 tMaker_obj%gs_equil%ip_ratio_target=ip_ratio_target
 END SUBROUTINE tokamaker_set_targets
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Sets isoflux targets for a TokaMaker instance
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_isoflux(tMaker_ptr,targets,ref_points,weights,ntargets,grad_wt_lim,error_str) BIND(C,NAME="tokamaker_set_isoflux")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
-INTEGER(c_int), VALUE, INTENT(in) :: ntargets !< Needs docs
-REAL(c_double), INTENT(in) :: targets(2,ntargets) !< Needs docs
-REAL(c_double), INTENT(in) :: ref_points(2,ntargets) !< Needs docs
-REAL(c_double), INTENT(in) :: weights(ntargets) !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: grad_wt_lim !< Needs docs
+INTEGER(c_int), VALUE, INTENT(in) :: ntargets !< Number of isoflux target points
+REAL(c_double), INTENT(in) :: targets(2,ntargets) !< Isoflux target locations
+REAL(c_double), INTENT(in) :: ref_points(2,ntargets) !< Reference points for isoflux targets
+REAL(c_double), INTENT(in) :: weights(ntargets) !< Weights for isoflux targets
+REAL(c_double), VALUE, INTENT(in) :: grad_wt_lim !< Limit on gradient-based weighting (negative to disable)
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 TYPE(tokamaker_instance), POINTER :: tMaker_obj
 IF(.NOT.tokamaker_ccast(tMaker_ptr,tMaker_obj,error_str))RETURN
@@ -1443,15 +1443,15 @@ ELSE
 END IF
 END SUBROUTINE tokamaker_set_isoflux
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Sets the flux targets for a TokaMaker instance
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_flux(tMaker_ptr,locations,targets,weights,ntargets,grad_wt_lim,error_str) BIND(C,NAME="tokamaker_set_flux")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
-INTEGER(c_int), VALUE, INTENT(in) :: ntargets !< Needs docs
-REAL(c_double), INTENT(in) :: locations(2,ntargets) !< Needs docs
-REAL(c_double), INTENT(in) :: targets(ntargets) !< Needs docs
-REAL(c_double), INTENT(in) :: weights(ntargets) !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: grad_wt_lim !< Needs docs
+INTEGER(c_int), VALUE, INTENT(in) :: ntargets !< Number of flux target points
+REAL(c_double), INTENT(in) :: locations(2,ntargets) !< Flux target locations
+REAL(c_double), INTENT(in) :: targets(ntargets) !< Flux target values
+REAL(c_double), INTENT(in) :: weights(ntargets) !< Weights for flux targets
+REAL(c_double), VALUE, INTENT(in) :: grad_wt_lim !< Limit on gradient-based weighting (negative to disable)
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 TYPE(tokamaker_instance), POINTER :: tMaker_obj
 IF(.NOT.tokamaker_ccast(tMaker_ptr,tMaker_obj,error_str))RETURN
@@ -1469,13 +1469,13 @@ IF(ntargets>0)THEN
 END IF
 END SUBROUTINE tokamaker_set_flux
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Sets the saddle point targets for a TokaMaker instance
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_saddles(tMaker_ptr,targets,weights,ntargets,error_str) BIND(C,NAME="tokamaker_set_saddles")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
-INTEGER(c_int), VALUE, INTENT(in) :: ntargets !< Needs docs
-REAL(c_double), INTENT(in) :: targets(2,ntargets) !< Needs docs
-REAL(c_double), INTENT(in) :: weights(ntargets) !< Needs docs
+INTEGER(c_int), VALUE, INTENT(in) :: ntargets !< Number of saddle point target points
+REAL(c_double), INTENT(in) :: targets(2,ntargets) !< Saddle point target locations
+REAL(c_double), INTENT(in) :: weights(ntargets) !< Weights for saddle point targets
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error information
 TYPE(tokamaker_instance), POINTER :: tMaker_obj
 IF(.NOT.tokamaker_ccast(tMaker_ptr,tMaker_obj,error_str))RETURN
@@ -1489,11 +1489,11 @@ IF(ntargets>0)THEN
 END IF
 END SUBROUTINE tokamaker_set_saddles
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Set coil currents for a TokaMaker instance
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_coil_currents(tMaker_ptr,currents,error_str) BIND(C,NAME="tokamaker_set_coil_currents")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
-TYPE(c_ptr), VALUE, INTENT(in) :: currents !< Needs docs
+TYPE(c_ptr), VALUE, INTENT(in) :: currents !< Coil currents [A]
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error information
 INTEGER(4) :: i
 REAL(8) :: curr
@@ -1506,14 +1506,14 @@ tMaker_obj%gs_equil%coil_currs = vals_tmp*mu0
 tMaker_obj%gs_equil%vcontrol_val = 0.d0
 END SUBROUTINE tokamaker_set_coil_currents
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Sets the regularization matrix for coil currents in a TokaMaker instance
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_coil_regmat(tMaker_ptr,nregularize,coil_reg_mat,coil_reg_targets,coil_reg_weights,error_str) BIND(C,NAME="tokamaker_set_coil_regmat")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
-INTEGER(c_int), VALUE, INTENT(in) :: nregularize !< Needs docs
-TYPE(c_ptr), VALUE, INTENT(in) :: coil_reg_mat !< Needs docs
-TYPE(c_ptr), VALUE, INTENT(in) :: coil_reg_targets !< Needs docs
-TYPE(c_ptr), VALUE, INTENT(in) :: coil_reg_weights !< Needs docs
+INTEGER(c_int), VALUE, INTENT(in) :: nregularize !< Number of regularization terms
+TYPE(c_ptr), VALUE, INTENT(in) :: coil_reg_mat !< Regularization matrix for coil currents
+TYPE(c_ptr), VALUE, INTENT(in) :: coil_reg_targets !< Target values for regularization
+TYPE(c_ptr), VALUE, INTENT(in) :: coil_reg_weights !< Weights for regularization terms
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error information
 REAL(8), POINTER, DIMENSION(:,:) :: vals_tmp
 INTEGER(4) :: i
@@ -1535,11 +1535,11 @@ DO i=1,tMaker_obj%gs_equil%nregularize
 END DO
 END SUBROUTINE tokamaker_set_coil_regmat
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Set hard bounds on coil currents for a TokaMaker instance
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_coil_bounds(tMaker_ptr,coil_bounds,error_str) BIND(C,NAME="tokamaker_set_coil_bounds")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
-TYPE(c_ptr), VALUE, INTENT(in) :: coil_bounds !< Needs docs
+TYPE(c_ptr), VALUE, INTENT(in) :: coil_bounds !< Hard bounds for each coil's current
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error information
 REAL(8), POINTER, DIMENSION(:,:) :: vals_tmp
 INTEGER(4) :: i
@@ -1556,11 +1556,11 @@ END DO
 tMaker_obj%device%coil_bounds([2,1],tMaker_obj%device%ncoils+1)=-vals_tmp(:,tMaker_obj%device%ncoils+1)*mu0
 END SUBROUTINE tokamaker_set_coil_bounds
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Define virtual VSC coil for a TokaMaker instance as a weighted sum of physical coils
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_coil_vsc(tMaker_ptr,coil_gains,error_str) BIND(C,NAME="tokamaker_set_coil_vsc")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
-TYPE(c_ptr), VALUE, INTENT(in) :: coil_gains !< Needs docs
+TYPE(c_ptr), VALUE, INTENT(in) :: coil_gains !< Coil weights for virtual VSC coil
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 REAL(8), POINTER, DIMENSION(:) :: vals_tmp
 INTEGER(4) :: i
@@ -1584,21 +1584,21 @@ CALL c_f_pointer(rcoils, rtmp, [tMaker_obj%device%ncoils])
 tMaker_obj%device%Rcoils(1:tMaker_obj%device%ncoils)=rtmp
 END SUBROUTINE tokamaker_set_vcoil
 !---------------------------------------------------------------------------------
-!> Needs docs
+!> Save current equilibrium in gEQDSK format
 !---------------------------------------------------------------------------------
 SUBROUTINE tokamaker_save_eqdsk(tMaker_equil_ptr,filename,nr,nz,rbounds,zbounds,run_info,psi_pad,rcentr,trunc_eq,lim_filename,lcfs_press,cocos,error_str) BIND(C,NAME="tokamaker_save_eqdsk")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< TokaMaker equilibrium instance
-CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Needs docs
-CHARACTER(KIND=c_char), INTENT(in) :: run_info(40) !< Needs docs
-INTEGER(c_int), VALUE, INTENT(in) :: nr !< Needs docs
-INTEGER(c_int), VALUE, INTENT(in) :: nz !< Needs docs
-REAL(c_double), INTENT(in) :: rbounds(2) !< Needs docs
-REAL(c_double), INTENT(in) :: zbounds(2) !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: psi_pad !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: rcentr !< Needs docs
-LOGICAL(c_bool), VALUE, INTENT(in) :: trunc_eq !< Needs docs
-CHARACTER(KIND=c_char), INTENT(in) :: lim_filename(OFT_PATH_SLEN) !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: lcfs_press !< Needs docs
+CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Filename to save equilibrium to
+CHARACTER(KIND=c_char), INTENT(in) :: run_info(40) !< Run information
+INTEGER(c_int), VALUE, INTENT(in) :: nr !< Number of radial grid points
+INTEGER(c_int), VALUE, INTENT(in) :: nz !< Number of vertical grid points
+REAL(c_double), INTENT(in) :: rbounds(2) !< Radial grid bounds
+REAL(c_double), INTENT(in) :: zbounds(2) !< Vertical grid bounds
+REAL(c_double), VALUE, INTENT(in) :: psi_pad !< Padding in normalized flux at LCFS
+REAL(c_double), VALUE, INTENT(in) :: rcentr !< Value to use for Rcentr in gEQDSK file (negative to use equilibrium magnetic axis)
+LOGICAL(c_bool), VALUE, INTENT(in) :: trunc_eq !< Truncate equilibrium at `lcfs_pad`, if `False` \f$ q(\hat{\psi} > 1-pad) = q(1-pad) \f$
+CHARACTER(KIND=c_char), INTENT(in) :: lim_filename(OFT_PATH_SLEN) !< File containing limiter contour to use instead of TokaMaker limiter
+REAL(c_double), VALUE, INTENT(in) :: lcfs_press !< Plasma pressure on the LCFS (zero by default)
 INTEGER(c_int), VALUE, INTENT(in) :: cocos !< COCOS version. (Only 2 or 7 supported. COCOS=7 is the default.)
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 CHARACTER(LEN=40) :: run_info_f
@@ -1619,18 +1619,18 @@ END IF
 CALL copy_string(TRIM(error_flag),error_str)
 END SUBROUTINE tokamaker_save_eqdsk
 !------------------------------------------------------------------------------
-!> Needs docs
+!> Save current equilibrium to iFile format
 !------------------------------------------------------------------------------
 SUBROUTINE tokamaker_save_ifile(tMaker_equil_ptr,filename,npsi,ntheta,psi_pad,lcfs_press,pack_lcfs,single_prec,error_str) BIND(C,NAME="tokamaker_save_ifile")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< TokaMaker equilibrium instance
-CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Needs docs
-INTEGER(c_int), VALUE, INTENT(in) :: npsi !< Needs docs
-INTEGER(c_int), VALUE, INTENT(in) :: ntheta !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: psi_pad !< Needs docs
-REAL(c_double), VALUE, INTENT(in) :: lcfs_press !< Needs docs
-LOGICAL(c_bool), VALUE, INTENT(in) :: pack_lcfs !< Needs docs
-LOGICAL(c_bool), VALUE, INTENT(in) :: single_prec !< Needs docs
-CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Needs docs
+CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Filename to save equilibrium to
+INTEGER(c_int), VALUE, INTENT(in) :: npsi !< Number of radial sampling points
+INTEGER(c_int), VALUE, INTENT(in) :: ntheta !< Number of poloidal sampling points
+REAL(c_double), VALUE, INTENT(in) :: psi_pad !< Padding in normalized flux at LCFS
+REAL(c_double), VALUE, INTENT(in) :: lcfs_press !< Plasma pressure on the LCFS (zero by default)
+LOGICAL(c_bool), VALUE, INTENT(in) :: pack_lcfs !< Pack toward LCFS with quadraturic sampling?
+LOGICAL(c_bool), VALUE, INTENT(in) :: single_prec !< Save single precision file? (default: double precision)
+CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 CHARACTER(LEN=OFT_PATH_SLEN) :: filename_tmp
 CHARACTER(LEN=OFT_ERROR_SLEN) :: error_flag
 TYPE(gs_equil), POINTER :: tMaker_equil_obj
@@ -1641,27 +1641,27 @@ CALL gs_save_ifile(tMaker_equil_obj,filename_tmp,npsi,ntheta,psi_pad,lcfs_press=
 CALL copy_string(TRIM(error_flag),error_str)
 END SUBROUTINE tokamaker_save_ifile
 !------------------------------------------------------------------------------
-!> Needs docs
+!> Save current equilibrium in MUG transfer format
 !------------------------------------------------------------------------------
 SUBROUTINE tokamaker_save_mug(tMaker_equil_ptr,filename,error_str) BIND(C,NAME="tokamaker_save_mug")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< TokaMaker equilibrium instance
-CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Needs docs
-CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Needs docs
+CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Filename to save equilibrium to
+CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 CHARACTER(LEN=OFT_PATH_SLEN) :: filename_tmp
-CHARACTER(LEN=OFT_ERROR_SLEN) :: error_flag
+! CHARACTER(LEN=OFT_ERROR_SLEN) :: error_flag
 TYPE(gs_equil), POINTER :: tMaker_equil_obj
 IF(.NOT.tokamaker_equil_ccast(tMaker_equil_ptr,tMaker_equil_obj,error_str))RETURN
 CALL copy_string_rev(filename,filename_tmp)
 CALL gs_save_mug(tMaker_equil_obj,filename_tmp)
-CALL copy_string(TRIM(error_flag),error_str)
+! CALL copy_string(TRIM(error_flag),error_str)
 END SUBROUTINE tokamaker_save_mug
 !------------------------------------------------------------------------------
-!> Needs docs
+!> Save current equilibrium in native TokaMaker format (eg. for restarting)
 !------------------------------------------------------------------------------
 SUBROUTINE tokamaker_save_tokamaker(tMaker_equil_ptr,filename,error_str) BIND(C,NAME="tokamaker_save_tokamaker")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< TokaMaker equilibrium instance
-CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Needs docs
-CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Needs docs
+CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Filename to save equilibrium to
+CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 CHARACTER(LEN=OFT_PATH_SLEN) :: filename_tmp
 TYPE(gs_equil), POINTER :: tMaker_equil_obj
 IF(.NOT.tokamaker_equil_ccast(tMaker_equil_ptr,tMaker_equil_obj,error_str))RETURN
@@ -1669,12 +1669,12 @@ CALL copy_string_rev(filename,filename_tmp)
 CALL gs_save_tokamaker(tMaker_equil_obj,filename_tmp)
 END SUBROUTINE tokamaker_save_tokamaker
 !------------------------------------------------------------------------------
-!> Needs docs
+!> Load equilibrium from native TokaMaker format
 !------------------------------------------------------------------------------
 SUBROUTINE tokamaker_load_tokamaker(tMaker_equil_ptr,filename,error_str) BIND(C,NAME="tokamaker_load_tokamaker")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_equil_ptr !< TokaMaker equilibrium instance
-CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Needs docs
-CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Needs docs
+CHARACTER(KIND=c_char), INTENT(in) :: filename(OFT_PATH_SLEN) !< Filename to load equilibrium from
+CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 CHARACTER(LEN=OFT_PATH_SLEN) :: filename_tmp
 CHARACTER(LEN=OFT_ERROR_SLEN) :: error_flag
 TYPE(gs_equil), POINTER :: tMaker_equil_obj
@@ -1688,10 +1688,10 @@ END SUBROUTINE tokamaker_load_tokamaker
 !------------------------------------------------------------------------------
 SUBROUTINE tokamaker_set_coil_current_dist(tMaker_ptr,iCoil,curr_dist,dist_pointer,normalize,error_str) BIND(C,NAME="tokamaker_set_coil_current_dist")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
-INTEGER(c_int), VALUE, INTENT(in) :: iCoil
-TYPE(c_ptr), VALUE, INTENT(in) :: curr_dist
-TYPE(c_ptr), INTENT(out) :: dist_pointer
-LOGICAL(c_bool), VALUE, INTENT(in) :: normalize
+INTEGER(c_int), VALUE, INTENT(in) :: iCoil !< Coil index
+TYPE(c_ptr), VALUE, INTENT(in) :: curr_dist !< Current distribution for coil
+TYPE(c_ptr), INTENT(out) :: dist_pointer !< Pointer to current distribution (for use in plotting)
+LOGICAL(c_bool), VALUE, INTENT(in) :: normalize !< Normalize distribution to have unit current?
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 INTEGER(4) :: i,ic
 REAL(r8) :: norm

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -1402,7 +1402,7 @@ TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< TokaMaker instance
 REAL(c_double), VALUE, INTENT(in) :: ip_target !< Target plasma current [A]
 REAL(c_double), VALUE, INTENT(in) :: ip_ratio_target !< Ratio of net plasma current contribution from \f$F F'\f$ compared to \f$ P' \f$
 REAL(c_double), VALUE, INTENT(in) :: pax_target !< Target axis pressure [Pa]
-REAL(c_double), VALUE, INTENT(in) :: estore_target !< Target sotred energy [J]
+REAL(c_double), VALUE, INTENT(in) :: estore_target !< Target stored energy [J]
 REAL(c_double), VALUE, INTENT(in) :: R0_target !< Target major radius for magnetic axis
 REAL(c_double), VALUE, INTENT(in) :: Z0_target !< Target vertical position for magnetic axis
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -451,9 +451,10 @@ END SUBROUTINE tokamaker_init_psi
 !---------------------------------------------------------------------------------
 !> Needs docs
 !---------------------------------------------------------------------------------
-SUBROUTINE tokamaker_solve(tMaker_ptr,vacuum,error_str) BIND(C,NAME="tokamaker_solve")
+SUBROUTINE tokamaker_solve(tMaker_ptr,vacuum,nl_its,error_str) BIND(C,NAME="tokamaker_solve")
 TYPE(c_ptr), VALUE, INTENT(in) :: tMaker_ptr !< Pointer to TokaMaker object
 LOGICAL(c_bool), VALUE, INTENT(in) :: vacuum !< Perform vacuum solve?
+INTEGER(c_int), INTENT(out) :: nl_its !< Number of nonlinear iterations
 CHARACTER(KIND=c_char), INTENT(out) :: error_str(OFT_ERROR_SLEN) !< Error string (empty if no error)
 INTEGER(i4) :: ntargets,ierr
 LOGICAL :: vac_save
@@ -475,6 +476,7 @@ tMaker_obj%device%timing=0.d0
 CALL tMaker_obj%device%solve(tMaker_obj%gs_equil,ierr)
 IF(vacuum)tMaker_obj%gs_equil%has_plasma=vac_save
 IF(ierr/=0)CALL copy_string(gs_err_reason(ierr),error_str)
+nl_its=tMaker_obj%device%nl_its
 END SUBROUTINE tokamaker_solve
 !---------------------------------------------------------------------------------
 !> Needs docs

--- a/src/tests/physics/test_TokaMaker.py
+++ b/src/tests/physics/test_TokaMaker.py
@@ -459,7 +459,7 @@ def test_coil_h3(order,dist_coil):
 
 
 #============================================================================
-def run_ITER_case(mesh_resolution,fe_orders,eig_test,stability_test,test_recon,mp_q):
+def run_ITER_case(mesh_resolution,fe_orders,test_type,mp_q):
     def create_mesh():
         with open('ITER_geom.json','r') as fid:
             ITER_geom = json.load(fid)
@@ -509,7 +509,7 @@ def run_ITER_case(mesh_resolution,fe_orders,eig_test,stability_test,test_recon,m
         mygs.setup_regions(cond_dict=cond_dict,coil_dict=coil_dict)
         mygs.setup(order=fe_order,F0=5.3*6.2)
         #
-        if eig_test:
+        if test_type == 'eig':
             eig_vals, _ = mygs.eig_wall(10)
             mp_q.put([{'Tau_w': eig_vals[:5,0]}])
             oftpy_dump_cov()
@@ -564,11 +564,11 @@ def run_ITER_case(mesh_resolution,fe_orders,eig_test,stability_test,test_recon,m
         delta = 0.0
         try:
             mygs.init_psi(R0, Z0, a, kappa, delta)
-            mygs.solve()
+            EQ_obj, nl_its = mygs.solve(return_its=True)
         except ValueError:
             mp_q.put(None)
             return
-        if stability_test:
+        if test_type == 'stab':
             eig_vals, eig_vecs = mygs.eig_td(-1.E2,10,False)
             # Run brief nonlinear evolution
             psi0 = mygs.get_psi(False)
@@ -581,18 +581,25 @@ def run_ITER_case(mesh_resolution,fe_orders,eig_test,stability_test,test_recon,m
             mygs.setup_td(dt,1.E-13,1.E-11)
             sim_time = 0.0
             for i in range(5):
-                sim_time, _, nl_its, lin_its, nretry = mygs.step_td(sim_time,dt)
+                sim_time, _, _, _, _ = mygs.step_td(sim_time,dt)
             psi1 = mygs.get_psi(False)
             mp_q.put([{'gamma': eig_vals[:5,0], 'nl_change': np.linalg.norm(psi1-psi0)}])
             oftpy_dump_cov()
             return
         mygs.save_eqdsk('test.eqdsk',lcfs_pressure=6.E4)
-        eq_info = mygs.get_stats(li_normalization='ITER')
+        if test_type == 'io':
+            EQ_obj.save_TokaMaker('test_eq.h5')
+            mygs.init_psi(R0, Z0, a, kappa, delta)
+            mygs.replace_eq(source_file='test_eq.h5')
+            EQ_obj = mygs.copy_eq()
+            _, nl_its = mygs.solve(return_its=True)
+        eq_info = EQ_obj.get_stats(li_normalization='ITER')
         Lmat = mygs.get_coil_Lmat()
         eq_info['LCS1'] = Lmat[mygs.coil_sets['CS1U']['id'],mygs.coil_sets['CS1U']['id']]
         eq_info['MCS1_plasma'] = Lmat[mygs.coil_sets['CS1U']['id'],-1]
         eq_info['Lplasma'] = Lmat[-1,-1]
-    if test_recon:
+        eq_info['nl_its'] = nl_its
+    if test_type == 'recon':
         import random
         from OpenFUSIONToolkit.TokaMaker.reconstruction import reconstruction
         # Sample constraint locations
@@ -648,7 +655,7 @@ def run_ITER_case(mesh_resolution,fe_orders,eig_test,stability_test,test_recon,m
         a = 1.0
         kappa = 1.0
         delta = 0.0
-        err_flag = mygs.init_psi(R0, Z0, a, kappa, delta)
+        mygs.init_psi(R0, Z0, a, kappa, delta)
         mygs.settings.maxits=100
         mygs.update_settings()
         mygs.solve()
@@ -661,7 +668,7 @@ def run_ITER_case(mesh_resolution,fe_orders,eig_test,stability_test,test_recon,m
         myrecon.settings.fitR0 = True
         myrecon.settings.fitCoils = True
         myrecon.settings.pm = False
-        err_flag = myrecon.reconstruct()
+        _ = myrecon.reconstruct()
         #
         eq_info = mygs.get_stats(li_normalization='ITER')
         eq_info['LCS1'] = Lmat[mygs.coil_sets['CS1U']['id'],mygs.coil_sets['CS1U']['id']]
@@ -685,7 +692,7 @@ def test_ITER_eig(order):
     exp_dict = {
         'Tau_w': [1.51083009, 2.87431718, 3.91493237, 5.23482507, 5.61049374]
     }
-    results = mp_run(run_ITER_case,(1.0,(order,),True,False,False))
+    results = mp_run(run_ITER_case,(1.0,(order,),'eig'))
     assert validate_dict(results,exp_dict)
 
 @pytest.mark.coverage
@@ -695,7 +702,7 @@ def test_ITER_stability(order):
         'gamma': [-12.3620, 1.83981, 3.41613, 5.12470, 6.53393],
         'nl_change': [225.4421413167051, 338.0113029638385][order-2]
     }
-    results = mp_run(run_ITER_case,(1.0,(order,),False,True,False))
+    results = mp_run(run_ITER_case,(1.0,(order,),'stab'))
     assert validate_dict(results,exp_dict)
 
 ITER_eq_dict = {
@@ -728,10 +735,18 @@ ITER_eq_dict = {
 @pytest.mark.coverage
 @pytest.mark.parametrize("order", (2,3))#,4))
 def test_ITER_eq(order):
-    results = mp_run(run_ITER_case,(1.0,(order,),False,False,False))
+    results = mp_run(run_ITER_case,(1.0,(order,),''))
     assert validate_dict(results,ITER_eq_dict)
     assert validate_eqdsk('tokamaker.eqdsk','ITER_test.eqdsk')
     assert validate_ifile('tokamaker.ifile','ITER_test.ifile')
+
+@pytest.mark.coverage
+@pytest.mark.parametrize("order", (2,3))#,4))
+def test_ITER_eq_io(order):
+    eq_dict = ITER_eq_dict.copy()
+    eq_dict['nl_its'] = 1
+    results = mp_run(run_ITER_case,(1.0,(order,),'io'))
+    assert validate_dict(results,eq_dict)
 
 @pytest.mark.coverage
 def test_ITER_recon():
@@ -743,11 +758,11 @@ def test_ITER_recon():
     ITER_recon_dict['beta_pol'] = 44.16835089714342
     ITER_recon_dict['beta_tor'] = 1.8950360948919174
     ITER_recon_dict['beta_n'] = 1.2576100533550467
-    results = mp_run(run_ITER_case,(1.0,(2,),False,False,True))
+    results = mp_run(run_ITER_case,(1.0,(2,),'recon'))
     assert validate_dict(results,ITER_recon_dict)
 
 def test_ITER_concurrent():
-    results = mp_run(run_ITER_case,(1.0,(2,3),False,False,False))
+    results = mp_run(run_ITER_case,(1.0,(2,3),''))
     assert validate_dict(results,ITER_eq_dict)
 
 #============================================================================


### PR DESCRIPTION
This pull request adds the capability to save and load `TokaMaker_equilibrium` objects to allow sharing state between sessions, including:

 - Add implementations to `hdf5_read` and `hdf5_write` for logical and string variables
 - Handle loading/saving flux profiles via class methods
 - Add support for replacing the current equilibrium on a `TokaMaker` object

Additionally, this PR makes the following changes:

- Complete transition of `V0` -> `Z0` for magnetic axis vertical position in TokaMaker usage, including deprecation of support for old naming

There are **no backwards incompatible API changes** in this PR.