### PR TITLE
Add timing to example tests and fix naming of lint workflow

### DIFF
--- a/.github/workflows/copilot-code-review.yml
+++ b/.github/workflows/copilot-code-review.yml
@@ -10,7 +10,7 @@ on:
       - src/utilities/build_libs.py
 
 jobs:
-  copilot-code-review:
+  copilot-setup-steps:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,14 +6,14 @@ on:
       - main
   pull_request:
     types: [opened, reopened, synchronize]
-  
+
 jobs:
-  cleanup:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v5
-      
+
       - name: Install prerequisites
         run: |
           python3 -m venv ${{ github.workspace }}/oft_venv

--- a/src/examples/Marklin/test_examples.sh.in
+++ b/src/examples/Marklin/test_examples.sh.in
@@ -5,16 +5,18 @@ ROOT_PATH=$(pwd)
 
 run_test() {
   cd $1
+  start_time=$SECONDS
   jupyter nbconvert --execute --to notebook --inplace --ExecutePreprocessor.kernel_name=@OFT_PY_KERNEL@ $2 > tmp.log 2>&1
+  elapsed=$((SECONDS - start_time))
   if [ $? -ne 0 ]; then
-    echo "Example Marklin/$1/$2 failed."
+    echo "Example Marklin/$1/$2 failed in $elapsed seconds."
     echo "" >> $log_path
     echo "====== Begin Marklin/$1/$2 output ======" >> $log_path
     cat tmp.log >> $log_path
     echo "======  End Marklin/$1/$2 output  ======" >> $log_path
     echo "" >> $log_path
   else
-    echo "Example Marklin/$1/$2 ran successfully."
+    echo "Example Marklin/$1/$2 ran successfully in $elapsed seconds."
   fi
   rm tmp.log
   cd $ROOT_PATH

--- a/src/examples/Marklin/test_examples.sh.in
+++ b/src/examples/Marklin/test_examples.sh.in
@@ -7,8 +7,8 @@ run_test() {
   cd $1
   start_time=$SECONDS
   jupyter nbconvert --execute --to notebook --inplace --ExecutePreprocessor.kernel_name=@OFT_PY_KERNEL@ $2 > tmp.log 2>&1
-  elapsed=$((SECONDS - start_time))
   if [ $? -ne 0 ]; then
+    elapsed=$((SECONDS - start_time))
     echo "Example Marklin/$1/$2 failed in $elapsed seconds."
     echo "" >> $log_path
     echo "====== Begin Marklin/$1/$2 output ======" >> $log_path
@@ -16,6 +16,7 @@ run_test() {
     echo "======  End Marklin/$1/$2 output  ======" >> $log_path
     echo "" >> $log_path
   else
+    elapsed=$((SECONDS - start_time))
     echo "Example Marklin/$1/$2 ran successfully in $elapsed seconds."
   fi
   rm tmp.log

--- a/src/examples/ThinCurr/test_examples.sh.in
+++ b/src/examples/ThinCurr/test_examples.sh.in
@@ -5,16 +5,18 @@ ROOT_PATH=$(pwd)
 
 run_test() {
   cd $1
+  start_time=$SECONDS
   jupyter nbconvert --execute --to notebook --inplace --ExecutePreprocessor.kernel_name=@OFT_PY_KERNEL@ $2 > tmp.log 2>&1
+  elapsed=$((SECONDS - start_time))
   if [ $? -ne 0 ]; then
-    echo "Example ThinCurr/$1/$2 failed."
+    echo "Example ThinCurr/$1/$2 failed in $elapsed seconds."
     echo "" >> $log_path
     echo "====== Begin ThinCurr/$1/$2 output ======" >> $log_path
     cat tmp.log >> $log_path
     echo "======  End ThinCurr/$1/$2 output  ======" >> $log_path
     echo "" >> $log_path
   else
-    echo "Example ThinCurr/$1/$2 ran successfully."
+    echo "Example ThinCurr/$1/$2 ran successfully in $elapsed seconds."
   fi
   rm tmp.log
   cd $ROOT_PATH

--- a/src/examples/ThinCurr/test_examples.sh.in
+++ b/src/examples/ThinCurr/test_examples.sh.in
@@ -7,8 +7,8 @@ run_test() {
   cd $1
   start_time=$SECONDS
   jupyter nbconvert --execute --to notebook --inplace --ExecutePreprocessor.kernel_name=@OFT_PY_KERNEL@ $2 > tmp.log 2>&1
-  elapsed=$((SECONDS - start_time))
   if [ $? -ne 0 ]; then
+    elapsed=$((SECONDS - start_time))
     echo "Example ThinCurr/$1/$2 failed in $elapsed seconds."
     echo "" >> $log_path
     echo "====== Begin ThinCurr/$1/$2 output ======" >> $log_path
@@ -16,6 +16,7 @@ run_test() {
     echo "======  End ThinCurr/$1/$2 output  ======" >> $log_path
     echo "" >> $log_path
   else
+    elapsed=$((SECONDS - start_time))
     echo "Example ThinCurr/$1/$2 ran successfully in $elapsed seconds."
   fi
   rm tmp.log

--- a/src/examples/TokaMaker/test_examples.sh.in
+++ b/src/examples/TokaMaker/test_examples.sh.in
@@ -5,16 +5,18 @@ ROOT_PATH=$(pwd)
 
 run_test() {
   cd $1
+  start_time=$SECONDS
   jupyter nbconvert --execute --to notebook --inplace --ExecutePreprocessor.kernel_name=@OFT_PY_KERNEL@ $2 > tmp.log 2>&1
+  elapsed=$((SECONDS - start_time))
   if [ $? -ne 0 ]; then
-    echo "Example TokaMaker/$1/$2 failed."
+    echo "Example TokaMaker/$1/$2 failed in $elapsed seconds."
     echo "" >> $log_path
     echo "====== Begin TokaMaker/$1/$2 output ======" >> $log_path
     cat tmp.log >> $log_path
     echo "======  End TokaMaker/$1/$2 output  ======" >> $log_path
     echo "" >> $log_path
   else
-    echo "Example TokaMaker/$1/$2 ran successfully."
+    echo "Example TokaMaker/$1/$2 ran successfully in $elapsed seconds."
   fi
   rm tmp.log
   cd $ROOT_PATH

--- a/src/examples/TokaMaker/test_examples.sh.in
+++ b/src/examples/TokaMaker/test_examples.sh.in
@@ -7,8 +7,8 @@ run_test() {
   cd $1
   start_time=$SECONDS
   jupyter nbconvert --execute --to notebook --inplace --ExecutePreprocessor.kernel_name=@OFT_PY_KERNEL@ $2 > tmp.log 2>&1
-  elapsed=$((SECONDS - start_time))
   if [ $? -ne 0 ]; then
+    elapsed=$((SECONDS - start_time))
     echo "Example TokaMaker/$1/$2 failed in $elapsed seconds."
     echo "" >> $log_path
     echo "====== Begin TokaMaker/$1/$2 output ======" >> $log_path
@@ -16,6 +16,7 @@ run_test() {
     echo "======  End TokaMaker/$1/$2 output  ======" >> $log_path
     echo "" >> $log_path
   else
+    elapsed=$((SECONDS - start_time))
     echo "Example TokaMaker/$1/$2 ran successfully in $elapsed seconds."
   fi
   rm tmp.log


### PR DESCRIPTION
This PR adds timing information to example tests and fixes naming of the lint workflow, which was previously displayed as `cleanup`.

This PR **does not** modify any existing APIs or input files.