### PR TITLE
TokaMaker: Fix bugs with negative F0 and `mode=1`, fixes #321

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
           python3 -m venv ${{ github.workspace }}/oft_venv
           echo "source ${{ github.workspace }}/oft_venv/bin/activate" > ${{ github.workspace }}/setup_env.sh
           source ${{ github.workspace }}/setup_env.sh
-          pip install ruff
+          pip install "ruff<0.16.0"
 
       - name: Check stack entries
         working-directory: src

--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -3451,7 +3451,7 @@ do j=1,device%fe_rep%mesh%nc
     IF(self%mode==0)THEN
       f=self%ffp_scale*self%I%f(psitmp(1))+self%I%f_offset
     ELSE
-      f=SQRT(self%ffp_scale*self%I%F(psitmp(1)) + self%I%f_offset**2)
+      f=SIGN(1.d0,self%I%f_offset)*SQRT(self%ffp_scale*self%I%F(psitmp(1)) + self%I%f_offset**2)
     END IF
     do l=1,device%fe_rep%nce
       call oft_blag_eval(device%fe_rep,j,l,device%fe_rep%quad%pts(:,m),rop)
@@ -4084,7 +4084,7 @@ DO i=1,npts
   IF(self%mode==0)THEN
     B(2)=(self%ffp_scale*self%I%f(psitmp(1))+self%I%f_offset)/pts(1,i)
   ELSE
-    B(2)=SQRT(self%ffp_scale*self%I%f(psitmp(1)) + self%I%f_offset**2)/pts(1,i)
+    B(2)=SIGN(1.d0,self%I%f_offset)*SQRT(self%ffp_scale*self%I%f(psitmp(1)) + self%I%f_offset**2)/pts(1,i)
   END IF
   B=B*self%psiscale
   ! Handle anisotropic pressure
@@ -4477,8 +4477,7 @@ do j=1,nr
   IF(gseq%mode==0)THEN
     fpol=gseq%ffp_scale*gseq%I%f(psi_surf)+gseq%I%f_offset
   ELSE
-    fpol=SQRT(gseq%ffp_scale*gseq%I%f(psi_surf) + gseq%I%f_offset**2) &
-    + gseq%I%f_offset*(1.d0-SIGN(1.d0,gseq%I%f_offset))
+    fpol=SIGN(1.d0,gseq%I%f_offset)*SQRT(gseq%ffp_scale*gseq%I%f(psi_surf) + gseq%I%f_offset**2)
   END IF
   !---Safety Factor (q)
   qpsi=fpol*active_tracer%v(3)/(2*pi)
@@ -4640,7 +4639,7 @@ SELECT CASE(self%mode)
       IF(self%equil%mode==0)THEN
         val(1)=self%equil%psiscale*(self%equil%ffp_scale*self%equil%I%f(psitmp(1))+self%equil%I%f_offset)
       ELSE
-        val(1)=self%equil%psiscale*SQRT(self%equil%ffp_scale*self%equil%I%f(psitmp(1)) + self%equil%I%f_offset**2)
+        val(1)=self%equil%psiscale*SIGN(1.d0,self%equil%I%f_offset)*SQRT(self%equil%ffp_scale*self%equil%I%f(psitmp(1)) + self%equil%I%f_offset**2)
       END IF
     ELSE
       val(1)=self%equil%psiscale*self%equil%I%f_offset
@@ -4698,7 +4697,7 @@ IF(in_plasma.AND.(psitmp(1)>self%equil%plasma_bounds(1)))THEN
   IF(self%equil%mode==0)THEN
     val(2)=self%equil%psiscale*(self%equil%ffp_scale*self%equil%I%f(psitmp(1))+self%equil%I%f_offset)/(pt(1)+gs_epsilon)
   ELSE
-    val(2)=self%equil%psiscale*SQRT(self%equil%ffp_scale*self%equil%I%f(psitmp(1)) + self%equil%I%f_offset**2)/(pt(1)+gs_epsilon)
+    val(2)=self%equil%psiscale*SIGN(1.d0,self%equil%I%f_offset)*SQRT(self%equil%ffp_scale*self%equil%I%f(psitmp(1)) + self%equil%I%f_offset**2)/(pt(1)+gs_epsilon)
   END IF
 ELSE
   val(2)=self%equil%psiscale*self%equil%I%f_offset/(pt(1)+gs_epsilon)
