### PR TITLE
Fix improper handling of periodicity for 2D meshes in full matrix assembly

### DIFF
--- a/src/fem/fem_base.F90
+++ b/src/fem/fem_base.F90
@@ -2217,20 +2217,23 @@ END IF
 !---Local connectivity
 !---Determine location of boundary points on other processors
 neel=0
-!$omp parallel do private(mm) reduction(+:neel)
-do m=1,self%nbe ! Loop over boundary points
-  do mm=1,self%nbe ! Loop over input points
-    if(m==mm)CYCLE
-    if(leout(m)==leout(mm))then ! Found match
-      !$omp critical
-      ncon(0)=ncon(0)+1
-      linktmp(:,ncon(0),0)=(/mm,m/)
-      !$omp end critical
-      neel=neel+1
-    end if
-    if(leout(mm)==0)exit ! End of input points
+IF(self%mesh%periodic%nper>0)THEN
+  !$omp parallel do private(mm) reduction(+:neel)
+  do m=1,self%nbe ! Loop over boundary points
+    do mm=m+1,self%nbe ! Loop over input points
+      if(leout(m)==leout(mm))then ! Found match
+        !$omp critical
+        ncon(0)=ncon(0)+1
+        linktmp(:,ncon(0),0)=(/mm,m/)
+        ncon(0)=ncon(0)+1
+        linktmp(:,ncon(0),0)=(/m,mm/)
+        !$omp end critical
+        neel=neel+2
+      end if
+      if(leout(mm)==0)exit ! End of input points
+    end do
   end do
-end do
+END IF
 self%linkage%kle(0)=neel
 !---Condense linkage to sparse rep
 self%linkage%nle=sum(self%linkage%kle)

--- a/src/fem/fem_base.F90
+++ b/src/fem/fem_base.F90
@@ -2051,6 +2051,7 @@ CALL oft_abort("Distributed linkage requires MPI","bfem_global_linkage",__FILE__
   DEALLOCATE(lesend,lerecv)
   !---Construct map
   ALLOCATE(self%map)
+  self%map%per=(mesh%periodic%nper>0) ! Not sure if this should be here or not
   self%map%offset=0
   self%map%n=0
   self%map%ng=self%global%ne
@@ -2306,6 +2307,7 @@ DEALLOCATE(lesend(1)%le)
 DEALLOCATE(lesend,lerecv)
 !---Construct map
 ALLOCATE(self%map)
+self%map%per=(mesh%periodic%nper>0)
 self%map%offset=0
 self%map%n=self%ne
 self%map%ng=self%global%ne

--- a/src/lin_alg/native_la.F90
+++ b/src/lin_alg/native_la.F90
@@ -2590,7 +2590,7 @@ IF(.NOT.uv%stitch_info%full)THEN
     jp=1
     last=0
     do mm=1,netmp ! Loop over input points
-      IF(letmp(1,mm)==last)THEN
+      IF(letmp(1,mm)==last.AND.periodic)THEN
         m=jp
       ELSE
         last=letmp(1,mm)
@@ -2631,7 +2631,7 @@ IF(jn>0)THEN
   jp=1
   last=0
   do mm=1,neout ! Loop over input points
-    IF(leout(1,mm)==last)THEN
+    IF(leout(1,mm)==last.AND.periodic)THEN
       m=jp
     ELSE
       last=leout(1,mm)

--- a/src/tests/physics/oft_in_taylor_green.xml
+++ b/src/tests/physics/oft_in_taylor_green.xml
@@ -3,6 +3,7 @@
     <pre type="gmres">
       <its>2</its>
       <nrits>2</nrits>
+      <atol>1E-11</atol>
       <pre type="block_jacobi">
         <nlocal>1</nlocal>
         <solver type="lu"></solver>

--- a/src/tests/physics/oft_in_taylor_green.xml
+++ b/src/tests/physics/oft_in_taylor_green.xml
@@ -1,9 +1,8 @@
 <oft>
   <xmhd2d>
     <pre type="gmres">
-      <its>2</its>
-      <nrits>2</nrits>
-      <atol>1E-11</atol>
+      <its>1</its>
+      <nrits>1</nrits>
       <pre type="block_jacobi">
         <nlocal>1</nlocal>
         <solver type="lu"></solver>


### PR DESCRIPTION
This PR fixes incorrect handling of periodicity in 2D meshes when full local matrices are required (eg. for LU factorization of matrices). Previously, the periodicity information was not being propagated from the mesh to the linear algebra mappings. This also reverts a temporary, but possibly invalid workaround introduced in 5da9985b.

This PR **does not** change and APIs or input files.
