### PR TITLE
ThinCurr: Fix edge case bug in jumper construction with single edge jumper

### DIFF
--- a/src/physics/thin_wall.F90
+++ b/src/physics/thin_wall.F90
@@ -2764,7 +2764,7 @@ DO jj=1,n
     END IF
   END IF
 END DO
-IF(flag_list(i0)==1)THEN
+IF((flag_list(i0)==1).AND.(n>2))THEN
   list_out(n+1)=lloop_tmp(i0)
 ELSE
   list_out(n+1)=0


### PR DESCRIPTION
This PR fixes an edge case bug in jumper construction when the jumper is composed of a single edge. Since 3db6ce3 the jumper was erroneous looped back on itself, causing cancellation of any hole coupling. As a result, single edge jumpers always measured zero current as seen in #331.

This PR **does not** change any existing APIs or input files.