@@ -5156,7 +5155,7 @@ DO i=0,m
     outtmp(2)=self%ffp_scale*self%I%fp(r)
     outtmp(3)=self%psiscale*self%ffp_scale*self%I%f(r) + self%I%f_offset
   ELSE
-    outtmp(3)=SQRT(self%psiscale*self%ffp_scale*self%I%f(r) + self%I%f_offset**2)
+    outtmp(3)=SIGN(1.d0,self%I%f_offset)*SQRT(self%psiscale*self%ffp_scale*self%I%f(r) + self%I%f_offset**2)
     outtmp(2)=self%ffp_scale*self%I%fp(r)/(2.d0*outtmp(3))
   END IF
   outtmp(4)=self%psiscale*self%p_scale*self%P%fp(r)

--- a/src/physics/grad_shaf_fit.F90
+++ b/src/physics/grad_shaf_fit.F90
@@ -537,20 +537,20 @@ CHARACTER(LEN=OFT_ERROR_SLEN) :: exit_reason
 !           is at most xtol.
 !
 ! info = 3  conditions for info = 1 and info = 2 both hold.
-! 
+!
 ! info = 4  the cosine of the angle between fvec and any
 !           column of the jacobian is at most gtol in
 !           absolute value.
-! 
+!
 ! info = 5  number of calls to fcn with iflag = 1 has
 !           reached maxfev.
-! 
+!
 ! info = 6  ftol is too small. no further reduction in
 !           the sum of squares is possible.
-! 
+!
 ! info = 7  xtol is too small. no further improvement in
 !           the approximate solution x is possible.
-! 
+!
 ! info = 8  gtol is too small. fvec is orthogonal to the
 !           columns of the jacobian to machine precision.
 SELECT CASE(info)
@@ -1444,7 +1444,7 @@ btmp(1)= -gs%psiscale*gpsi(2)/self%r(1)
 IF(gs%mode==0)THEN
   btmp(2)= gs%psiscale*(gs%ffp_scale*gs%I%f(psi(1))+gs%I%f_offset)/self%r(1)
 ELSE
-  btmp(2)=gs%psiscale*SQRT(gs%ffp_scale*gs%I%f(psi(1)) + gs%I%f_offset**2)/self%r(1)
+  btmp(2)=gs%psiscale*SIGN(1.d0,gs%I%f_offset)*SQRT(gs%ffp_scale*gs%I%f(psi(1)) + gs%I%f_offset**2)/self%r(1)
 END IF
 btmp(3)= gs%psiscale*gpsi(1)/self%r(1)
 !---

--- a/src/physics/grad_shaf_util.F90
+++ b/src/physics/grad_shaf_util.F90
@@ -867,8 +867,7 @@ do j=2,npsi
   IF(gseq%mode==0)THEN
     cout(j,2)=gseq%ffp_scale*gseq%I%f(psi_surf(1))+gseq%I%f_offset
   ELSE
-    cout(j,2)=SQRT(gseq%ffp_scale*gseq%I%f(psi_surf(1)) + gseq%I%f_offset**2) &
-    + gseq%I%f_offset*(1.d0-SIGN(1.d0,gseq%I%f_offset))
+    cout(j,2)=SIGN(1.d0,gseq%I%f_offset)*SQRT(gseq%ffp_scale*gseq%I%f(psi_surf(1)) + gseq%I%f_offset**2)
   END IF
   cout(j,3)=gseq%p_scale*gseq%P%f(psi_surf(1))/mu0 ! Plasma pressure
   cout(j,4)=cout(j,2)*active_tracer%v(3)/(2*pi) ! Safety Factor (q)
@@ -891,8 +890,7 @@ cout(1,1)=x2
 IF(gseq%mode==0)THEN
   cout(1,2)=(gseq%ffp_scale*gseq%I%f(x2)+gseq%I%f_offset)
 ELSE
-  cout(1,2)=SQRT(gseq%ffp_scale*gseq%I%f(x2) + gseq%I%f_offset**2) &
-      + gseq%I%f_offset*(1.d0-SIGN(1.d0,gseq%I%f_offset))
+  cout(1,2)=SIGN(1.d0,gseq%I%f_offset)*SQRT(gseq%ffp_scale*gseq%I%f(x2) + gseq%I%f_offset**2)
 END IF
 cout(1,3)=gseq%p_scale*gseq%P%f(x2)/mu0
 cout(1,4)=(cout(3,4)-cout(2,4))*(x2-cout(2,1))/(cout(3,1)-cout(2,1)) + cout(2,4)
@@ -1132,10 +1130,8 @@ do j=1,nr
     fpol(j)=gseq%ffp_scale*gseq%I%f(psi_surf)+gseq%I%f_offset
     ffprim(j)=gseq%I%fp(psi_surf)*((gseq%ffp_scale**2)*gseq%I%f(psi_surf)+gseq%ffp_scale*gseq%I%f_offset)
   ELSE
-    fptmp=SQRT(gseq%ffp_scale*gseq%I%f(psi_trace) + gseq%I%f_offset**2) &
-      + gseq%I%f_offset*(1.d0-SIGN(1.d0,gseq%I%f_offset))
-    fpol(j)=SQRT(gseq%ffp_scale*gseq%I%f(psi_surf) + gseq%I%f_offset**2) &
-      + gseq%I%f_offset*(1.d0-SIGN(1.d0,gseq%I%f_offset))
+    fptmp=SIGN(1.d0,gseq%I%f_offset)*SQRT(gseq%ffp_scale*gseq%I%f(psi_trace) + gseq%I%f_offset**2)
+    fpol(j)=SIGN(1.d0,gseq%I%f_offset)*SQRT(gseq%ffp_scale*gseq%I%f(psi_surf) + gseq%I%f_offset**2)
     ffprim(j)=0.5d0*gseq%ffp_scale*gseq%I%fp(psi_surf)
   END IF
   pres(j)=gseq%p_scale*gseq%P%f(psi_surf)/mu0
@@ -1414,8 +1410,7 @@ do j=1,nr
   IF(gseq%mode==0)THEN
     field%f_surf=gseq%ffp_scale*gseq%I%f(psi_surf)+gseq%I%f_offset
   ELSE
-    field%f_surf=SQRT(gseq%ffp_scale*gseq%I%f(psi_surf) + gseq%I%f_offset**2) &
-      + gseq%I%f_offset*(1.d0-SIGN(1.d0,gseq%I%f_offset))
+    field%f_surf=SIGN(1.d0,gseq%I%f_offset)*SQRT(gseq%ffp_scale*gseq%I%f(psi_surf) + gseq%I%f_offset**2)
   END IF
   field%bmax=0.d0
   field%stage_1=.TRUE.

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -1302,7 +1302,7 @@ DO i=1,npsi
     fp(i)=tMaker_equil_obj%ffp_scale*tMaker_equil_obj%I%fp(r)
     f(i)=tMaker_equil_obj%psiscale*tMaker_equil_obj%ffp_scale*tMaker_equil_obj%I%f(r) + tMaker_equil_obj%I%f_offset
   ELSE
-    f(i)=SQRT(tMaker_equil_obj%psiscale*tMaker_equil_obj%ffp_scale*tMaker_equil_obj%I%f(r) + tMaker_equil_obj%I%f_offset**2)
+    f(i)=SIGN(1.d0,tMaker_equil_obj%I%f_offset)*SQRT(tMaker_equil_obj%psiscale*tMaker_equil_obj%ffp_scale*tMaker_equil_obj%I%f(r) + tMaker_equil_obj%I%f_offset**2)
     fp(i)=tMaker_equil_obj%ffp_scale*tMaker_equil_obj%I%fp(r)/(2.d0*f(i))
   END IF
   pp(i)=tMaker_equil_obj%psiscale*tMaker_equil_obj%p_scale*tMaker_equil_obj%P%fp(r)

--- a/src/tests/physics/test_TokaMaker.py
+++ b/src/tests/physics/test_TokaMaker.py
@@ -799,7 +799,7 @@ def test_ITER_eq(order,helicity):
     eq_dict['tflux'] *= helicity
     eq_dict['dflux'] *= helicity
     results = mp_run(run_ITER_case,(1.0,(order,),'',helicity))
-    assert validate_dict(results,ITER_tmp_dict)
+    assert validate_dict(results,eq_dict)
     assert validate_eqdsk('tokamaker.eqdsk','ITER_test.eqdsk',helicity)
     assert validate_ifile('tokamaker.ifile','ITER_test.ifile',helicity)
 

--- a/src/tests/physics/test_TokaMaker.py
+++ b/src/tests/physics/test_TokaMaker.py
@@ -798,6 +798,8 @@ def test_ITER_eq(order,helicity):
     eq_dict = ITER_eq_dict.copy()
     eq_dict['tflux'] *= helicity
     eq_dict['dflux'] *= helicity
+    eq_dict['q_0'] *= helicity
+    eq_dict['q_95'] *= helicity
     results = mp_run(run_ITER_case,(1.0,(order,),'',helicity))
     assert validate_dict(results,eq_dict)
     assert validate_eqdsk('tokamaker.eqdsk','ITER_test.eqdsk',helicity)
@@ -811,6 +813,8 @@ def test_ITER_eq_io(order,helicity):
     eq_dict['nl_its'] = 1
     eq_dict['tflux'] *= helicity
     eq_dict['dflux'] *= helicity
+    eq_dict['q_0'] *= helicity
+    eq_dict['q_95'] *= helicity
     results = mp_run(run_ITER_case,(1.0,(order,),'io',helicity))
     assert validate_dict(results,eq_dict)
 

--- a/src/tests/physics/test_TokaMaker.py
+++ b/src/tests/physics/test_TokaMaker.py
@@ -86,7 +86,7 @@ def validate_dict(results,dict_exp,tol_dict=None):
     return test_result
 
 
-def validate_eqdsk(file_test,file_ref):
+def validate_eqdsk(file_test,file_ref,helicity=1.0):
     from OpenFUSIONToolkit.TokaMaker.util import read_eqdsk
     try:
         test_data = read_eqdsk(file_test)
@@ -98,6 +98,9 @@ def validate_eqdsk(file_test,file_ref):
     except:
         print("FAILED: Could not read reference EQDSK")
         return False
+    ref_data['bcentr'] *= helicity
+    ref_data['fpol'] *= helicity
+    ref_data['qpsi'] *= helicity
     test_result = True
     for key, exp_val in ref_data.items():
         result_val = test_data.get(key,None)
@@ -121,7 +124,7 @@ def validate_eqdsk(file_test,file_ref):
     return test_result
 
 
-def validate_ifile(ifile_test,ifile_ref):
+def validate_ifile(ifile_test,ifile_ref,helicity=1.0):
     from OpenFUSIONToolkit.TokaMaker.util import read_ifile
     try:
         test_data = read_ifile(ifile_test)
@@ -133,6 +136,8 @@ def validate_ifile(ifile_test,ifile_ref):
     except:
         print("FAILED: Could not read reference i-file")
         return False
+    ref_data['f'] *= helicity
+    ref_data['q'] *= helicity
     test_result = True
     for key, exp_val in ref_data.items():
         result_val = test_data.get(key,None)
@@ -467,7 +472,7 @@ def test_coil_h3(order,dist_coil):
 
 
 #============================================================================
-def run_ITER_case(mesh_resolution,fe_orders,test_type,mp_q):
+def run_ITER_case(mesh_resolution,fe_orders,test_type,helicity,mp_q):
     def create_mesh():
         with open('ITER_geom.json','r') as fid:
             ITER_geom = json.load(fid)
@@ -515,7 +520,7 @@ def run_ITER_case(mesh_resolution,fe_orders,test_type,mp_q):
         mesh_pts,mesh_lc,mesh_reg,coil_dict,cond_dict = load_gs_mesh('ITER_mesh.h5')
         mygs.setup_mesh(mesh_pts,mesh_lc,mesh_reg)
         mygs.setup_regions(cond_dict=cond_dict,coil_dict=coil_dict)
-        mygs.setup(order=fe_order,F0=5.3*6.2)
+        mygs.setup(order=fe_order,F0=helicity*5.3*6.2)
         #
         if test_type.startswith('eig'):
             if test_type == 'eig_dep':
@@ -740,10 +745,10 @@ def test_ITER_eig(order):
     exp_dict = {
         'Tau_w': [6.619977E-01, 3.479492E-01, 2.554444E-01, 1.910381E-01, 1.782464E-01]
     }
-    results = mp_run(run_ITER_case,(1.0,(order,),'eig'))
+    results = mp_run(run_ITER_case,(1.0,(order,),'eig',1.0))
     assert validate_dict(results,exp_dict)
     # Test deprecated interface
-    results = mp_run(run_ITER_case,(1.0,(order,),'eig_dep'))
+    results = mp_run(run_ITER_case,(1.0,(order,),'eig_dep',1.0))
     assert validate_dict(results,exp_dict)
 
 @pytest.mark.coverage
@@ -753,10 +758,10 @@ def test_ITER_stability(order):
         'gamma': [12.3620, -1.83981, -3.41613, -5.12470, -6.53393],
         'nl_change': [225.4421413167051, 338.0113029638385][order-2]
     }
-    results = mp_run(run_ITER_case,(1.0,(order,),'stab'))
+    results = mp_run(run_ITER_case,(1.0,(order,),'stab',1.0))
     assert validate_dict(results,exp_dict)
     # Test deprecated interface
-    results = mp_run(run_ITER_case,(1.0,(order,),'stab_dep'))
+    results = mp_run(run_ITER_case,(1.0,(order,),'stab_dep',1.0))
     assert validate_dict(results,exp_dict)
 
 ITER_eq_dict = {
@@ -788,18 +793,25 @@ ITER_eq_dict = {
 
 @pytest.mark.coverage
 @pytest.mark.parametrize("order", (2,3))#,4))
-def test_ITER_eq(order):
-    results = mp_run(run_ITER_case,(1.0,(order,),''))
-    assert validate_dict(results,ITER_eq_dict)
-    assert validate_eqdsk('tokamaker.eqdsk','ITER_test.eqdsk')
-    assert validate_ifile('tokamaker.ifile','ITER_test.ifile')
+@pytest.mark.parametrize("helicity", (1.0,-1.0))
+def test_ITER_eq(order,helicity):
+    eq_dict = ITER_eq_dict.copy()
+    eq_dict['tflux'] *= helicity
+    eq_dict['dflux'] *= helicity
+    results = mp_run(run_ITER_case,(1.0,(order,),'',helicity))
+    assert validate_dict(results,ITER_tmp_dict)
+    assert validate_eqdsk('tokamaker.eqdsk','ITER_test.eqdsk',helicity)
+    assert validate_ifile('tokamaker.ifile','ITER_test.ifile',helicity)
 
 @pytest.mark.coverage
 @pytest.mark.parametrize("order", (2,3))#,4))
-def test_ITER_eq_io(order):
+@pytest.mark.parametrize("helicity", (1.0,-1.0))
+def test_ITER_eq_io(order,helicity):
     eq_dict = ITER_eq_dict.copy()
     eq_dict['nl_its'] = 1
-    results = mp_run(run_ITER_case,(1.0,(order,),'io'))
+    eq_dict['tflux'] *= helicity
+    eq_dict['dflux'] *= helicity
+    results = mp_run(run_ITER_case,(1.0,(order,),'io',helicity))
     assert validate_dict(results,eq_dict)
 
 @pytest.mark.coverage
@@ -813,7 +825,7 @@ def test_ITER_recon():
     ITER_recon_dict['l_i'] = 0.8872565
     ITER_recon_dict['beta_tor'] = 1.906180
     ITER_recon_dict['beta_n'] = 1.284312
-    results = mp_run(run_ITER_case,(1.0,(2,),'recon'))
+    results = mp_run(run_ITER_case,(1.0,(2,),'recon',1.0))
     assert validate_dict(results,ITER_recon_dict)
 
 @pytest.mark.coverage
@@ -829,11 +841,11 @@ def test_ITER_recon_legacy():
     ITER_recon_dict['l_i'] = 0.8906732
     ITER_recon_dict['beta_tor'] = 1.934024
     ITER_recon_dict['beta_n'] = 1.294385
-    results = mp_run(run_ITER_case,(1.0,(2,),'recon_legacy'))
+    results = mp_run(run_ITER_case,(1.0,(2,),'recon_legacy',1.0))
     assert validate_dict(results,ITER_recon_dict)
 
 def test_ITER_concurrent():
-    results = mp_run(run_ITER_case,(1.0,(2,3),''))
+    results = mp_run(run_ITER_case,(1.0,(2,3),'',1.0))
     assert validate_dict(results,ITER_eq_dict)
 
 #============================================================================


### PR DESCRIPTION
This PR fixes a bug in some TokaMaker output with negative F0 and `mode=1`. The bug impacts the `F` and most downstream fields (eg. `B_T`, `q`, etc.) although some (eg. `dflux`) were treated correctly.

This PR **does not** change any APIs or input files.
